### PR TITLE
fix(release): install protoc inside manylinux container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,11 @@ jobs:
           target: x86_64
           manylinux: auto
           args: --release --out dist -m crates/python/Cargo.toml
+          before-script-linux: |
+            # Install protoc inside manylinux container
+            curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protoc-25.1-linux-x86_64.zip
+            unzip protoc-25.1-linux-x86_64.zip -d /usr/local
+            rm protoc-25.1-linux-x86_64.zip
 
       - name: Build wheels (macOS)
         if: runner.os == 'macOS'


### PR DESCRIPTION
## Problem

Linux wheel build fails with:
```
Could not find `protoc`. If `protoc` is installed, try setting the `PROTOC` environment variable...
```

The manylinux Docker container doesn't have protoc, and installing it on the host doesn't help since the build happens inside Docker.

## Fix

Use maturin-action's `before-script-linux` to install protoc inside the container before building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)