### PR TITLE
chore: bump version 0.3.0 → 0.4.0

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,6 +1,6 @@
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.3.0"
+version = "0.4.0"
 tag_format = "v$version"
 version_files = [
     # Workspace version (first match)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,3 +100,90 @@ Python API now has full feature parity with CLI.
 [0.3.0]: https://github.com/geoparquet-io/gpq-tiles/releases/tag/v0.3.0
 [0.2.0]: https://github.com/geoparquet-io/gpq-tiles/releases/tag/v0.2.0
 [0.1.0]: https://github.com/geoparquet-io/gpq-tiles/releases/tag/v0.1.0
+
+## v0.4.0 (2026-02-25)
+
+### Feat
+
+- **python**: add progress callback support
+- **python**: add streaming mode and parallel control parameters
+- **python**: add property filtering and layer name parameters
+
+### Fix
+
+- add version sync safeguards and fix pyproject.toml version mismatch
+- add clippy allow for too_many_arguments and add clippy to pre-commit
+- use workspace dependency for gpq-tiles-core version
+
+## v0.2.0 (2026-02-25)
+
+### Fix
+
+- **release**: complete v0.2.0 release setup
+
+## v0.1.0 (2026-02-24)
+
+### Feat
+
+- set up commitizen for automated versioning and releases
+- **quality**: warn about pathologically small row groups
+- default to zstd compression, expose parallel options in CLI
+- add progress bars for cleaner output
+- parallelize geometry processing within row groups (#37)
+- parallelize tile processing for large geometries (#33)
+- **cli**: add --streaming-mode flag with progress reporting
+- **pipeline**: implement ExternalSort streaming mode
+- **pipeline**: add StreamingMode::ExternalSort variant
+- **core**: add external sort and WKB serialization modules
+- **streaming**: add StreamingPmtilesWriter with LowMemory mode
+- **streaming**: add memory budget configuration and tracking
+- **streaming**: add row-group-based streaming tile generation
+- **quality**: add GeoParquet file quality detection for streaming
+- add tile deduplication with XXH3 hashing and run_length encoding
+- add compression options (gzip, brotli, zstd, none) for PMTiles output
+- add property filtering with --include/-y, --exclude/-x, --exclude-all/-X flags
+- add 17K feature fixture for parallelization benchmarks
+- add tilestats metadata to PMTiles output
+- auto-extract field metadata from GeoParquet schema
+- add field metadata support to PMTiles writer
+- derive layer name from input filename, add --layer-name CLI flag
+- complete Phase 5 Python bindings with uv/ruff tooling
+- add benchmark suite with generate_tiles_from_geometries API
+- **pipeline**: add Rayon parallel tile generation
+- **pipeline**: wire spatial indexing into tile generation
+- **spatial-index**: add space-filling curve sorting for efficient tile generation
+- complete Phase 3 with density-based dropping
+- integrate feature dropping into pipeline (Phase 3)
+- add point thinning (1/2.5 drop rate per zoom)
+- add line dropping (coordinate quantization algorithm)
+- implement tiny polygon dropping with diffuse probability
+- implement PMTiles v3 writer (Tasks 7-9)
+- implement tiler pipeline wiring clip → simplify → MVT
+- implement MVT encoding for vector tiles
+- add golden comparison tests against tippecanoe output
+- implement geometry clipping with correct BooleanOps
+- implement zoom-based simplification
+- implement Arrow-native geometry batch processing (TDD green)
+
+### Fix
+
+- **release**: add version to core dep, add READMEs, fix benchmark filter
+- **release**: install protoc inside manylinux container
+- **python**: copy README into crate for sdist builds
+- **ci**: use tag triggers for release, skip slow benchmarks
+- consolidate release workflows and fix version bump detection
+- guard against degenerate linestrings in simplify and fix flaky test
+- PMTiles now compatible with pmtiles.io and standard viewers
+- **golden**: update stale Z8 test to use full pipeline
+- resolve three medium/low priority issues
+- simplify geometry in tile-local pixel coordinates
+- handle antimeridian crossing in tiles_for_bbox
+- **clip**: preserve all polygon parts when clipping produces MultiPolygon
+- use real bbox calculation instead of world bounds
+- resolve CI timeouts and coverage linker errors
+- upgrade pyo3 0.24 → 0.28 for Python 3.14 support
+- resolve CI failures for benchmark, check, test, and security audit
+
+### Perf
+
+- **streaming**: add memory benchmarks for streaming pipeline

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Nissim Lebovits <nlebovits@pm.me>"]
@@ -19,7 +19,7 @@ categories = ["science", "data-structures", "encoding"]
 
 [workspace.dependencies]
 # Internal crates
-gpq-tiles-core = { path = "crates/core", version = "0.3.0" }
+gpq-tiles-core = { path = "crates/core", version = "0.4.0" }
 
 # Core geospatial dependencies
 geoarrow = "0.4"

--- a/crates/python/pyproject.toml
+++ b/crates/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "gpq-tiles"
-version = "0.3.0"
+version = "0.4.0"
 description = "Fast GeoParquet to PMTiles converter"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/crates/python/uv.lock
+++ b/crates/python/uv.lock
@@ -459,7 +459,7 @@ wheels = [
 
 [[package]]
 name = "gpq-tiles"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Version bump created by `cz bump --changelog`.

This PR syncs main with the v0.4.0 tag that was already pushed.

**Note:** The v0.4.0 tag is already pushed and the release workflow is running. This PR just gets the version files on main in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)