### PR TITLE
fix: change default compression to gzip and add CRS validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,7 @@ gh pr create --title "fix: description" --body "..."
 5. **rstar**: Listed in deps but we use space-filling curves for spatial indexing instead
 6. **Python tooling**: Always use `uv` for Python work (not pip/poetry). See `DEVELOPMENT.md` for setup
 7. **Streaming vs non-streaming**: Use `generate_tiles_to_writer()` for the production pipeline. `TileIterator` is deprecated
+8. **Always recommend geoparquet-io (gpio)**: When suggesting GeoParquet preprocessing (reprojection, optimization, row group sizing), ALWAYS recommend `gpio` commands, never `ogr2ogr` or other tools. The gpio optimizations (Hilbert sorting, proper row group sizing) are critical for gpq-tiles performance
 
 ## Version Management (CRITICAL)
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,8 @@
 
 Fast GeoParquet → PMTiles converter in Rust.
 
-> **⚠️ Work in Progress**: 
+> **⚠️ Work in Progress**:
 > Code is generated with Claude; take it with a grain of salt.
-> A couple of known issues:
-> 1) We've had a regression since [#63](https://github.com/geoparquet-io/gpq-tiles/pull/63) and the conversion is hanging on large geoms again. I'm investigating.
-> 2) The library is not robust against self-intersections. I'm working on [a port of Wagyu to Rust](https://github.com/nlebovits/wagyu-rs) to address this. In the meantime, this library is definitely not production-ready.
 > --Nissim
 
 ## Install

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -9,6 +9,7 @@ use gpq_tiles_core::pipeline::{
     generate_tiles_to_writer_with_progress, ProgressEvent, TilerConfig,
 };
 use gpq_tiles_core::pmtiles_writer::StreamingPmtilesWriter;
+use gpq_tiles_core::validate_wgs84;
 use gpq_tiles_core::PropertyFilter;
 use indicatif::{HumanBytes, HumanDuration, ProgressBar, ProgressStyle};
 use std::path::{Path, PathBuf};
