### PR TITLE
bump: version 0.4.0 → 0.5.0

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,6 +1,6 @@
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.4.0"
+version = "0.5.0"
 tag_format = "v$version"
 version_files = [
     # Workspace version (first match)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,47 @@ Python API now has full feature parity with CLI.
 [0.2.0]: https://github.com/geoparquet-io/gpq-tiles/releases/tag/v0.2.0
 [0.1.0]: https://github.com/geoparquet-io/gpq-tiles/releases/tag/v0.1.0
 
+## v0.5.0 (2026-03-10)
+
+### Feat
+
+- **core**: wire up pipeline to use WorldCoord throughout (Phase 2)
+- **core**: add WorldCoord-based hierarchical clipping (Phase 2)
+- **core**: add WorldCoord-based feature drop functions (Phase 2)
+- **core**: add WorldCoord support to MVT encoding and validation (Phase 1)
+- **core**: add WorldCoord support to clipping modules (Phase 1)
+- **core**: add WorldCoord-based simplification functions (Phase 1)
+- **core**: add WorldCoord type for 32-bit integer coordinates (Phase 0)
+- **clip**: integrate wagyu-rs for robust polygon clipping
+- add --deterministic flag and fix PR #63 review feedback
+
+### Fix
+
+- **clip**: enable U-shape split test with wagyu-rs v0.2.1
+- **clip**: add wagyu fallback for edge case geometry handling (#94)
+- change default compression to gzip and add CRS validation
+- change default compression to gzip for compatibility
+- implement leaf directory support for large PMTiles archives
+- **core**: clamp tile coordinates and bounds to valid ranges
+- **core**: fix issue #83 - geometry coordinates collapsing to zeros
+- resolve clippy warnings in tests
+- **core**: align feature_drop coordinate precision with MVT encoding
+- **ci**: download fixtures from release instead of LFS
+- **ci**: remove 1.8GB fixture from LFS to fix bandwidth quota
+- Remove unused MIN_EXPECTED_TILES constant
+- Remove #[ignore] from regression tests - fixture is in LFS
+- use is_empty() instead of len() > 0 for Clippy
+- Fix clippy warning and add clipping benchmarks
+- **tile**: clamp latitude to Web Mercator bounds
+- use wagyu-rs from crates.io instead of path dependency
+- **ci**: update benchmark group names after consolidation
+
+### Perf
+
+- Add pre-clip bounding box filter for large geometries
+- Implement hierarchical clipping across zoom levels
+- Replace Wagyu with Sutherland-Hodgman for tile clipping
+
 ## v0.4.0 (2026-02-25)
 
 ### Feat

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Nissim Lebovits <nlebovits@pm.me>"]
@@ -19,7 +19,7 @@ categories = ["science", "data-structures", "encoding"]
 
 [workspace.dependencies]
 # Internal crates
-gpq-tiles-core = { path = "crates/core", version = "0.4.0" }
+gpq-tiles-core = { path = "crates/core", version = "0.5.0" }
 
 # Core geospatial dependencies
 geoarrow = "0.4"

--- a/crates/python/pyproject.toml
+++ b/crates/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "gpq-tiles"
-version = "0.4.0"
+version = "0.5.0"
 description = "Fast GeoParquet to PMTiles converter"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## Summary

Release v0.5.0 with the following highlights:

### Features
- **WorldCoord integer coordinate system** - 32-bit integer coordinates for precision and performance
- **Wagyu-rs polygon clipping** - Robust fallback for edge case geometries
- **CRS validation** - Warns on non-WGS84 input files
- `--deterministic` flag for reproducible output

### Fixes
- U-shape polygon clipping (wagyu-rs v0.2.1)
- Leaf directory support for large PMTiles archives
- Default compression changed to gzip for compatibility
- Latitude clamping to Web Mercator bounds

### Performance
- Hierarchical clipping across zoom levels
- Pre-clip bounding box filtering
- Sutherland-Hodgman primary clipper (wagyu fallback)

## After merge

```bash
git checkout main && git pull
git tag v0.5.0
git push --tags  # Triggers release workflow
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)