### PR TITLE
fix(ci): use tag triggers for release, skip slow benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,8 +172,9 @@ jobs:
           path: target
           key: ${{ runner.os }}-cargo-bench-target-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Run benchmarks
-        run: cargo bench --all-features
+      - name: Run benchmarks (fast only)
+        run: cargo bench --all-features -- --skip "large_" --skip "external_sort_larger"
+        timeout-minutes: 15
 
       - name: Upload benchmark results
         uses: actions/upload-artifact@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,26 +1,23 @@
-# Tag-based release workflow using commitizen
+# Tag-based release workflow
 # See CONTRIBUTING.md for the full release strategy
 #
-# This workflow:
-# 1. Detects if the merged commit is a version bump (from `cz bump` in PR)
-# 2. If yes: creates git tag, publishes to crates.io and PyPI, creates GitHub Release
-# 3. If no: exits successfully (normal PR merge)
+# Triggers on version tags (v0.1.0, v1.0.0, etc.) or manual dispatch.
 #
 # Developer workflow:
 # 1. Accumulate changes via normal PR merges
-# 2. When ready to release, create a PR running: uv run cz bump --changelog
-# 3. Merge bump PR → this workflow creates tag and publishes
+# 2. When ready to release: uv run cz bump --changelog && git push --tags
+# 3. Tag push triggers this workflow → publishes to crates.io, PyPI, GitHub
 name: Release
 
 on:
   push:
-    branches: [main]
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'  # Matches v0.1.0, v1.0.0, etc.
   workflow_dispatch:
 
 jobs:
   release-rust:
     name: Release to crates.io
-    if: startsWith(github.event.head_commit.message, 'bump:') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -101,7 +98,6 @@ jobs:
 
   build-wheels:
     name: Build wheels (${{ matrix.os }})
-    if: startsWith(github.event.head_commit.message, 'bump:') || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -159,7 +155,6 @@ jobs:
 
   build-sdist:
     name: Build source distribution
-    if: startsWith(github.event.head_commit.message, 'bump:') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -179,7 +174,6 @@ jobs:
   publish-python:
     name: Publish to PyPI
     needs: [build-wheels, build-sdist]
-    if: startsWith(github.event.head_commit.message, 'bump:') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # Required for trusted publishing


### PR DESCRIPTION
- Release workflow now triggers on version tags (v*.*.*)
- Benchmarks skip large_* and external_sort_larger in CI
- Added 15min timeout for benchmark job safety