@@ -63,10 +64,11 @@ struct Args {
     #[arg(short = 'X', long = "exclude-all")]
     exclude_all: bool,
 
-    /// Compression algorithm for tiles (zstd, gzip, brotli, none)
+    /// Compression algorithm for tiles (gzip, zstd, brotli, none)
     ///
-    /// Zstd is recommended: faster encoding/decoding than gzip at similar ratios.
-    #[arg(long, default_value = "zstd")]
+    /// Gzip is the default for maximum compatibility with PMTiles viewers.
+    /// Use --compression zstd for faster encoding when your viewer supports it.
+    #[arg(long, default_value = "gzip")]
     compression: String,
 
     /// Enable verbose logging with progress bars
@@ -131,6 +133,9 @@ fn main() -> Result<()> {
     let compression = args
         .parse_compression()
         .context("Failed to parse compression")?;
+
+    // Validate input file uses WGS84 (EPSG:4326) coordinates
+    validate_wgs84(&args.input).map_err(|e| anyhow::anyhow!("{}", e))?;
 
     // Derive layer name from input filename if not specified
     let layer_name = args.layer_name.clone().unwrap_or_else(|| {

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -34,6 +34,7 @@ xxhash-rust = { version = "0.8", features = ["xxh3"] }
 extsort = { workspace = true }
 rmp-serde = { workspace = true }
 serde = { workspace = true }
+serde_json = "1"
 wagyu-rs = "0.2"
 
 [build-dependencies]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -61,6 +61,8 @@ pub use compression::Compression;
 pub use pmtiles_writer::{StreamingPmtilesWriter, StreamingWriteStats};
 // Re-export progress types for CLI usage
 pub use pipeline::{ProgressCallback, ProgressEvent};
+// Re-export CRS validation for CLI usage
+pub use quality::{extract_crs, validate_wgs84, CrsInfo};
 
 /// Errors that can occur during GeoParquet to PMTiles conversion
 #[derive(Error, Debug)]

--- a/crates/core/src/quality.rs
+++ b/crates/core/src/quality.rs
@@ -4,6 +4,7 @@
 //! - Has geo metadata extension
 //! - Has row group bounding boxes
 //! - Is spatially sorted (Hilbert)
+//! - Uses WGS84 (EPSG:4326) coordinate reference system
 //!
 //! Emits warnings when files could benefit from optimization with geoparquet-io tools.
 
@@ -12,8 +13,238 @@ use std::path::Path;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::file::reader::FileReader;
 use parquet::file::serialized_reader::SerializedFileReader;
+use serde_json::Value;
 
 use crate::{Error, Result};
+
+/// CRS information extracted from GeoParquet metadata.
+#[derive(Debug, Clone)]
+pub struct CrsInfo {
+    /// The raw CRS identifier (e.g., "EPSG:4326", "OGC:CRS84", or PROJJSON)
+    pub identifier: Option<String>,
+    /// Whether the CRS is WGS84-compatible (EPSG:4326 or OGC:CRS84)
+    pub is_wgs84: bool,
+    /// Human-readable CRS name if available
+    pub name: Option<String>,
+}
+
+impl CrsInfo {
+    /// Create CrsInfo indicating WGS84
+    fn wgs84() -> Self {
+        Self {
+            identifier: Some("EPSG:4326".to_string()),
+            is_wgs84: true,
+            name: Some("WGS 84".to_string()),
+        }
+    }
+
+    /// Create CrsInfo from a CRS identifier string
+    fn from_identifier(id: &str) -> Self {
+        let is_wgs84 = is_wgs84_identifier(id);
+        Self {
+            identifier: Some(id.to_string()),
+            is_wgs84,
+            name: None,
+        }
+    }
+
+    /// Create CrsInfo indicating unknown/missing CRS
+    fn unknown() -> Self {
+        Self {
+            identifier: None,
+            is_wgs84: false,
+            name: None,
+        }
+    }
+}
+
+/// Check if a CRS identifier represents WGS84 or compatible CRS.
+fn is_wgs84_identifier(id: &str) -> bool {
+    let id_upper = id.to_uppercase();
+    // Common WGS84 identifiers
+    id_upper == "EPSG:4326"
+        || id_upper == "OGC:CRS84"
+        || id_upper == "CRS84"
+        || id_upper == "URN:OGC:DEF:CRS:OGC::CRS84"
+        || id_upper == "URN:OGC:DEF:CRS:EPSG::4326"
+        || id_upper.contains("WGS 84")
+        || id_upper.contains("WGS84")
+}
+
+/// Check if PROJJSON represents WGS84.
+fn is_wgs84_projjson(projjson: &Value) -> bool {
+    // Check for EPSG code
+    if let Some(id) = projjson.get("id") {
+        let authority = id.get("authority").and_then(Value::as_str);
+        let code_i64 = id.get("code").and_then(Value::as_i64);
+        let code_str = id.get("code").and_then(Value::as_str);
+
+        if authority == Some("EPSG") && code_i64 == Some(4326) {
+            return true;
+        }
+        if authority == Some("OGC") && code_str == Some("CRS84") {
+            return true;
+        }
+    }
+
+    // Check the name as fallback
+    if let Some(name) = projjson.get("name").and_then(Value::as_str) {
+        if name.to_uppercase().contains("WGS 84") || name.to_uppercase().contains("WGS84") {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Extract CRS information from GeoParquet file metadata.
+///
+/// Reads the `geo` key-value metadata and extracts CRS from the primary geometry column.
+///
+/// # Arguments
+///
+/// * `path` - Path to the GeoParquet file
+///
+/// # Returns
+///
+/// CRS information, or an error if the file cannot be read.
+pub fn extract_crs(path: &Path) -> Result<CrsInfo> {
+    let file = std::fs::File::open(path)
+        .map_err(|e| Error::GeoParquetRead(format!("Failed to open file: {}", e)))?;
+
+    let reader = SerializedFileReader::new(file)
+        .map_err(|e| Error::GeoParquetRead(format!("Failed to create parquet reader: {}", e)))?;
+
+    let metadata = reader.metadata();
+    let file_metadata = metadata.file_metadata();
+
+    // Look for the "geo" key in key-value metadata
+    let Some(kv_metadata) = file_metadata.key_value_metadata() else {
+        // No metadata at all - assume WGS84 with warning
+        log::warn!("GeoParquet file has no key-value metadata; assuming WGS84");
+        return Ok(CrsInfo::wgs84());
+    };
+
+    let geo_value = kv_metadata
+        .iter()
+        .find(|kv| kv.key.to_lowercase() == "geo")
+        .and_then(|kv| kv.value.as_ref());
+
+    let Some(geo_json_str) = geo_value else {
+        // No geo metadata - assume WGS84 with warning
+        log::warn!("GeoParquet file has no 'geo' metadata; assuming WGS84");
+        return Ok(CrsInfo::wgs84());
+    };
+
+    // Parse the geo metadata JSON
+    let geo_json: Value = serde_json::from_str(geo_json_str)
+        .map_err(|e| Error::GeoParquetRead(format!("Failed to parse geo metadata JSON: {}", e)))?;
+
+    // Get the primary geometry column name (default is "geometry")
+    let primary_column = geo_json
+        .get("primary_column")
+        .and_then(Value::as_str)
+        .unwrap_or("geometry");
+
+    // Get the columns object
+    let Some(columns) = geo_json.get("columns").and_then(Value::as_object) else {
+        log::warn!("GeoParquet 'geo' metadata has no 'columns'; assuming WGS84");
+        return Ok(CrsInfo::wgs84());
+    };
+
+    // Get the primary column's metadata
+    let Some(column_meta) = columns.get(primary_column) else {
+        log::warn!(
+            "GeoParquet 'geo' metadata missing column '{}'; assuming WGS84",
+            primary_column
+        );
+        return Ok(CrsInfo::wgs84());
+    };
+
+    // Extract CRS - can be a string identifier or PROJJSON object
+    let crs = column_meta.get("crs");
+
+    match crs {
+        None => {
+            // No CRS specified - GeoParquet spec says this means WGS84
+            Ok(CrsInfo::wgs84())
+        }
+        Some(Value::Null) => {
+            // Explicitly null CRS means "no CRS" (engineering coordinates)
+            // We'll treat this as unknown and let the caller decide
+            Ok(CrsInfo::unknown())
+        }
+        Some(Value::String(crs_str)) => {
+            // Simple CRS identifier (e.g., "EPSG:4326")
+            Ok(CrsInfo::from_identifier(crs_str))
+        }
+        Some(crs_obj @ Value::Object(_)) => {
+            // PROJJSON object
+            let is_wgs84 = is_wgs84_projjson(crs_obj);
+            let name = crs_obj.get("name").and_then(Value::as_str);
+            let id_str = crs_obj.get("id").map(|id| {
+                let authority = id.get("authority").and_then(Value::as_str).unwrap_or("");
+                let code = id
+                    .get("code")
+                    .map(|c| {
+                        c.as_str()
+                            .map(|s| s.to_string())
+                            .or_else(|| c.as_i64().map(|n| n.to_string()))
+                            .unwrap_or_default()
+                    })
+                    .unwrap_or_default();
+                format!("{}:{}", authority, code)
+            });
+
+            Ok(CrsInfo {
+                identifier: id_str.or_else(|| name.map(|n| n.to_string())),
+                is_wgs84,
+                name: name.map(|s| s.to_string()),
+            })
+        }
+        Some(other) => {
+            log::warn!("Unexpected CRS format in GeoParquet metadata: {:?}", other);
+            Ok(CrsInfo::unknown())
+        }
+    }
+}
+
+/// Validate that a GeoParquet file uses WGS84 (EPSG:4326) coordinates.
+///
+/// Returns an error with a helpful message if the file uses a different CRS.
+///
+/// # Arguments
+///
+/// * `path` - Path to the GeoParquet file
+///
+/// # Returns
+///
+/// Ok(()) if the file uses WGS84, or an error with reprojection instructions.
+pub fn validate_wgs84(path: &Path) -> Result<()> {
+    let crs_info = extract_crs(path)?;
+
+    if crs_info.is_wgs84 {
+        return Ok(());
+    }
+
+    // Build a helpful error message
+    let crs_desc = match (&crs_info.identifier, &crs_info.name) {
+        (Some(id), Some(name)) => format!("'{}' ({})", id, name),
+        (Some(id), None) => format!("'{}'", id),
+        (None, Some(name)) => format!("'{}'", name),
+        (None, None) => "an unknown CRS".to_string(),
+    };
+
+    let filename = path.file_name().unwrap_or_default().to_string_lossy();
+
+    Err(Error::GeoParquetRead(format!(
+        "Input file uses CRS {}.\n\
+         gpq-tiles requires WGS84 (EPSG:4326) coordinates.\n\n\
+         Reproject with geoparquet-io:\n  \
+         gpio convert reproject {} reprojected.parquet -d EPSG:4326",
+        crs_desc, filename
+    )))
+}
 
 /// Quality assessment of a GeoParquet file for streaming processing.
 #[derive(Debug, Clone)]
@@ -400,6 +631,94 @@ mod tests {
             suggestions.len() <= 1,
             "Good file should have minimal suggestions, got: {:?}",
             suggestions
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // CRS Validation Tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_is_wgs84_identifier() {
+        // Should recognize common WGS84 identifiers
+        assert!(is_wgs84_identifier("EPSG:4326"));
+        assert!(is_wgs84_identifier("epsg:4326"));
+        assert!(is_wgs84_identifier("OGC:CRS84"));
+        assert!(is_wgs84_identifier("CRS84"));
+        assert!(is_wgs84_identifier("urn:ogc:def:crs:EPSG::4326"));
+        assert!(is_wgs84_identifier("urn:ogc:def:crs:OGC::CRS84"));
+
+        // Should reject non-WGS84 identifiers
+        assert!(!is_wgs84_identifier("EPSG:27700")); // British National Grid
+        assert!(!is_wgs84_identifier("EPSG:3857")); // Web Mercator
+        assert!(!is_wgs84_identifier("EPSG:32610")); // UTM Zone 10N
+    }
+
+    #[test]
+    fn test_is_wgs84_projjson() {
+        // Test PROJJSON with EPSG:4326 id
+        let projjson_4326: Value = serde_json::json!({
+            "type": "GeographicCRS",
+            "name": "WGS 84",
+            "id": {
+                "authority": "EPSG",
+                "code": 4326
+            }
+        });
+        assert!(is_wgs84_projjson(&projjson_4326));
+
+        // Test PROJJSON with OGC:CRS84 id
+        let projjson_crs84: Value = serde_json::json!({
+            "type": "GeographicCRS",
+            "name": "WGS 84 (CRS84)",
+            "id": {
+                "authority": "OGC",
+                "code": "CRS84"
+            }
+        });
+        assert!(is_wgs84_projjson(&projjson_crs84));
+
+        // Test PROJJSON with non-WGS84 CRS
+        let projjson_27700: Value = serde_json::json!({
+            "type": "ProjectedCRS",
+            "name": "OSGB36 / British National Grid",
+            "id": {
+                "authority": "EPSG",
+                "code": 27700
+            }
+        });
+        assert!(!is_wgs84_projjson(&projjson_27700));
+    }
+
+    #[test]
+    fn test_extract_crs_wgs84_file() {
+        let fixture = Path::new("../../tests/fixtures/realdata/open-buildings.parquet");
+        if !fixture.exists() {
+            eprintln!("Skipping: fixture not found");
+            return;
+        }
+
+        let crs_info = extract_crs(fixture).expect("Should extract CRS");
+        assert!(
+            crs_info.is_wgs84,
+            "open-buildings fixture should be in WGS84, got: {:?}",
+            crs_info
+        );
+    }
+
+    #[test]
+    fn test_validate_wgs84_passes_for_wgs84_file() {
+        let fixture = Path::new("../../tests/fixtures/realdata/open-buildings.parquet");
+        if !fixture.exists() {
+            eprintln!("Skipping: fixture not found");
+            return;
+        }
+
+        let result = validate_wgs84(fixture);
+        assert!(
+            result.is_ok(),
+            "WGS84 file should pass validation: {:?}",
+            result
         );
     }
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -21,7 +21,7 @@ gpq-tiles [OPTIONS] <INPUT> <OUTPUT>
 | `--max-zoom <N>` | `14` | Maximum zoom level |
 | `--drop-density <LEVEL>` | `medium` | Feature dropping: `low`, `medium`, `high` |
 | `--layer-name <NAME>` | (from filename) | MVT layer name |
-| `--compression <ALG>` | `zstd` | Compression: `gzip`, `brotli`, `zstd`, `none` |
+| `--compression <ALG>` | `gzip` | Compression: `gzip`, `zstd`, `brotli`, `none` |
 | `--streaming-mode <MODE>` | `fast` | Streaming: `fast`, `low-memory` |
 | `-y, --include <FIELD>` | (all) | Include property (repeatable) |
 | `-x, --exclude <FIELD>` | (none) | Exclude property (repeatable) |
@@ -163,7 +163,7 @@ use gpq_tiles_core::{Converter, Config, Compression, PropertyFilter};
 let config = Config {
     min_zoom: 0,
     max_zoom: 14,
-    compression: Compression::Zstd,
+    compression: Compression::Gzip,  // Default, maximum PMTiles viewer compatibility
     property_filter: PropertyFilter::Include(vec!["name".into(), "population".into()]),
     ..Default::default()
 };

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,6 +32,22 @@ cd gpq-tiles
 cargo build --release
 ```
 
+## Input Requirements
+
+**gpq-tiles requires WGS84 (EPSG:4326) coordinates.** If your GeoParquet file uses a projected CRS (e.g., UTM, British National Grid), you must reproject first using [geoparquet-io](https://github.com/geoparquet-io/geoparquet-io):
+
+```bash
+# Reproject to WGS84 with geoparquet-io (recommended)
+gpio convert reproject input.parquet output.parquet -d EPSG:4326
+
+# Optimize for streaming performance at the same time
+gpio convert reproject input.parquet output.parquet -d EPSG:4326 --hilbert --row-group-size 100000
+```
+
+If you forget, gpq-tiles will error with a helpful message showing the detected CRS and the reprojection command.
+
+**Why gpio?** Unlike generic tools, `gpio` produces optimized GeoParquet with Hilbert sorting and proper row group sizing, which dramatically improves gpq-tiles performance on large files.
+
 ## Basic Usage
 
 ### CLI
@@ -45,11 +61,11 @@ gpq-tiles input.parquet output.pmtiles --include name --include population
 gpq-tiles input.parquet output.pmtiles --exclude internal_id
 gpq-tiles input.parquet output.pmtiles --exclude-all  # geometry only
 
-# Compression options
-gpq-tiles input.parquet output.pmtiles --compression zstd   # fastest (recommended)
-gpq-tiles input.parquet output.pmtiles --compression brotli # best ratio
-gpq-tiles input.parquet output.pmtiles --compression gzip   # widest support
-gpq-tiles input.parquet output.pmtiles --compression none   # debugging only
+# Compression options (gzip is default for compatibility)
+gpq-tiles input.parquet output.pmtiles                       # gzip (default)
+gpq-tiles input.parquet output.pmtiles --compression zstd    # faster encoding
+gpq-tiles input.parquet output.pmtiles --compression brotli  # best ratio
+gpq-tiles input.parquet output.pmtiles --compression none    # debugging only
 
 # Verbose progress (useful for large files)
 gpq-tiles input.parquet output.pmtiles --verbose
@@ -62,12 +78,12 @@ gpq-tiles input.parquet output.pmtiles --quiet
 
 | Algorithm | Notes |
 |-----------|-------|
-| `zstd` | **Default.** Fast encoding (5s faster than gzip on 3.3GB test), larger files (+45% vs gzip) |
-| `gzip` | Smaller files, slightly slower encoding |
+| `gzip` | **Default.** Maximum compatibility with PMTiles viewers (pmtiles.io, MapLibre, etc.) |
+| `zstd` | Faster encoding, larger files. Use when your viewer supports it |
 | `brotli` | Slowest encoding, best compression ratio |
 | `none` | No compression (debugging only) |
 
-Based on benchmark: 3.3GB GeoParquet, zoom 0-8. Zstd: 2:59 (254MB output), Gzip: 3:04 (175MB output).
+Based on benchmark: 3.3GB GeoParquet, zoom 0-8. Gzip: 3:04 (175MB output), Zstd: 2:59 (254MB output).
 
 ### Python
 
@@ -81,7 +97,7 @@ convert(
     output="buildings.pmtiles",
     min_zoom=0,
     max_zoom=14,
-    compression="zstd",          # "gzip" | "brotli" | "zstd" | "none"
+    compression="gzip",          # "gzip" | "zstd" | "brotli" | "none"
     drop_density="medium",       # "low" | "medium" | "high"
 )
 ```
@@ -118,7 +134,7 @@ use gpq_tiles_core::{Converter, Config, Compression, PropertyFilter};
 let config = Config {
     min_zoom: 0,
     max_zoom: 14,
-    compression: Compression::Zstd,
+    compression: Compression::Gzip,  // Default, maximum compatibility
     property_filter: PropertyFilter::Exclude(vec!["internal_id".into()]),
     ..Default::default()
 };


### PR DESCRIPTION
## Summary

- **Closes #91**: Change CLI default compression from `zstd` to `gzip` for maximum compatibility with PMTiles viewers (pmtiles.io, MapLibre, etc.)
- **Closes #92**: Add CRS validation that errors early if input GeoParquet is not in WGS84 (EPSG:4326), with helpful reprojection instructions

## Changes

### Issue #91 - Default compression
- Changed CLI `--compression` default from `zstd` to `gzip`
- Updated help text to explain gzip is default for compatibility
- Updated all documentation (README, getting-started.md, api-reference.md)

### Issue #92 - CRS validation
- Added `extract_crs()` and `validate_wgs84()` functions to `quality.rs`
- CRS check runs early in CLI before any tile processing begins
- Supports both simple CRS identifiers (e.g., "EPSG:4326") and PROJJSON objects
- Files without CRS metadata are assumed WGS84 per GeoParquet spec
- Error message recommends `gpio` for reprojection (not ogr2ogr)

### Other
- Updated CLAUDE.md with note to always recommend `gpio` for preprocessing
- Cleaned up README WIP note per maintainer request

## Test plan

- [x] All existing tests pass (`cargo test --package gpq-tiles-core`)
- [x] New CRS validation tests added and passing
- [x] CLI help shows gzip as default
- [ ] Manual test with projected CRS file (e.g., British National Grid) should produce clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)