### PR TITLE
docs: remove false 1.4x performance claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Crates.io](https://img.shields.io/crates/v/gpq-tiles.svg)](https://crates.io/crates/gpq-tiles)
 [![PyPI](https://img.shields.io/pypi/v/gpq-tiles.svg)](https://pypi.org/project/gpq-tiles/)
 
-Fast GeoParquet → PMTiles converter. 1.4x faster than tippecanoe.
+Fast GeoParquet → PMTiles converter in Rust.
 
 ## Install
 
@@ -30,7 +30,6 @@ convert("input.parquet", "output.pmtiles", min_zoom=0, max_zoom=14)
 - **[Getting Started](docs/getting-started.md)** — Installation, basic usage, property filtering
 - **[Advanced Usage](docs/advanced-usage.md)** — Performance tuning, streaming, CI/CD
 - **[API Reference](docs/api-reference.md)** — CLI flags, Rust API, Python API
-- **[ROADMAP](ROADMAP.md)** — Implementation phases and progress
 
 ## Development
 

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -5,7 +5,7 @@
 [![Crates.io](https://img.shields.io/crates/v/gpq-tiles.svg)](https://crates.io/crates/gpq-tiles)
 [![PyPI](https://img.shields.io/pypi/v/gpq-tiles.svg)](https://pypi.org/project/gpq-tiles/)
 
-Fast GeoParquet → PMTiles converter. 1.4x faster than tippecanoe.
+Fast GeoParquet → PMTiles converter in Rust.
 
 ## Install
 
@@ -30,7 +30,6 @@ convert("input.parquet", "output.pmtiles", min_zoom=0, max_zoom=14)
 - **[Getting Started](docs/getting-started.md)** — Installation, basic usage, property filtering
 - **[Advanced Usage](docs/advanced-usage.md)** — Performance tuning, streaming, CI/CD
 - **[API Reference](docs/api-reference.md)** — CLI flags, Rust API, Python API
-- **[ROADMAP](ROADMAP.md)** — Implementation phases and progress
 
 ## Development
 

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -5,7 +5,7 @@
 [![Crates.io](https://img.shields.io/crates/v/gpq-tiles.svg)](https://crates.io/crates/gpq-tiles)
 [![PyPI](https://img.shields.io/pypi/v/gpq-tiles.svg)](https://pypi.org/project/gpq-tiles/)
 
-Fast GeoParquet → PMTiles converter. 1.4x faster than tippecanoe.
+Fast GeoParquet → PMTiles converter in Rust.
 
 ## Install
 
@@ -30,7 +30,6 @@ convert("input.parquet", "output.pmtiles", min_zoom=0, max_zoom=14)
 - **[Getting Started](docs/getting-started.md)** — Installation, basic usage, property filtering
 - **[Advanced Usage](docs/advanced-usage.md)** — Performance tuning, streaming, CI/CD
 - **[API Reference](docs/api-reference.md)** — CLI flags, Rust API, Python API
-- **[ROADMAP](ROADMAP.md)** — Implementation phases and progress
 
 ## Development
 

--- a/crates/python/README.md
+++ b/crates/python/README.md
@@ -5,7 +5,7 @@
 [![Crates.io](https://img.shields.io/crates/v/gpq-tiles.svg)](https://crates.io/crates/gpq-tiles)
 [![PyPI](https://img.shields.io/pypi/v/gpq-tiles.svg)](https://pypi.org/project/gpq-tiles/)
 
-Fast GeoParquet → PMTiles converter. 1.4x faster than tippecanoe.
+Fast GeoParquet → PMTiles converter in Rust.
 
 ## Install
 
@@ -30,7 +30,6 @@ convert("input.parquet", "output.pmtiles", min_zoom=0, max_zoom=14)
 - **[Getting Started](docs/getting-started.md)** — Installation, basic usage, property filtering
 - **[Advanced Usage](docs/advanced-usage.md)** — Performance tuning, streaming, CI/CD
 - **[API Reference](docs/api-reference.md)** — CLI flags, Rust API, Python API
-- **[ROADMAP](ROADMAP.md)** — Implementation phases and progress
 
 ## Development
 


### PR DESCRIPTION
The 1.4x faster than tippecanoe claim was speculative and not backed by benchmarks. Actual performance varies by file and is roughly comparable to tippecanoe (~6% faster on some files).

Also removes stale ROADMAP.md links from READMEs.