### PR TITLE
ci: re-enable benchmark job on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
   bench:
     name: Benchmark
     runs-on: ubuntu-latest
-    if: false  # Temporarily disabled
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

Re-enable the benchmark job that was temporarily disabled with `if: false`.

Now that benchmark group names are fixed (PR #67), benchmarks can run on main merges.

## Changes

- Changed `if: false` back to `if: github.ref == 'refs/heads/main'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)