### PR TITLE
docs: add crates.io and PyPI badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![CI](https://github.com/geoparquet-io/gpq-tiles/actions/workflows/ci.yml/badge.svg)](https://github.com/geoparquet-io/gpq-tiles/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/geoparquet-io/gpq-tiles/branch/main/graph/badge.svg)](https://codecov.io/gh/geoparquet-io/gpq-tiles)
+[![Crates.io](https://img.shields.io/crates/v/gpq-tiles.svg)](https://crates.io/crates/gpq-tiles)
+[![PyPI](https://img.shields.io/pypi/v/gpq-tiles.svg)](https://pypi.org/project/gpq-tiles/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
 Fast GeoParquet → PMTiles converter in Rust.


### PR DESCRIPTION
Adds package registry badges now that v0.1.0 is being released.

- [![Crates.io](https://img.shields.io/crates/v/gpq-tiles.svg)](https://crates.io/crates/gpq-tiles)
- [![PyPI](https://img.shields.io/pypi/v/gpq-tiles.svg)](https://pypi.org/project/gpq-tiles/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)