### PR TITLE
chore: bump version 0.5.0 → 0.6.0

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,6 +1,6 @@
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.5.0"
+version = "0.6.0"
 tag_format = "v$version"
 version_files = [
     # Workspace version (first match)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,39 @@ Python API now has full feature parity with CLI.
 [0.2.0]: https://github.com/geoparquet-io/gpq-tiles/releases/tag/v0.2.0
 [0.1.0]: https://github.com/geoparquet-io/gpq-tiles/releases/tag/v0.1.0
 
+## v0.6.0 (2026-03-11)
+
+### Feat
+
+- implement point clustering with position averaging (#25)
+- implement accumulator system for attribute aggregation (#23)
+- implement gap-based density detection (#24)
+- support WKT geometry encoding (#35)
+- implement tiny polygon accumulation (#85)
+- **profiling**: add fine-grained spans to read_parquet phase
+- add time profiling with tracing
+- add memory profiling with dhat
+
+### Fix
+
+- remove needless borrow in benchmark
+- resolve clippy warnings and unused imports
+- remove WKT fixture from repo, tests skip when missing
+- gracefully skip WKT tests when fixture is missing
+- skip profiling integration tests when dhat-heap feature enabled
+- use tempfile crate for proper temp directory isolation in tests
+- use cross-platform temp directories in integration tests
+
+### Refactor
+
+- replace wagyu-rs with i_overlay for polygon clipping
+
+### Perf
+
+- parallel row group I/O for ~24% speedup
+- reuse file handle across row groups (#41)
+- parallelize tile encoding in Phase 3 (#90)
+
 ## v0.5.0 (2026-03-10)
 
 ### Feat

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Nissim Lebovits <nlebovits@pm.me>"]
@@ -19,7 +19,7 @@ categories = ["science", "data-structures", "encoding"]
 
 [workspace.dependencies]
 # Internal crates
-gpq-tiles-core = { path = "crates/core", version = "0.5.0" }
+gpq-tiles-core = { path = "crates/core", version = "0.6.0" }
 
 # Core geospatial dependencies
 geoarrow = "0.4"

--- a/crates/python/pyproject.toml
+++ b/crates/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "gpq-tiles"
-version = "0.5.0"
+version = "0.6.0"
 description = "Fast GeoParquet to PMTiles converter"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## Summary

Version bump for v0.6.0 release.

## Changelog highlights

- **perf**: Parallel row group I/O for ~24% speedup (#108, #109)
  - 3.5GB file: 76s → 58s
  - ~60MB/s throughput through full tiling pipeline

🤖 Generated with [Claude Code](https://claude.ai/code)