### PR TITLE
feat: zoom-dependent geometry simplification (--simplify)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -235,6 +235,21 @@ struct Args {
     #[arg(long = "coalesce-attrs", value_name = "MODE", default_value = "drop")]
     coalesce_attrs: String,
 
+    /// Enable zoom-dependent geometry simplification.
+    ///
+    /// Applies Douglas-Peucker simplification with tolerance scaling by zoom level.
+    /// Dramatically reduces tile sizes for linear features (roads, rivers, boundaries).
+    /// At lower zoom levels (zoomed out), more aggressive simplification is applied.
+    #[arg(long)]
+    simplify: bool,
+
+    /// Simplification factor (default: 1.0 = 1 pixel tolerance).
+    ///
+    /// Controls aggressiveness: 0.5 = more detail, 1.0 = standard, 2.0 = aggressive.
+    /// Only used when --simplify is enabled.
+    #[arg(long, default_value = "1.0")]
+    simplify_factor: f64,
+
     /// Enable automatic per-feature max zoom based on feature area.
     ///
     /// Large features (e.g., country polygons) stop at low zoom levels where they
@@ -552,6 +567,11 @@ fn main() -> Result<()> {
         tiler_config = tiler_config.with_coalesce_attribute_mode(attr_mode);
     }
 
+    // Configure simplification if requested
+    if args.simplify {
+        tiler_config = tiler_config.with_simplify(args.simplify_factor);
+    }
+
     // Configure zoom-by-area if requested
     if args.zoom_by_area {
         tiler_config.zoom_by_area = true;
@@ -608,6 +628,9 @@ fn main() -> Result<()> {
                 "  Clustering: distance={}, max_zoom={}",
                 cluster.distance, cluster.max_zoom
             );
+        }
+        if let Some(factor) = tiler_config.simplify_factor {
+            eprintln!("  Simplification: enabled (factor={})", factor);
         }
         if tiler_config.zoom_by_area {
             eprintln!(

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -96,6 +96,8 @@ pub use covering::{
 };
 // Re-export ProcessingMode for memory-bounded processing
 pub use pipeline::{auto_bucket_count, auto_processing_mode, ProcessingMode};
+// Re-export simplify functions for external use
+pub use simplify::simplify_geometry_for_tile;
 
 /// Format a helpful error message for CannotReduceFurther errors
 fn format_cannot_reduce_error(

--- a/crates/core/src/mvt.rs
+++ b/crates/core/src/mvt.rs
@@ -1916,4 +1916,139 @@ mod tests {
             ring2_first_y
         );
     }
+
+    // ------------------------------------------------------------------------
+    // MVT Encoding Overhead Tests
+    // ------------------------------------------------------------------------
+
+    /// Test to measure MVT encoding overhead for MultiLineString vs single LineString.
+    ///
+    /// Hypothesis: A MultiLineString with many short linestrings is MUCH larger than
+    /// a single LineString with the same total points due to MoveTo command overhead.
+    ///
+    /// Each linestring in a MultiLineString requires:
+    /// - MoveTo(1) command: 1 u32
+    /// - First point coordinates: 2 u32 (zigzag encoded dx, dy)
+    /// - LineTo(n-1) command: 1 u32
+    /// - Remaining points: 2*(n-1) u32
+    ///
+    /// For a 2-point linestring, that's: 1 + 2 + 1 + 2 = 6 u32 per linestring
+    /// For 100 2-point linestrings: 600 u32
+    ///
+    /// A single 200-point linestring:
+    /// - MoveTo(1) command: 1 u32
+    /// - First point: 2 u32
+    /// - LineTo(199): 1 u32
+    /// - Remaining 199 points: 398 u32
+    /// Total: 402 u32
+    ///
+    /// Expected overhead ratio: ~1.5x for geometry commands alone,
+    /// but protobuf varint encoding may amplify this.
+    #[test]
+    fn test_mvt_encoding_overhead_multilinestring_vs_linestring() {
+        use geo::coord;
+        use prost::Message;
+
+        let bounds = TileBounds {
+            lng_min: -180.0,
+            lat_min: -85.0,
+            lng_max: 180.0,
+            lat_max: 85.0,
+        };
+        let extent = DEFAULT_EXTENT;
+
+        // Create 100 separate 2-point linestrings (200 total points)
+        let mut lines: Vec<LineString> = Vec::with_capacity(100);
+        for i in 0..100 {
+            // Each linestring spans a small portion of the tile
+            let x1 = -180.0 + (i as f64 * 3.6); // spread across longitude
+            let x2 = x1 + 1.0;
+            let y = (i as f64) * 0.8 - 40.0; // spread across latitude
+            let line = LineString::new(vec![coord! { x: x1, y: y }, coord! { x: x2, y: y }]);
+            lines.push(line);
+        }
+        let multi_linestring = MultiLineString::new(lines);
+
+        // Create a single linestring with 200 points
+        let mut single_coords: Vec<geo::Coord<f64>> = Vec::with_capacity(200);
+        for i in 0..200 {
+            let x = -180.0 + (i as f64 * 1.8);
+            let y = (i as f64) * 0.4 - 40.0;
+            single_coords.push(coord! { x: x, y: y });
+        }
+        let single_linestring = LineString::new(single_coords);
+
+        // Encode MultiLineString
+        let multi_cmds = encode_multi_linestring(&multi_linestring, &bounds, extent);
+
+        // Encode single LineString
+        let single_cmds = encode_linestring(&single_linestring, &bounds, extent);
+
+        println!("\n=== MVT Encoding Overhead Test ===");
+        println!("MultiLineString: 100 linestrings x 2 points each = 200 total points");
+        println!("Single LineString: 200 points");
+        println!();
+        println!("Geometry command counts:");
+        println!("  MultiLineString: {} u32 values", multi_cmds.len());
+        println!("  Single LineString: {} u32 values", single_cmds.len());
+        println!(
+            "  Command overhead ratio: {:.2}x",
+            multi_cmds.len() as f64 / single_cmds.len() as f64
+        );
+
+        // Now encode to full MVT tiles and compare byte sizes
+        let mut multi_layer = LayerBuilder::new("test");
+        multi_layer.add_feature(
+            Some(1),
+            &Geometry::MultiLineString(multi_linestring.clone()),
+            &[],
+            &bounds,
+        );
+        let multi_tile = TileBuilder::new();
+        let mut multi_builder = multi_tile;
+        multi_builder.add_layer(multi_layer.build());
+        let multi_tile_proto = multi_builder.build();
+        let multi_bytes = multi_tile_proto.encode_to_vec();
+
+        let mut single_layer = LayerBuilder::new("test");
+        single_layer.add_feature(
+            Some(1),
+            &Geometry::LineString(single_linestring.clone()),
+            &[],
+            &bounds,
+        );
+        let single_tile = TileBuilder::new();
+        let mut single_builder = single_tile;
+        single_builder.add_layer(single_layer.build());
+        let single_tile_proto = single_builder.build();
+        let single_bytes = single_tile_proto.encode_to_vec();
+
+        println!();
+        println!("MVT protobuf byte sizes:");
+        println!("  MultiLineString tile: {} bytes", multi_bytes.len());
+        println!("  Single LineString tile: {} bytes", single_bytes.len());
+        println!(
+            "  Byte overhead ratio: {:.2}x",
+            multi_bytes.len() as f64 / single_bytes.len() as f64
+        );
+        println!();
+        println!(
+            "Overhead per linestring: {} extra bytes",
+            (multi_bytes.len() - single_bytes.len()) / 100
+        );
+
+        // Verify the hypothesis: MultiLineString should be significantly larger
+        assert!(
+            multi_cmds.len() > single_cmds.len(),
+            "MultiLineString should have more command values than single LineString"
+        );
+
+        // The ratio should be around 1.5x for 2-point linestrings
+        let cmd_ratio = multi_cmds.len() as f64 / single_cmds.len() as f64;
+        assert!(
+            cmd_ratio > 1.2,
+            "Command overhead ratio should be >1.2x, got {:.2}x",
+            cmd_ratio
+        );
+    }
 }

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -2450,13 +2450,45 @@ fn generate_tiles_to_writer_internal(
                 }
 
                 if !linestrings.is_empty() {
-                    let coalesced = if linestrings.len() == 1 {
-                        WorldClippedGeometry::LineString(linestrings.into_iter().next().unwrap())
+                    // Aggressively simplify coalesced linestrings WITHOUT boundary preservation.
+                    // For coalesced features, we want maximum simplification since feature
+                    // boundaries no longer matter after merging.
+                    let simplified_linestrings: Vec<Vec<WorldCoord>> = if let Some(factor) =
+                        simplify_factor
+                    {
+                        let pixel_tolerance =
+                            factor * (1u32 << 14u8.saturating_sub(coord.z)) as f64;
+                        let after_simplify: Vec<Vec<WorldCoord>> = linestrings
+                            .into_iter()
+                            .map(|ls| {
+                                crate::simplify::simplify_coalesced_linestring(
+                                    &ls,
+                                    &coord,
+                                    extent,
+                                    pixel_tolerance,
+                                )
+                            })
+                            .filter(|ls| ls.len() >= 2)
+                            .collect();
+
+                        // Apply tippecanoe-style remove_noop ACROSS all linestrings.
+                        // This drops linestrings that start where others end (same pixel).
+                        crate::simplify::remove_noop_multilinestring(after_simplify, &coord, extent)
                     } else {
-                        WorldClippedGeometry::MultiLineString(linestrings)
+                        linestrings
                     };
-                    layer_builder.add_feature_world(Some(feat_id), &coalesced, &props, &coord);
-                    feature_count += 1;
+
+                    if !simplified_linestrings.is_empty() {
+                        let coalesced = if simplified_linestrings.len() == 1 {
+                            WorldClippedGeometry::LineString(
+                                simplified_linestrings.into_iter().next().unwrap(),
+                            )
+                        } else {
+                            WorldClippedGeometry::MultiLineString(simplified_linestrings)
+                        };
+                        layer_builder.add_feature_world(Some(feat_id), &coalesced, &props, &coord);
+                        feature_count += 1;
+                    }
                 }
 
                 if !polygons.is_empty() {
@@ -2468,6 +2500,12 @@ fn generate_tiles_to_writer_internal(
                         }
                     } else {
                         WorldClippedGeometry::MultiPolygon(polygons)
+                    };
+                    // Re-simplify coalesced geometry for aggressive reduction at low zoom
+                    let coalesced = if let Some(factor) = simplify_factor {
+                        simplify_geometry_for_tile(&coalesced, &coord, extent, factor)
+                    } else {
+                        coalesced
                     };
                     layer_builder.add_feature_world(Some(feat_id), &coalesced, &props, &coord);
                     feature_count += 1;

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -407,6 +407,23 @@ pub struct TilerConfig {
     ///
     /// Can be explicitly set to force a specific mode.
     pub processing_mode: ProcessingMode,
+
+    /// Simplification factor for zoom-dependent geometry simplification.
+    ///
+    /// When set, Douglas-Peucker simplification is applied to geometries per-tile
+    /// with tolerance scaling by zoom level. The tolerance at each zoom is:
+    ///
+    /// ```text
+    /// tolerance = simplify_factor / (extent * 2^zoom)
+    /// ```
+    ///
+    /// - `None` (default): No simplification applied
+    /// - `Some(1.0)`: Standard simplification (1 pixel tolerance at max zoom)
+    /// - `Some(0.5)`: Less aggressive simplification
+    /// - `Some(2.0)`: More aggressive simplification
+    ///
+    /// This matches tippecanoe's `-S` / `--simplification` flag behavior.
+    pub simplify_factor: Option<f64>,
 }
 
 impl Default for TilerConfig {
@@ -466,6 +483,8 @@ impl Default for TilerConfig {
             spatial_filter: None,
             // In-memory mode by default (auto-tuning happens at runtime based on file size)
             processing_mode: ProcessingMode::default(),
+            // No simplification by default - exact geometry preservation
+            simplify_factor: None,
         }
     }
 }
@@ -901,6 +920,37 @@ impl TilerConfig {
     /// This is a convenience method for `.with_processing_mode(ProcessingMode::bucketed_auto())`.
     pub fn with_bucketed_auto(self) -> Self {
         self.with_processing_mode(ProcessingMode::bucketed_auto())
+    }
+
+    /// Enable zoom-dependent geometry simplification.
+    ///
+    /// Applies Douglas-Peucker simplification to geometries per-tile with
+    /// tolerance scaling by zoom level. The tolerance at each zoom is:
+    ///
+    /// ```text
+    /// tolerance = factor / (extent * 2^zoom)
+    /// ```
+    ///
+    /// This matches tippecanoe's `-S` / `--simplification` flag.
+    ///
+    /// # Arguments
+    ///
+    /// * `factor` - Simplification factor. Common values:
+    ///   - `1.0` - Standard (1 pixel tolerance at max zoom)
+    ///   - `0.5` - Less aggressive (preserves more detail)
+    ///   - `2.0` - More aggressive (reduces file size)
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use gpq_tiles_core::pipeline::TilerConfig;
+    ///
+    /// let config = TilerConfig::new(0, 14)
+    ///     .with_simplify(1.0);  // Standard simplification
+    /// ```
+    pub fn with_simplify(mut self, factor: f64) -> Self {
+        self.simplify_factor = Some(factor);
+        self
     }
 }
 
@@ -3783,6 +3833,21 @@ mod tests {
         assert_eq!(config.extent, 512);
         assert_eq!(config.buffer_pixels, 16);
         assert_eq!(config.layer_name, "buildings");
+    }
+
+    #[test]
+    fn test_tiler_config_simplify_factor() {
+        // Default should be None (no simplification)
+        let config = TilerConfig::default();
+        assert_eq!(config.simplify_factor, None);
+
+        // Builder should enable simplification with factor
+        let config_enabled = TilerConfig::default().with_simplify(1.0);
+        assert_eq!(config_enabled.simplify_factor, Some(1.0));
+
+        // Should work with different factor values
+        let config_custom = TilerConfig::default().with_simplify(0.5);
+        assert_eq!(config_custom.simplify_factor, Some(0.5));
     }
 
     // ========== GeneratedTile Tests ==========

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -41,7 +41,7 @@ use crate::hierarchical_clip::{clip_geometry_hierarchical_world, WorldClippedGeo
 use crate::mvt::{LayerBuilder, TileBuilder};
 use crate::property_filter::PropertyFilter;
 use crate::sampling::{BoundedSampler, ExtentSampler, GapSampler};
-use crate::simplify::simplify_for_zoom;
+use crate::simplify::{simplify_for_zoom, simplify_geometry_for_tile};
 use crate::spatial_index::{sort_features, sort_geometries};
 use crate::tile::{tiles_for_bbox, TileBounds, TileCoord};
 use crate::validate::filter_valid_geometry;
@@ -1910,6 +1910,8 @@ fn generate_tiles_to_writer_internal(
         drop_smallest_as_needed: bool,
         drop_smallest_threshold: f64,
         gamma: Option<f64>,
+        // Zoom-dependent simplification factor (None = no simplification)
+        simplify_factor: Option<f64>,
         // Samplers for adaptive threshold iteration (Wave 2)
         mut gap_sampler: Option<&mut GapSampler>,
         mut extent_sampler: Option<&mut ExtentSampler>,
@@ -1996,6 +1998,13 @@ fn generate_tiles_to_writer_internal(
                 let geom = match WorldClippedGeometry::from_bytes(&raw_feat.geometry_bytes) {
                     Some(g) => g,
                     None => continue,
+                };
+
+                // Apply zoom-dependent simplification if enabled
+                let geom = if let Some(factor) = simplify_factor {
+                    simplify_geometry_for_tile(&geom, &coord, extent, factor)
+                } else {
+                    geom
                 };
 
                 if geom.is_degenerate_in_tile(&coord, extent) {
@@ -2324,6 +2333,13 @@ fn generate_tiles_to_writer_internal(
                     None => continue,
                 };
 
+                // Apply zoom-dependent simplification if enabled
+                let geom = if let Some(factor) = simplify_factor {
+                    simplify_geometry_for_tile(&geom, &coord, extent, factor)
+                } else {
+                    geom
+                };
+
                 if geom.is_degenerate_in_tile(&coord, extent) {
                     continue;
                 }
@@ -2494,6 +2510,13 @@ fn generate_tiles_to_writer_internal(
             let geom = match WorldClippedGeometry::from_bytes(&raw_feat.geometry_bytes) {
                 Some(g) => g,
                 None => continue,
+            };
+
+            // Apply zoom-dependent simplification if enabled
+            let geom = if let Some(factor) = simplify_factor {
+                simplify_geometry_for_tile(&geom, &coord, extent, factor)
+            } else {
+                geom
             };
 
             if geom.is_degenerate_in_tile(&coord, extent) {
@@ -2763,6 +2786,7 @@ fn generate_tiles_to_writer_internal(
                 drop_smallest_as_needed,
                 drop_smallest_threshold,
                 gamma,
+                config.simplify_factor,
                 None,
                 None,
             ));
@@ -2827,6 +2851,7 @@ fn generate_tiles_to_writer_internal(
                 drop_smallest_as_needed,
                 effective_drop_threshold,
                 effective_gamma,
+                config.simplify_factor,
                 Some(&mut gap_sampler),
                 Some(&mut extent_sampler),
             );

--- a/crates/core/src/simplify.rs
+++ b/crates/core/src/simplify.rs
@@ -492,6 +492,85 @@ pub fn simplify_world_ring(
     result
 }
 
+/// Simplify a linestring while preserving points on tile boundaries.
+///
+/// This is the production simplification function that prevents tile-edge seams.
+/// Points within 1 pixel of tile boundaries are never removed, matching
+/// tippecanoe's behavior of marking boundary-crossing points as "necessary".
+///
+/// # Algorithm
+/// 1. Identify which points are on tile boundaries
+/// 2. Split the linestring at boundary points
+/// 3. Simplify each segment independently
+/// 4. Rejoin segments, preserving boundary points
+///
+/// # Arguments
+/// * `coords` - Polyline vertices in world coordinates
+/// * `tile` - The tile context for boundary detection and coordinate transformation
+/// * `extent` - Tile extent (typically 4096)
+/// * `pixel_tolerance` - Simplification tolerance in pixels
+///
+/// # Returns
+/// Simplified polyline with boundary points preserved.
+pub fn simplify_world_linestring_preserve_boundaries(
+    coords: &[WorldCoord],
+    tile: &TileCoord,
+    extent: u32,
+    pixel_tolerance: f64,
+) -> Vec<WorldCoord> {
+    if coords.len() < 2 {
+        return coords.to_vec();
+    }
+
+    // Find indices of boundary points (these must be preserved)
+    let boundary_indices: Vec<usize> = coords
+        .iter()
+        .enumerate()
+        .filter(|(_, c)| is_on_tile_boundary(c, tile, extent, 1.0))
+        .map(|(i, _)| i)
+        .collect();
+
+    // If no boundary points, use standard simplification
+    if boundary_indices.is_empty() {
+        return simplify_world_linestring(coords, tile, extent, pixel_tolerance);
+    }
+
+    // Split at boundary points and simplify each segment
+    let mut result = Vec::new();
+    let mut segment_start = 0;
+
+    for &boundary_idx in &boundary_indices {
+        if boundary_idx > segment_start {
+            // Simplify segment from segment_start to boundary_idx (inclusive)
+            let segment = &coords[segment_start..=boundary_idx];
+            let simplified_segment =
+                simplify_world_linestring(segment, tile, extent, pixel_tolerance);
+
+            // Add all but the last point (boundary point will be added next)
+            if result.is_empty() {
+                result.extend_from_slice(&simplified_segment[..simplified_segment.len() - 1]);
+            } else {
+                // Skip first point (duplicate of previous boundary)
+                result.extend_from_slice(&simplified_segment[1..simplified_segment.len() - 1]);
+            }
+        }
+
+        // Always add the boundary point
+        result.push(coords[boundary_idx]);
+        segment_start = boundary_idx;
+    }
+
+    // Handle final segment (from last boundary to end)
+    if segment_start < coords.len() - 1 {
+        let segment = &coords[segment_start..];
+        let simplified_segment = simplify_world_linestring(segment, tile, extent, pixel_tolerance);
+        // Skip first point (duplicate of boundary)
+        result.extend_from_slice(&simplified_segment[1..]);
+    }
+
+    result
+}
+
 /// Get the simplified vertex count for a WorldCoord polyline without
 /// materializing the result. Useful for feature dropping decisions.
 ///
@@ -934,6 +1013,40 @@ mod tests {
         // Point on bottom edge (y = tile_max_y)
         let on_bottom = WorldCoord::new(1 << 30, 1 << 31);
         assert!(is_on_tile_boundary(&on_bottom, &tile, extent, 1.0));
+    }
+
+    #[test]
+    fn test_simplify_world_linestring_preserve_boundaries() {
+        use crate::tile::TileCoord;
+        use crate::world_coord::WorldCoord;
+
+        let tile = TileCoord::new(0, 0, 1);
+        let extent = 4096u32;
+
+        // Create a linestring that crosses the tile boundary
+        // Points: start inside, cross boundary, end inside
+        let coords = vec![
+            WorldCoord::new(1 << 30, 1 << 30),               // inside
+            WorldCoord::new(1 << 30, (1 << 30) + 100), // small deviation (should be simplified away normally)
+            WorldCoord::new(1 << 31, 1 << 30),         // ON RIGHT BOUNDARY - must be preserved
+            WorldCoord::new(1 << 31, (1 << 30) + 100), // small deviation on boundary
+            WorldCoord::new((1 << 30) + (1 << 29), 1 << 30), // inside
+        ];
+
+        // Simplify with boundary preservation
+        let simplified = simplify_world_linestring_preserve_boundaries(
+            &coords, &tile, extent, 10.0, // aggressive tolerance to trigger simplification
+        );
+
+        // The boundary point (index 2) must be preserved
+        assert!(
+            simplified.contains(&coords[2]),
+            "Boundary point must be preserved"
+        );
+
+        // First and last points are always preserved by Douglas-Peucker
+        assert_eq!(simplified.first(), Some(&coords[0]));
+        assert_eq!(simplified.last(), Some(&coords[4]));
     }
 
     // ========================================================================

--- a/crates/core/src/simplify.rs
+++ b/crates/core/src/simplify.rs
@@ -571,6 +571,44 @@ pub fn simplify_world_linestring_preserve_boundaries(
     result
 }
 
+/// Simplify a polygon ring while preserving points on tile boundaries.
+///
+/// Same as [`simplify_world_linestring_preserve_boundaries`] but ensures the ring
+/// remains closed and has at least 4 points (3 unique + closing).
+pub fn simplify_world_ring_preserve_boundaries(
+    coords: &[WorldCoord],
+    tile: &TileCoord,
+    extent: u32,
+    pixel_tolerance: f64,
+) -> Vec<WorldCoord> {
+    if coords.len() < 4 {
+        return coords.to_vec();
+    }
+
+    // Simplify as a linestring (excluding the closing point to avoid duplication)
+    let open_coords = if coords.first() == coords.last() && coords.len() > 1 {
+        &coords[..coords.len() - 1]
+    } else {
+        coords
+    };
+
+    let mut simplified =
+        simplify_world_linestring_preserve_boundaries(open_coords, tile, extent, pixel_tolerance);
+
+    // Ensure minimum ring size (3 unique points)
+    // Douglas-Peucker might reduce below this; if so, return original
+    if simplified.len() < 3 {
+        return coords.to_vec();
+    }
+
+    // Close the ring
+    if simplified.first() != simplified.last() {
+        simplified.push(simplified[0]);
+    }
+
+    simplified
+}
+
 /// Get the simplified vertex count for a WorldCoord polyline without
 /// materializing the result. Useful for feature dropping decisions.
 ///
@@ -1047,6 +1085,43 @@ mod tests {
         // First and last points are always preserved by Douglas-Peucker
         assert_eq!(simplified.first(), Some(&coords[0]));
         assert_eq!(simplified.last(), Some(&coords[4]));
+    }
+
+    #[test]
+    fn test_simplify_world_ring_preserve_boundaries() {
+        use crate::tile::TileCoord;
+        use crate::world_coord::WorldCoord;
+
+        let tile = TileCoord::new(0, 0, 1);
+        let extent = 4096u32;
+
+        // Create a ring that crosses the tile boundary
+        // Square with one edge on the tile boundary
+        let ring = vec![
+            WorldCoord::new(1 << 30, 1 << 30),               // inside corner
+            WorldCoord::new(1 << 31, 1 << 30),               // ON RIGHT BOUNDARY
+            WorldCoord::new(1 << 31, (1 << 30) + (1 << 28)), // ON RIGHT BOUNDARY
+            WorldCoord::new(1 << 30, (1 << 30) + (1 << 28)), // inside corner
+            WorldCoord::new(1 << 30, 1 << 30),               // close ring
+        ];
+
+        let simplified = simplify_world_ring_preserve_boundaries(&ring, &tile, extent, 10.0);
+
+        // Boundary points must be preserved
+        assert!(
+            simplified.contains(&ring[1]),
+            "First boundary point must be preserved"
+        );
+        assert!(
+            simplified.contains(&ring[2]),
+            "Second boundary point must be preserved"
+        );
+
+        // Ring must remain closed
+        assert_eq!(simplified.first(), simplified.last(), "Ring must be closed");
+
+        // Ring must have at least 4 points (3 unique + closing)
+        assert!(simplified.len() >= 4, "Ring must have at least 4 points");
     }
 
     // ========================================================================

--- a/crates/core/src/simplify.rs
+++ b/crates/core/src/simplify.rs
@@ -19,6 +19,7 @@
 //! Geographic Coords → Transform to tile coords → Simplify (pixels) → Encode
 //! ```
 
+use crate::hierarchical_clip::WorldClippedGeometry;
 use crate::tile::{TileBounds, TileCoord};
 use crate::world_coord::{WorldCoord, WORLD_SCALE};
 use geo::{Coord, Geometry, LineString, MultiLineString, MultiPolygon, Point, Polygon, Simplify};
@@ -609,6 +610,125 @@ pub fn simplify_world_ring_preserve_boundaries(
     simplified
 }
 
+/// Simplify a WorldClippedGeometry for a specific tile.
+///
+/// This is the main entry point for tile-level simplification in the encoding
+/// pipeline. It applies boundary-preserving Douglas-Peucker simplification
+/// with zoom-appropriate tolerance.
+///
+/// # Arguments
+/// * `geom` - The clipped geometry to simplify
+/// * `tile` - The tile being encoded (for boundary detection and tolerance)
+/// * `extent` - Tile extent (typically 4096)
+/// * `simplify_factor` - Multiplier for pixel tolerance (typically 1.0)
+///
+/// # Returns
+/// Simplified geometry with boundary points preserved.
+pub fn simplify_geometry_for_tile(
+    geom: &WorldClippedGeometry,
+    tile: &TileCoord,
+    extent: u32,
+    simplify_factor: f64,
+) -> WorldClippedGeometry {
+    // Tolerance in pixels, scaled by factor
+    let pixel_tolerance = simplify_factor;
+
+    match geom {
+        // Points cannot be simplified
+        WorldClippedGeometry::Point(p) => WorldClippedGeometry::Point(*p),
+        WorldClippedGeometry::MultiPoint(points) => {
+            WorldClippedGeometry::MultiPoint(points.clone())
+        }
+
+        // Linestrings: use boundary-preserving simplification
+        WorldClippedGeometry::LineString(coords) => {
+            let simplified = simplify_world_linestring_preserve_boundaries(
+                coords,
+                tile,
+                extent,
+                pixel_tolerance,
+            );
+            WorldClippedGeometry::LineString(simplified)
+        }
+
+        WorldClippedGeometry::MultiLineString(lines) => {
+            let simplified_lines: Vec<Vec<WorldCoord>> = lines
+                .iter()
+                .map(|line| {
+                    simplify_world_linestring_preserve_boundaries(
+                        line,
+                        tile,
+                        extent,
+                        pixel_tolerance,
+                    )
+                })
+                .filter(|line| line.len() >= 2) // Filter degenerate lines
+                .collect();
+            WorldClippedGeometry::MultiLineString(simplified_lines)
+        }
+
+        // Polygons: use boundary-preserving ring simplification
+        WorldClippedGeometry::Polygon {
+            exterior,
+            interiors,
+        } => {
+            let simplified_exterior =
+                simplify_world_ring_preserve_boundaries(exterior, tile, extent, pixel_tolerance);
+
+            // Only keep interior rings that remain valid after simplification
+            let simplified_interiors: Vec<Vec<WorldCoord>> = interiors
+                .iter()
+                .map(|ring| {
+                    simplify_world_ring_preserve_boundaries(ring, tile, extent, pixel_tolerance)
+                })
+                .filter(|ring| ring.len() >= 4) // Filter degenerate rings
+                .collect();
+
+            // If exterior becomes degenerate, return original
+            if simplified_exterior.len() < 4 {
+                return geom.clone();
+            }
+
+            WorldClippedGeometry::Polygon {
+                exterior: simplified_exterior,
+                interiors: simplified_interiors,
+            }
+        }
+
+        WorldClippedGeometry::MultiPolygon(polys) => {
+            let simplified_polys: Vec<(Vec<WorldCoord>, Vec<Vec<WorldCoord>>)> = polys
+                .iter()
+                .map(|(exterior, interiors)| {
+                    let simplified_exterior = simplify_world_ring_preserve_boundaries(
+                        exterior,
+                        tile,
+                        extent,
+                        pixel_tolerance,
+                    );
+
+                    let simplified_interiors: Vec<Vec<WorldCoord>> = interiors
+                        .iter()
+                        .map(|ring| {
+                            simplify_world_ring_preserve_boundaries(
+                                ring,
+                                tile,
+                                extent,
+                                pixel_tolerance,
+                            )
+                        })
+                        .filter(|ring| ring.len() >= 4)
+                        .collect();
+
+                    (simplified_exterior, simplified_interiors)
+                })
+                .filter(|(ext, _)| ext.len() >= 4) // Filter degenerate polygons
+                .collect();
+
+            WorldClippedGeometry::MultiPolygon(simplified_polys)
+        }
+    }
+}
+
 /// Get the simplified vertex count for a WorldCoord polyline without
 /// materializing the result. Useful for feature dropping decisions.
 ///
@@ -1122,6 +1242,39 @@ mod tests {
 
         // Ring must have at least 4 points (3 unique + closing)
         assert!(simplified.len() >= 4, "Ring must have at least 4 points");
+    }
+
+    #[test]
+    fn test_simplify_geometry_for_tile() {
+        use crate::hierarchical_clip::WorldClippedGeometry;
+        use crate::tile::TileCoord;
+        use crate::world_coord::WorldCoord;
+
+        let tile = TileCoord::new(0, 0, 5);
+        let extent = 4096u32;
+        let factor = 1.0;
+
+        // Test with a linestring
+        let line = WorldClippedGeometry::LineString(vec![
+            WorldCoord::new(1 << 26, 1 << 26),
+            WorldCoord::new((1 << 26) + 1, (1 << 26) + 1), // tiny deviation
+            WorldCoord::new(1 << 27, 1 << 27),
+        ]);
+
+        let simplified = simplify_geometry_for_tile(&line, &tile, extent, factor);
+
+        // Should have fewer or equal points
+        if let WorldClippedGeometry::LineString(coords) = simplified {
+            assert!(coords.len() <= 3);
+            assert!(coords.len() >= 2); // Minimum for valid linestring
+        } else {
+            panic!("Expected LineString");
+        }
+
+        // Test that points pass through unchanged
+        let point = WorldClippedGeometry::Point(WorldCoord::new(1 << 26, 1 << 26));
+        let simplified_point = simplify_geometry_for_tile(&point, &tile, extent, factor);
+        assert!(matches!(simplified_point, WorldClippedGeometry::Point(_)));
     }
 
     // ========================================================================

--- a/crates/core/src/simplify.rs
+++ b/crates/core/src/simplify.rs
@@ -23,6 +23,7 @@ use crate::hierarchical_clip::WorldClippedGeometry;
 use crate::tile::{TileBounds, TileCoord};
 use crate::world_coord::{WorldCoord, WORLD_SCALE};
 use geo::{Coord, Geometry, LineString, MultiLineString, MultiPolygon, Point, Polygon, Simplify};
+use tracing::debug;
 
 /// Default pixel tolerance for simplification (matches tippecanoe)
 pub const DEFAULT_PIXEL_TOLERANCE: f64 = 1.0;
@@ -407,6 +408,181 @@ fn tile_linestring_to_world_coords(
 /// marking boundary-crossing points as "necessary".
 ///
 /// # Arguments
+/// Aggressively simplify a coalesced linestring without boundary preservation.
+///
+/// For coalesced geometries, we don't want to preserve feature boundaries since
+/// features have been merged. This allows much more aggressive simplification.
+/// Matches tippecanoe's approach: simplify the entire coalesced geometry as one unit.
+pub fn simplify_coalesced_linestring(
+    coords: &[WorldCoord],
+    tile: &TileCoord,
+    extent: u32,
+    pixel_tolerance: f64,
+) -> Vec<WorldCoord> {
+    if coords.len() < 2 {
+        return Vec::new(); // Drop degenerate linestrings
+    }
+
+    // Calculate minimum pixel extent threshold based on zoom level.
+    // At low zoom levels, we need to be VERY aggressive about dropping tiny segments
+    // because there are so MANY of them (road networks have millions of segments).
+    //
+    // The key insight: at low zoom, the visual contribution of a tiny road segment
+    // is negligible, but it still costs ~20-40 bytes in the tile. With millions of
+    // segments, this adds up fast.
+    //
+    // Threshold scales with zoom to maintain visual quality while controlling size:
+    // z0-4 = 16px (very aggressive - only major roads visible)
+    // z5-7 = 8px  (moderate - regional roads)
+    // z8-10 = 4px (less aggressive - local roads start appearing)
+    // z11+ = 2px  (minimal - all detail preserved)
+    let min_extent_px = if tile.z <= 4 {
+        16.0
+    } else if tile.z <= 7 {
+        8.0
+    } else if tile.z <= 10 {
+        4.0
+    } else {
+        2.0
+    };
+
+    let extent_pixels = linestring_extent_pixels(coords, tile, extent);
+    if extent_pixels < min_extent_px {
+        return Vec::new(); // Drop sub-threshold linestring entirely
+    }
+
+    // Aggressive simplification without boundary preservation
+    let simplified = simplify_world_linestring(coords, tile, extent, pixel_tolerance);
+
+    // Then remove consecutive same-pixel points
+    remove_noop_linestring(&simplified, tile, extent)
+}
+
+/// Calculate the maximum extent (width or height) of a linestring in tile pixels.
+fn linestring_extent_pixels(coords: &[WorldCoord], tile: &TileCoord, extent: u32) -> f64 {
+    if coords.is_empty() {
+        return 0.0;
+    }
+
+    let mut min_x = f64::MAX;
+    let mut max_x = f64::MIN;
+    let mut min_y = f64::MAX;
+    let mut max_y = f64::MIN;
+
+    for coord in coords {
+        let (x, y) = world_to_tile_local_f64(*coord, tile, extent);
+        min_x = min_x.min(x);
+        max_x = max_x.max(x);
+        min_y = min_y.min(y);
+        max_y = max_y.max(y);
+    }
+
+    // Return the larger of width or height
+    (max_x - min_x).max(max_y - min_y)
+}
+
+/// Remove consecutive duplicate points when rounded to tile pixel coordinates.
+///
+/// This mirrors tippecanoe's `remove_noop` function (clip.cpp:532-604).
+/// After simplification, points may land on the same pixel - this removes those
+/// duplicates. If all points collapse to the same pixel, the result will have
+/// length < 2 and the linestring should be dropped.
+fn remove_noop_linestring(coords: &[WorldCoord], tile: &TileCoord, extent: u32) -> Vec<WorldCoord> {
+    if coords.is_empty() {
+        return Vec::new();
+    }
+
+    let mut result = Vec::with_capacity(coords.len());
+    let mut prev_px: Option<(i32, i32)> = None;
+
+    for coord in coords {
+        let (x, y) = world_to_tile_local_f64(*coord, tile, extent);
+        let px = (x.round() as i32, y.round() as i32);
+
+        // Keep point if it's on a different pixel than the previous
+        if prev_px.map_or(true, |prev| prev != px) {
+            result.push(*coord);
+            prev_px = Some(px);
+        }
+    }
+
+    result
+}
+
+/// Tippecanoe-style remove_noop for MultiLineString.
+///
+/// Unlike `remove_noop_linestring` which processes each linestring independently,
+/// this function works ACROSS linestrings like tippecanoe does. Key behaviors:
+///
+/// 1. **LINETO dedup**: Consecutive LINETOs on same pixel are dropped (within each linestring)
+/// 2. **MOVETO-after-LINETO**: If a new linestring starts on the same pixel where the
+///    previous linestring ended, the new linestring is dropped entirely
+/// 3. **Empty linestrings**: Linestrings with < 2 unique pixel positions are dropped
+///
+/// This is critical for coalesced road networks where many tiny segments end where
+/// others begin - they should merge into the visual line, not create separate features.
+pub fn remove_noop_multilinestring(
+    linestrings: Vec<Vec<WorldCoord>>,
+    tile: &TileCoord,
+    extent: u32,
+) -> Vec<Vec<WorldCoord>> {
+    let mut result = Vec::with_capacity(linestrings.len());
+
+    // Track the last pixel position ACROSS all linestrings
+    let mut last_lineto_px: Option<(i32, i32)> = None;
+
+    for coords in linestrings {
+        if coords.is_empty() {
+            continue;
+        }
+
+        // Check if this linestring's MOVETO lands on the same pixel as the previous LINETO
+        // (tippecanoe's third pass for VT_LINE)
+        let first_coord = coords[0];
+        let (fx, fy) = world_to_tile_local_f64(first_coord, tile, extent);
+        let first_px = (fx.round() as i32, fy.round() as i32);
+
+        if let Some(last_px) = last_lineto_px {
+            if first_px == last_px {
+                // MOVETO lands on same pixel as previous LINETO - skip entire linestring
+                // But update last_lineto_px to this linestring's end in case it extends further
+                if coords.len() >= 2 {
+                    let last_coord = coords[coords.len() - 1];
+                    let (lx, ly) = world_to_tile_local_f64(last_coord, tile, extent);
+                    last_lineto_px = Some((lx.round() as i32, ly.round() as i32));
+                }
+                continue;
+            }
+        }
+
+        // Process this linestring with within-linestring dedup
+        let mut deduped = Vec::with_capacity(coords.len());
+        let mut prev_px: Option<(i32, i32)> = None;
+
+        for coord in &coords {
+            let (x, y) = world_to_tile_local_f64(*coord, tile, extent);
+            let px = (x.round() as i32, y.round() as i32);
+
+            if prev_px.map_or(true, |prev| prev != px) {
+                deduped.push(*coord);
+                prev_px = Some(px);
+            }
+        }
+
+        // Only keep linestrings with at least 2 unique pixel positions
+        if deduped.len() >= 2 {
+            // Update last_lineto_px to this linestring's end
+            let last_coord = deduped[deduped.len() - 1];
+            let (lx, ly) = world_to_tile_local_f64(last_coord, tile, extent);
+            last_lineto_px = Some((lx.round() as i32, ly.round() as i32));
+
+            result.push(deduped);
+        }
+    }
+
+    result
+}
+
 /// * `coord` - The world coordinate to check
 /// * `tile` - The tile to check boundaries against
 /// * `extent` - Tile extent (typically 4096)
@@ -630,8 +806,10 @@ pub fn simplify_geometry_for_tile(
     extent: u32,
     simplify_factor: f64,
 ) -> WorldClippedGeometry {
-    // Tolerance in pixels, scaled by factor
-    let pixel_tolerance = simplify_factor;
+    // Tolerance in pixels, scaled by zoom level (doubles for each zoom below z=14)
+    // At z=14: 1 pixel tolerance. At z=2: 4096 pixel tolerance (very aggressive).
+    // Matches tippecanoe's approach: res = 1 << (32 - detail - z) with detail=12.
+    let pixel_tolerance = simplify_factor * (1u32 << 14u8.saturating_sub(tile.z)) as f64;
 
     match geom {
         // Points cannot be simplified
@@ -640,7 +818,7 @@ pub fn simplify_geometry_for_tile(
             WorldClippedGeometry::MultiPoint(points.clone())
         }
 
-        // Linestrings: use boundary-preserving simplification
+        // Linestrings: use boundary-preserving simplification, then remove pixel duplicates
         WorldClippedGeometry::LineString(coords) => {
             let simplified = simplify_world_linestring_preserve_boundaries(
                 coords,
@@ -648,11 +826,18 @@ pub fn simplify_geometry_for_tile(
                 extent,
                 pixel_tolerance,
             );
-            WorldClippedGeometry::LineString(simplified)
+            // Remove consecutive points on same pixel (tippecanoe's remove_noop)
+            let deduped = remove_noop_linestring(&simplified, tile, extent);
+            WorldClippedGeometry::LineString(deduped)
         }
 
         WorldClippedGeometry::MultiLineString(lines) => {
-            let simplified_lines: Vec<Vec<WorldCoord>> = lines
+            // Count points BEFORE remove_noop (for debug logging at low zoom)
+            let before_linestrings = lines.len();
+            let before_points: usize = lines.iter().map(|l| l.len()).sum();
+
+            // First, apply boundary-preserving simplification
+            let after_simplify: Vec<Vec<WorldCoord>> = lines
                 .iter()
                 .map(|line| {
                     simplify_world_linestring_preserve_boundaries(
@@ -662,8 +847,38 @@ pub fn simplify_geometry_for_tile(
                         pixel_tolerance,
                     )
                 })
-                .filter(|line| line.len() >= 2) // Filter degenerate lines
                 .collect();
+
+            let after_simplify_linestrings = after_simplify.len();
+            let after_simplify_points: usize = after_simplify.iter().map(|l| l.len()).sum();
+
+            // Now apply remove_noop to each linestring
+            let simplified_lines: Vec<Vec<WorldCoord>> = after_simplify
+                .into_iter()
+                .map(|line| remove_noop_linestring(&line, tile, extent))
+                .filter(|line| line.len() >= 2) // Drop degenerate/collapsed lines
+                .collect();
+
+            // Count points AFTER remove_noop
+            let after_linestrings = simplified_lines.len();
+            let after_points: usize = simplified_lines.iter().map(|l| l.len()).sum();
+
+            // Debug log only for low zoom levels (z <= 4)
+            if tile.z <= 4 {
+                debug!(
+                    "simplify z={} MultiLineString: BEFORE remove_noop: {} linestrings, {} points",
+                    tile.z, after_simplify_linestrings, after_simplify_points
+                );
+                debug!(
+                    "simplify z={} MultiLineString: AFTER remove_noop: {} linestrings, {} points",
+                    tile.z, after_linestrings, after_points
+                );
+                debug!(
+                    "simplify z={} MultiLineString: TOTAL reduction: {} -> {} linestrings, {} -> {} points",
+                    tile.z, before_linestrings, after_linestrings, before_points, after_points
+                );
+            }
+
             WorldClippedGeometry::MultiLineString(simplified_lines)
         }
 
@@ -1754,6 +1969,447 @@ mod tests {
                     i32_y
                 );
             }
+        }
+
+        /// BUG REPRODUCTION: When coalescing MANY small features, each keeps 2+ points.
+        ///
+        /// ROOT CAUSE: `simplify_geometry_for_tile` simplifies WITHIN each sub-linestring
+        /// but doesn't merge ACROSS sub-linestrings. At low zoom where tolerance equals
+        /// the tile extent (4096 pixels), this creates massive output.
+        ///
+        /// OBSERVED: At zoom 2, coalesced features are 61KB each despite simplification.
+        ///
+        /// REPRODUCTION: 500 tiny linestrings (each 2 points) coalesced together.
+        /// Even with 4096px tolerance, we get 500 * 2 = 1000 points output.
+        /// The linestrings should be merged/dropped since they're sub-pixel at this zoom.
+        #[test]
+        fn test_simplify_multilinestring_at_low_zoom() {
+            use crate::hierarchical_clip::WorldClippedGeometry;
+            use crate::tile::TileCoord;
+
+            // Zoom 2: tolerance = 4096 pixels (entire tile extent!)
+            let tile = TileCoord::new(1, 1, 2);
+            let extent = 4096u32;
+            let simplify_factor = 1.0;
+
+            let shift = 32 - tile.z as u32;
+            let tile_origin_x = (tile.x as u64) << shift;
+            let tile_origin_y = (tile.y as u64) << shift;
+            let tile_size = 1u64 << shift;
+
+            // Create 500 tiny linestrings, each just 2 points
+            // These simulate coalesced road segments
+            let mut all_lines: Vec<Vec<WorldCoord>> = Vec::new();
+
+            for i in 0..500 {
+                // Spread across the tile in a grid pattern
+                let row = i / 25;
+                let col = i % 25;
+                let base_x = tile_origin_x + tile_size / 10 + (col as u64) * tile_size * 8 / 250;
+                let base_y = tile_origin_y + tile_size / 10 + (row as u64) * tile_size * 8 / 200;
+
+                // Each linestring is sub-pixel at z2 (tile_size/20000 << tile_size/4096)
+                let line = vec![
+                    WorldCoord::new(base_x as u32, base_y as u32),
+                    WorldCoord::new((base_x + tile_size / 20000) as u32, base_y as u32),
+                ];
+                all_lines.push(line);
+            }
+
+            let input_points: usize = all_lines.iter().map(|l| l.len()).sum();
+            let input_linestrings = all_lines.len();
+            println!(
+                "Input: {} linestrings, {} total points",
+                input_linestrings, input_points
+            );
+
+            // Create and simplify
+            let geom = WorldClippedGeometry::MultiLineString(all_lines);
+            let simplified = simplify_geometry_for_tile(&geom, &tile, extent, simplify_factor);
+
+            // Count output
+            let (output_linestrings, output_points) = match &simplified {
+                WorldClippedGeometry::MultiLineString(lines) => {
+                    let total: usize = lines.iter().map(|l| l.len()).sum();
+                    (lines.len(), total)
+                }
+                _ => panic!("Expected MultiLineString"),
+            };
+
+            let pixel_tolerance = simplify_factor * (1u32 << 14u8.saturating_sub(tile.z)) as f64;
+            println!(
+                "Output: {} linestrings, {} total points (tolerance: {} pixels)",
+                output_linestrings, output_points, pixel_tolerance
+            );
+
+            // After tippecanoe-style remove_noop: sub-pixel linestrings collapse because
+            // both points round to the same pixel and the duplicate is removed.
+            // Some linestrings may straddle pixel boundaries and remain as 2-point lines.
+            // We expect significant reduction (> 50%) from the original 1000 points.
+            assert!(
+                output_points < input_points / 2,
+                "Expected > 50% reduction from remove_noop. Input: {} points, Output: {} points.\n\
+                 Linestrings where both points round to same pixel should be dropped.",
+                input_points,
+                output_points
+            );
+        }
+
+        /// Test: remove_noop_multilinestring drops linestrings that START
+        /// on the same pixel where the previous linestring ENDED.
+        ///
+        /// Tippecanoe behavior: If linestring A ends at pixel (10, 20) and
+        /// linestring B starts at pixel (10, 20), linestring B should be dropped
+        /// entirely because it visually continues from the same pixel.
+        #[test]
+        fn test_remove_noop_drops_linestring_starting_at_previous_end() {
+            use crate::tile::TileCoord;
+
+            // Use zoom 10 with standard extent for pixel-level control
+            let tile = TileCoord::new(500, 500, 10);
+            let extent = 4096u32;
+
+            // Calculate world coordinate spacing for 1 pixel at this zoom
+            let shift = 32 - tile.z as u32;
+            let tile_size = 1u64 << shift;
+            let world_per_pixel = tile_size / extent as u64;
+
+            // Tile origin in world coordinates
+            let tile_origin_x = (tile.x as u64) << shift;
+            let tile_origin_y = (tile.y as u64) << shift;
+
+            // Create 3 linestrings:
+            // - Linestring 1: pixels (10, 20) -> (100, 20) -- visually significant
+            // - Linestring 2: pixels (100, 20) -> (200, 20) -- STARTS at same pixel as LS1 ends!
+            // - Linestring 3: pixels (300, 20) -> (400, 20) -- starts at a different pixel
+
+            // Linestring 1: (10, 20) -> (100, 20)
+            let ls1 = vec![
+                WorldCoord::new(
+                    (tile_origin_x + 10 * world_per_pixel) as u32,
+                    (tile_origin_y + 20 * world_per_pixel) as u32,
+                ),
+                WorldCoord::new(
+                    (tile_origin_x + 100 * world_per_pixel) as u32,
+                    (tile_origin_y + 20 * world_per_pixel) as u32,
+                ),
+            ];
+
+            // Linestring 2: STARTS at pixel (100, 20) -- same as where LS1 ends!
+            // Ends at pixel (200, 20)
+            let ls2 = vec![
+                WorldCoord::new(
+                    (tile_origin_x + 100 * world_per_pixel) as u32,
+                    (tile_origin_y + 20 * world_per_pixel) as u32,
+                ),
+                WorldCoord::new(
+                    (tile_origin_x + 200 * world_per_pixel) as u32,
+                    (tile_origin_y + 20 * world_per_pixel) as u32,
+                ),
+            ];
+
+            // Linestring 3: (300, 20) -> (400, 20) -- starts at DIFFERENT pixel
+            let ls3 = vec![
+                WorldCoord::new(
+                    (tile_origin_x + 300 * world_per_pixel) as u32,
+                    (tile_origin_y + 20 * world_per_pixel) as u32,
+                ),
+                WorldCoord::new(
+                    (tile_origin_x + 400 * world_per_pixel) as u32,
+                    (tile_origin_y + 20 * world_per_pixel) as u32,
+                ),
+            ];
+
+            let input = vec![ls1.clone(), ls2.clone(), ls3.clone()];
+            let result = remove_noop_multilinestring(input, &tile, extent);
+
+            println!("Input: 3 linestrings");
+            println!("Output: {} linestrings", result.len());
+
+            // Expected behavior (tippecanoe-style):
+            // - LS1 kept (starts at distinct pixel)
+            // - LS2 DROPPED (starts at same pixel where LS1 ends)
+            // - LS3 kept (starts at distinct pixel from where LS2 ended)
+            //
+            // So we expect 2 linestrings in the output
+            assert_eq!(
+                result.len(),
+                2,
+                "Expected 2 linestrings (LS2 should be dropped because it starts \
+                 at the same pixel where LS1 ends).\n\
+                 Got {} linestrings instead.",
+                result.len()
+            );
+
+            // Verify the first output is LS1
+            assert_eq!(
+                result[0].len(),
+                ls1.len(),
+                "First output linestring should match LS1"
+            );
+
+            // Verify the second output is LS3
+            assert_eq!(
+                result[1].len(),
+                ls3.len(),
+                "Second output linestring should match LS3"
+            );
+        }
+
+        /// Test that 2-point linestrings spanning exactly 1 pixel are dropped at low zoom.
+        ///
+        /// This tests the hypothesis: after coalescing, gpq-tiles has thousands of 2-point
+        /// linestrings that can't be simplified further because RDP can't simplify below
+        /// 2 points, but these linestrings are visually insignificant (only 1 pixel long).
+        ///
+        /// At zoom 2, a 1-pixel linestring is visually negligible and should be dropped
+        /// to reduce tile size.
+        #[test]
+        fn test_single_pixel_linestrings_should_be_dropped_at_low_zoom() {
+            use crate::tile::TileCoord;
+
+            // Zoom 2: entire tile is 4096 pixels
+            let tile = TileCoord::new(1, 1, 2);
+            let extent = 4096u32;
+            let simplify_factor = 1.0;
+
+            // Calculate world coordinate scale
+            let shift = 32 - tile.z as u32;
+            let tile_origin_x = (tile.x as u64) << shift;
+            let tile_origin_y = (tile.y as u64) << shift;
+            let tile_size = 1u64 << shift;
+
+            // World units per pixel: tile_size / extent
+            let world_per_pixel = tile_size / extent as u64;
+
+            // Create 100 linestrings, each spanning exactly 1 pixel (both points on adjacent pixels)
+            let mut count_surviving = 0;
+
+            for i in 0..100 {
+                // Spread across the tile
+                let base_x = tile_origin_x + (i as u64 * tile_size / 120);
+                let base_y = tile_origin_y + tile_size / 2;
+
+                // Each linestring spans exactly 1 pixel (2 pixels apart = 1 pixel length)
+                // Point A at pixel N, Point B at pixel N+1
+                let coords = vec![
+                    WorldCoord::new(base_x as u32, base_y as u32),
+                    WorldCoord::new((base_x + world_per_pixel) as u32, base_y as u32),
+                ];
+
+                let simplified =
+                    simplify_coalesced_linestring(&coords, &tile, extent, simplify_factor);
+
+                if simplified.len() >= 2 {
+                    count_surviving += 1;
+                }
+            }
+
+            println!(
+                "1-pixel linestrings surviving at z2: {}/100 (should be 0)",
+                count_surviving
+            );
+
+            // At zoom 2, a 1-pixel linestring is visually insignificant.
+            // The min_extent_px threshold at z<=4 is 16px.
+            // These 1-pixel linestrings should be dropped because they're < 16px extent.
+            assert_eq!(
+                count_surviving, 0,
+                "Expected ALL 1-pixel linestrings to be dropped at z2.\n\
+                 Got {} surviving linestrings.\n\
+                 At zoom 2, min_extent_px=16, so linestrings < 16px should be dropped.",
+                count_surviving
+            );
+        }
+
+        /// Test that 2-point linestrings at the threshold boundary (16 pixels at z2) survive.
+        ///
+        /// This is the counterpart to the above test - linestrings at or above the
+        /// threshold should survive simplification.
+        #[test]
+        fn test_threshold_pixel_linestrings_survive_at_low_zoom() {
+            use crate::tile::TileCoord;
+
+            // Zoom 2: min_extent_px = 16
+            let tile = TileCoord::new(1, 1, 2);
+            let extent = 4096u32;
+            let simplify_factor = 1.0;
+
+            let shift = 32 - tile.z as u32;
+            let tile_origin_x = (tile.x as u64) << shift;
+            let tile_origin_y = (tile.y as u64) << shift;
+            let tile_size = 1u64 << shift;
+
+            let world_per_pixel = tile_size / extent as u64;
+
+            // Create 100 linestrings, each spanning exactly 16 pixels (at threshold)
+            let mut count_surviving = 0;
+
+            for i in 0..100 {
+                let base_x = tile_origin_x + (i as u64 * tile_size / 120);
+                let base_y = tile_origin_y + tile_size / 2;
+
+                // 16 pixels extent (at threshold)
+                let coords = vec![
+                    WorldCoord::new(base_x as u32, base_y as u32),
+                    WorldCoord::new((base_x + 16 * world_per_pixel) as u32, base_y as u32),
+                ];
+
+                let simplified =
+                    simplify_coalesced_linestring(&coords, &tile, extent, simplify_factor);
+
+                if simplified.len() >= 2 {
+                    count_surviving += 1;
+                }
+            }
+
+            println!(
+                "16-pixel linestrings surviving at z2: {}/100 (should be 100)",
+                count_surviving
+            );
+
+            // At threshold, linestrings should survive
+            assert_eq!(
+                count_surviving, 100,
+                "Expected ALL 16-pixel linestrings to survive at z2.\n\
+                 Got {} surviving. min_extent_px=16, so linestrings >= 16px should survive.",
+                count_surviving
+            );
+        }
+
+        /// Test that many tiny 2-point linestrings are kept at HIGH zoom levels.
+        ///
+        /// At zoom 12+, even tiny linestrings matter for visual detail.
+        /// This tests that the zoom-dependent thresholding works correctly
+        /// and doesn't over-aggressively drop features at high zoom.
+        #[test]
+        fn test_tiny_linestrings_survive_at_high_zoom() {
+            use crate::tile::TileCoord;
+
+            // Zoom 12: min_extent_px = 2
+            let tile = TileCoord::new(1000, 1000, 12);
+            let extent = 4096u32;
+            let simplify_factor = 1.0;
+
+            let shift = 32 - tile.z as u32;
+            let tile_origin_x = (tile.x as u64) << shift;
+            let tile_origin_y = (tile.y as u64) << shift;
+            let tile_size = 1u64 << shift;
+
+            let world_per_pixel = tile_size / extent as u64;
+
+            // Create 100 linestrings, each spanning exactly 3 pixels (above z12 threshold)
+            let mut count_surviving = 0;
+
+            for i in 0..100 {
+                let base_x = tile_origin_x + (i as u64 * tile_size / 120);
+                let base_y = tile_origin_y + tile_size / 2;
+
+                // 3 pixels extent (above z12 threshold of 2px)
+                let coords = vec![
+                    WorldCoord::new(base_x as u32, base_y as u32),
+                    WorldCoord::new((base_x + 3 * world_per_pixel) as u32, base_y as u32),
+                ];
+
+                let simplified =
+                    simplify_coalesced_linestring(&coords, &tile, extent, simplify_factor);
+
+                if simplified.len() >= 2 {
+                    count_surviving += 1;
+                }
+            }
+
+            println!(
+                "3-pixel linestrings surviving at z12: {}/100 (should be 100)",
+                count_surviving
+            );
+
+            assert_eq!(
+                count_surviving, 100,
+                "Expected ALL 3-pixel linestrings to survive at z12.\n\
+                 Got {} surviving. At z12 min_extent_px=2, so 3px linestrings should survive.",
+                count_surviving
+            );
+        }
+
+        /// FAILING TEST: Non-coalesced 2-point linestrings via simplify_geometry_for_tile
+        ///
+        /// This tests the hypothesis: simplify_geometry_for_tile does NOT drop tiny
+        /// 2-point linestrings even at low zoom, because it uses the boundary-preserving
+        /// simplification path which only removes pixel-duplicate points.
+        ///
+        /// The current implementation keeps all 2-point linestrings where points are
+        /// on different pixels, regardless of how far apart those pixels are.
+        /// This leads to thousands of tiny 2-point linestrings that can't be simplified
+        /// further by RDP but are visually insignificant.
+        #[test]
+        fn test_non_coalesced_tiny_linestrings_should_be_dropped() {
+            use crate::hierarchical_clip::WorldClippedGeometry;
+            use crate::tile::TileCoord;
+
+            // Zoom 2: tolerance = 4096 pixels (entire tile extent!)
+            let tile = TileCoord::new(1, 1, 2);
+            let extent = 4096u32;
+            let simplify_factor = 1.0;
+
+            let shift = 32 - tile.z as u32;
+            let tile_origin_x = (tile.x as u64) << shift;
+            let tile_origin_y = (tile.y as u64) << shift;
+            let tile_size = 1u64 << shift;
+
+            let world_per_pixel = tile_size / extent as u64;
+
+            // Create 100 linestrings, each spanning exactly 1 pixel (both points on adjacent pixels)
+            let mut all_lines: Vec<Vec<WorldCoord>> = Vec::new();
+
+            for i in 0..100 {
+                let base_x = tile_origin_x + (i as u64 * tile_size / 120);
+                let base_y = tile_origin_y + tile_size / 2;
+
+                // Each linestring spans exactly 1 pixel
+                let line = vec![
+                    WorldCoord::new(base_x as u32, base_y as u32),
+                    WorldCoord::new((base_x + world_per_pixel) as u32, base_y as u32),
+                ];
+                all_lines.push(line);
+            }
+
+            let input_linestrings = all_lines.len();
+            let input_points: usize = all_lines.iter().map(|l| l.len()).sum();
+            println!(
+                "Input (non-coalesced): {} linestrings, {} total points",
+                input_linestrings, input_points
+            );
+
+            // Use simplify_geometry_for_tile (the NON-coalesced path)
+            let geom = WorldClippedGeometry::MultiLineString(all_lines);
+            let simplified = simplify_geometry_for_tile(&geom, &tile, extent, simplify_factor);
+
+            let (output_linestrings, output_points) = match &simplified {
+                WorldClippedGeometry::MultiLineString(lines) => {
+                    let total: usize = lines.iter().map(|l| l.len()).sum();
+                    (lines.len(), total)
+                }
+                _ => panic!("Expected MultiLineString"),
+            };
+
+            println!(
+                "Output (non-coalesced): {} linestrings, {} total points",
+                output_linestrings, output_points
+            );
+
+            // This assertion SHOULD fail with current implementation!
+            // At zoom 2, 1-pixel linestrings are visually insignificant.
+            // They should be dropped, but simplify_geometry_for_tile doesn't have
+            // the extent-based filtering that simplify_coalesced_linestring has.
+            assert_eq!(
+                output_linestrings, 0,
+                "Expected ALL 1-pixel linestrings to be dropped at z2.\n\
+                 Got {} surviving linestrings (with {} points).\n\
+                 BUG: simplify_geometry_for_tile does not drop sub-threshold linestrings\n\
+                 like simplify_coalesced_linestring does (min_extent_px=16 at z2).",
+                output_linestrings, output_points
+            );
         }
     }
 }

--- a/crates/core/src/simplify.rs
+++ b/crates/core/src/simplify.rs
@@ -399,6 +399,36 @@ fn tile_linestring_to_world_coords(
         .collect()
 }
 
+/// Check if a WorldCoord lies on or near a tile boundary.
+///
+/// Points on tile boundaries must be preserved during simplification to prevent
+/// visible seams between adjacent tiles. This matches tippecanoe's approach of
+/// marking boundary-crossing points as "necessary".
+///
+/// # Arguments
+/// * `coord` - The world coordinate to check
+/// * `tile` - The tile to check boundaries against
+/// * `extent` - Tile extent (typically 4096)
+/// * `pixel_tolerance` - Distance in pixels to consider "on boundary"
+///
+/// # Returns
+/// `true` if the point is within `pixel_tolerance` pixels of any tile edge.
+pub fn is_on_tile_boundary(
+    coord: &WorldCoord,
+    tile: &TileCoord,
+    extent: u32,
+    pixel_tolerance: f64,
+) -> bool {
+    let (x, y) = world_to_tile_local_f64(*coord, tile, extent);
+    let extent_f = extent as f64;
+
+    // Check if within tolerance of any edge (0, extent)
+    x < pixel_tolerance
+        || x > extent_f - pixel_tolerance
+        || y < pixel_tolerance
+        || y > extent_f - pixel_tolerance
+}
+
 /// Simplify a polyline given as WorldCoords using Douglas-Peucker in tile-local space.
 ///
 /// This is the primary WorldCoord simplification function. It:
@@ -871,6 +901,39 @@ mod tests {
             matches!(simplified, Geometry::LineString(_)),
             "Should return a LineString geometry"
         );
+    }
+
+    // ========================================================================
+    // Boundary-Preserving Simplification Tests
+    // ========================================================================
+
+    #[test]
+    fn test_is_on_tile_boundary() {
+        use crate::tile::TileCoord;
+        use crate::world_coord::WorldCoord;
+
+        let tile = TileCoord::new(0, 0, 1); // zoom 1, tile (0,0)
+        let extent = 4096u32;
+
+        // Point clearly inside tile - not on boundary
+        let inside = WorldCoord::new(1 << 30, 1 << 30); // middle of tile
+        assert!(!is_on_tile_boundary(&inside, &tile, extent, 1.0));
+
+        // Point on left edge (x = tile_min_x)
+        let on_left = WorldCoord::new(0, 1 << 30);
+        assert!(is_on_tile_boundary(&on_left, &tile, extent, 1.0));
+
+        // Point on right edge (x = tile_max_x)
+        let on_right = WorldCoord::new(1 << 31, 1 << 30);
+        assert!(is_on_tile_boundary(&on_right, &tile, extent, 1.0));
+
+        // Point on top edge (y = tile_min_y)
+        let on_top = WorldCoord::new(1 << 30, 0);
+        assert!(is_on_tile_boundary(&on_top, &tile, extent, 1.0));
+
+        // Point on bottom edge (y = tile_max_y)
+        let on_bottom = WorldCoord::new(1 << 30, 1 << 31);
+        assert!(is_on_tile_boundary(&on_bottom, &tile, extent, 1.0));
     }
 
     // ========================================================================

--- a/crates/core/tests/simplification_integration.rs
+++ b/crates/core/tests/simplification_integration.rs
@@ -1,0 +1,221 @@
+//! Integration tests for zoom-dependent simplification (#156).
+//!
+//! Validates that simplification reduces tile sizes for complex geometries
+//! while preserving visual fidelity at each zoom level.
+
+use std::path::Path;
+
+use gpq_tiles_core::compression::Compression;
+use gpq_tiles_core::pipeline::{generate_tiles_to_writer, TilerConfig};
+use gpq_tiles_core::pmtiles_writer::StreamingPmtilesWriter;
+
+/// Test that simplification reduces output size for linear features.
+///
+/// Uses road-detections fixture which contains LineString geometries -
+/// ideal for testing Douglas-Peucker simplification since roads typically
+/// have many vertices that can be reduced at lower zoom levels.
+#[test]
+fn test_simplification_reduces_tile_size() {
+    // Try multiple fixtures - prefer roads (lines) but fall back to others
+    let fixtures = [
+        "../../tests/fixtures/realdata/road-detections.parquet",
+        "../../tests/fixtures/realdata/fieldmaps-boundaries.parquet",
+        "../../tests/fixtures/streaming/multi-rowgroup-small.parquet",
+    ];
+
+    let fixture = fixtures.iter().find(|p| Path::new(p).exists());
+    let Some(fixture_path) = fixture else {
+        eprintln!("Skipping: no suitable test fixture found");
+        return;
+    };
+    let fixture_path = Path::new(fixture_path);
+
+    println!("Using fixture: {}", fixture_path.display());
+
+    // Generate tiles WITHOUT simplification
+    let config_no_simplify = TilerConfig::new(0, 6)
+        .with_layer_name("test")
+        .with_quiet(true);
+
+    let mut writer_no_simplify =
+        StreamingPmtilesWriter::new(Compression::Gzip).expect("Should create writer");
+
+    let stats_no_simplify =
+        generate_tiles_to_writer(fixture_path, &config_no_simplify, &mut writer_no_simplify);
+    assert!(
+        stats_no_simplify.is_ok(),
+        "Tiling without simplification failed: {:?}",
+        stats_no_simplify.err()
+    );
+
+    // Finalize to get the total output size
+    let output_no_simplify = Path::new("/tmp/test-simplification-none.pmtiles");
+    let _ = std::fs::remove_file(output_no_simplify);
+    let write_stats_no_simplify = writer_no_simplify
+        .finalize(output_no_simplify)
+        .expect("Should finalize");
+    let size_no_simplify = std::fs::metadata(output_no_simplify)
+        .map(|m| m.len())
+        .unwrap_or(0);
+
+    // Generate tiles WITH simplification (factor 1.0 = standard)
+    let config_simplify = TilerConfig::new(0, 6)
+        .with_layer_name("test")
+        .with_quiet(true)
+        .with_simplify(1.0);
+
+    let mut writer_simplify =
+        StreamingPmtilesWriter::new(Compression::Gzip).expect("Should create writer");
+
+    let stats_simplify =
+        generate_tiles_to_writer(fixture_path, &config_simplify, &mut writer_simplify);
+    assert!(
+        stats_simplify.is_ok(),
+        "Tiling with simplification failed: {:?}",
+        stats_simplify.err()
+    );
+
+    let output_simplify = Path::new("/tmp/test-simplification-enabled.pmtiles");
+    let _ = std::fs::remove_file(output_simplify);
+    let write_stats_simplify = writer_simplify
+        .finalize(output_simplify)
+        .expect("Should finalize");
+    let size_simplify = std::fs::metadata(output_simplify)
+        .map(|m| m.len())
+        .unwrap_or(0);
+
+    println!(
+        "Without simplification: {} bytes ({} tiles)",
+        size_no_simplify, write_stats_no_simplify.total_tiles
+    );
+    println!(
+        "With simplification:    {} bytes ({} tiles)",
+        size_simplify, write_stats_simplify.total_tiles
+    );
+
+    // Simplification shouldn't change tile count (same features, same zooms)
+    assert_eq!(
+        write_stats_no_simplify.total_tiles, write_stats_simplify.total_tiles,
+        "Tile count should be identical"
+    );
+
+    // Output should be smaller or equal (not larger)
+    // Note: for very simple geometries (few vertices), there may be no reduction
+    assert!(
+        size_simplify <= size_no_simplify,
+        "Simplification should not increase output size: {} > {}",
+        size_simplify,
+        size_no_simplify
+    );
+
+    // If there was meaningful reduction, report it
+    if size_simplify < size_no_simplify {
+        let reduction_pct = 100.0 * (1.0 - (size_simplify as f64 / size_no_simplify as f64));
+        println!("Size reduction: {:.1}%", reduction_pct);
+    }
+
+    // Cleanup
+    let _ = std::fs::remove_file(output_no_simplify);
+    let _ = std::fs::remove_file(output_simplify);
+}
+
+/// Test that higher simplification factors produce smaller output.
+///
+/// Factor 2.0 should be more aggressive than factor 1.0.
+#[test]
+fn test_simplification_factor_scaling() {
+    // Use road-detections - it has linear geometries that benefit from simplification
+    let fixture = Path::new("../../tests/fixtures/realdata/road-detections.parquet");
+    if !fixture.exists() {
+        eprintln!("Skipping: road-detections fixture not found");
+        return;
+    }
+
+    // Helper to generate tiles with a given simplification factor
+    let generate_with_factor = |factor: Option<f64>| -> u64 {
+        let mut config = TilerConfig::new(0, 6)
+            .with_layer_name("test")
+            .with_quiet(true);
+
+        if let Some(f) = factor {
+            config = config.with_simplify(f);
+        }
+
+        let mut writer =
+            StreamingPmtilesWriter::new(Compression::Gzip).expect("Should create writer");
+        generate_tiles_to_writer(fixture, &config, &mut writer).expect("Tiling should succeed");
+
+        let output_path = format!(
+            "/tmp/test-simplify-factor-{}.pmtiles",
+            factor.unwrap_or(0.0)
+        );
+        let output = Path::new(&output_path);
+        let _ = std::fs::remove_file(output);
+        writer.finalize(output).expect("Should finalize");
+
+        let size = std::fs::metadata(output).map(|m| m.len()).unwrap_or(0);
+        let _ = std::fs::remove_file(output);
+        size
+    };
+
+    let size_none = generate_with_factor(None);
+    let size_low = generate_with_factor(Some(0.5));
+    let size_standard = generate_with_factor(Some(1.0));
+    let size_aggressive = generate_with_factor(Some(2.0));
+
+    println!("No simplification:  {} bytes", size_none);
+    println!("Factor 0.5 (mild):  {} bytes", size_low);
+    println!("Factor 1.0 (std):   {} bytes", size_standard);
+    println!("Factor 2.0 (aggr):  {} bytes", size_aggressive);
+
+    // Higher factor should mean smaller or equal output
+    // Note: relationship may not be strictly monotonic due to compression effects
+    assert!(
+        size_aggressive <= size_none,
+        "Aggressive simplification should not increase size vs none"
+    );
+}
+
+/// Test that simplification works correctly with deterministic mode.
+///
+/// Ensures reproducible output when both simplification and deterministic
+/// processing are enabled (important for golden tests).
+#[test]
+fn test_simplification_deterministic() {
+    let fixture = Path::new("../../tests/fixtures/streaming/multi-rowgroup-small.parquet");
+    if !fixture.exists() {
+        eprintln!("Skipping: multi-rowgroup-small fixture not found");
+        return;
+    }
+
+    let config = TilerConfig::new(0, 4)
+        .with_layer_name("test")
+        .with_quiet(true)
+        .with_simplify(1.0)
+        .with_deterministic(true);
+
+    // Generate twice with deterministic mode
+    let mut sizes = Vec::new();
+    for run in 0..2 {
+        let mut writer =
+            StreamingPmtilesWriter::new(Compression::Gzip).expect("Should create writer");
+        generate_tiles_to_writer(fixture, &config, &mut writer).expect("Tiling should succeed");
+
+        let output = Path::new(match run {
+            0 => "/tmp/test-simplify-det-1.pmtiles",
+            _ => "/tmp/test-simplify-det-2.pmtiles",
+        });
+        let _ = std::fs::remove_file(output);
+        writer.finalize(output).expect("Should finalize");
+
+        let size = std::fs::metadata(output).map(|m| m.len()).unwrap_or(0);
+        sizes.push(size);
+        let _ = std::fs::remove_file(output);
+    }
+
+    assert_eq!(
+        sizes[0], sizes[1],
+        "Deterministic mode should produce identical output sizes: {} vs {}",
+        sizes[0], sizes[1]
+    );
+}

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -94,6 +94,10 @@ fn progress_event_to_dict(py: Python<'_>, event: &ProgressEvent) -> PyResult<Py<
 ///     drop_smallest_threshold (float, optional): Minimum pixel area threshold for smallest-feature dropping. Defaults to 4.0.
 ///         Only used when ``drop_smallest_as_needed=True``. Features with pixel area below this
 ///         threshold are candidates for dropping.
+///     simplify_factor (float, optional): Geometry simplification factor. Defaults to None (disabled).
+///         When set, applies zoom-dependent simplification using Visvalingam-Whyatt algorithm.
+///         Value is relative to tile pixel tolerance (e.g., 1.0 = 1 pixel tolerance at each zoom).
+///         Higher values = more aggressive simplification. Typical range: 0.5-2.0.
 ///     progress_callback (callable, optional): A callback function that receives progress events as dicts.
 ///         Each event dict has a "phase" key indicating the event type:
 ///         - "start": Phase started. Keys: phase_num (int), name (str)
@@ -125,13 +129,15 @@ fn progress_event_to_dict(py: Python<'_>, event: &ProgressEvent) -> PyResult<Py<
 ///     >>> # Drop smallest features (tippecanoe parity)
 ///     >>> convert("buildings.parquet", "buildings.pmtiles", drop_smallest_as_needed=True)
 ///     >>> convert("buildings.parquet", "buildings.pmtiles", drop_smallest_as_needed=True, drop_smallest_threshold=2.0)
+///     >>> # Zoom-dependent simplification
+///     >>> convert("buildings.parquet", "buildings.pmtiles", simplify_factor=1.0)
 ///     >>> # With progress callback
 ///     >>> def on_progress(event):
 ///     ...     if event["phase"] == "complete":
 ///     ...         print(f"Generated {event['total_tiles']} tiles")
 ///     >>> convert("buildings.parquet", "buildings.pmtiles", progress_callback=on_progress)
 #[pyfunction]
-#[pyo3(signature = (input, output, min_zoom=0, max_zoom=14, drop_density="medium", compression="gzip", include=None, exclude=None, exclude_all=false, layer_name=None, deterministic=false, drop_smallest_as_needed=false, drop_smallest_threshold=4.0, progress_callback=None))]
+#[pyo3(signature = (input, output, min_zoom=0, max_zoom=14, drop_density="medium", compression="gzip", include=None, exclude=None, exclude_all=false, layer_name=None, deterministic=false, drop_smallest_as_needed=false, drop_smallest_threshold=4.0, simplify_factor=None, progress_callback=None))]
 #[allow(clippy::too_many_arguments)] // Python API mirrors CLI flags; grouping into struct would hurt usability
 fn convert(
     py: Python<'_>,
@@ -148,6 +154,7 @@ fn convert(
     deterministic: bool,
     drop_smallest_as_needed: bool,
     drop_smallest_threshold: f64,
+    simplify_factor: Option<f64>,
     progress_callback: Option<Py<PyAny>>,
 ) -> PyResult<()> {
     // Validate progress_callback is callable if provided
@@ -231,6 +238,10 @@ fn convert(
         config = config
             .with_drop_smallest_as_needed()
             .with_drop_smallest_threshold(drop_smallest_threshold);
+    }
+
+    if let Some(factor) = simplify_factor {
+        config = config.with_simplify(factor);
     }
 
     // Create streaming writer

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -132,6 +132,81 @@ Best for: Base layers, heatmaps, or cases where attributes aren't needed.
 
 ---
 
+## Geometry Simplification
+
+Simplification reduces vertex counts in complex geometries, dramatically shrinking tile sizes—especially for linear features like roads, rivers, and boundaries.
+
+### Basic Usage
+
+```bash
+# Enable simplification with default tolerance (1 pixel)
+gpq-tiles input.parquet output.pmtiles --simplify
+
+# More aggressive simplification (2 pixel tolerance)
+gpq-tiles input.parquet output.pmtiles --simplify --simplify-factor 2.0
+
+# Less aggressive (preserve more detail)
+gpq-tiles input.parquet output.pmtiles --simplify --simplify-factor 0.5
+```
+
+### How It Works
+
+gpq-tiles uses the **Douglas-Peucker algorithm** with zoom-dependent tolerance:
+
+```
+tolerance = simplify_factor / (extent × 2^zoom)
+```
+
+This means:
+- **Low zoom** (zoomed out): Aggressive simplification—roads become smooth arcs
+- **High zoom** (zoomed in): Gentle simplification—full detail preserved
+
+The default `simplify_factor` of `1.0` means "1 pixel tolerance"—vertices closer than 1 pixel are collapsed.
+
+### Tile Boundary Preservation
+
+To prevent visible seams between adjacent tiles, gpq-tiles marks vertices on tile boundaries as "necessary"—they're never removed during simplification.
+
+This matches tippecanoe's shared-node approach: clipping happens first, then simplification, ensuring adjacent tiles share identical boundary vertices.
+
+### When to Use Simplification
+
+**Best for:**
+- **Linear features**: Roads, rivers, rail lines, coastlines, boundaries
+- **Low zoom levels**: Where vertex-dense features create oversized tiles
+- **CannotReduceFurther errors**: When dropping features isn't enough
+
+**Less useful for:**
+- **Point features**: Already minimal geometry
+- **Polygons with few vertices**: Not much to simplify
+- **High zoom only**: Detail is already appropriate
+
+### Combining with Other Options
+
+Simplification works alongside feature dropping for maximum tile size reduction:
+
+```bash
+# Simplify geometry AND drop small features
+gpq-tiles roads.parquet roads.pmtiles \
+  --simplify \
+  --drop-smallest-as-needed \
+  --max-tile-size 500K
+
+# Simplify + density dropping (typical for dense road networks)
+gpq-tiles roads.parquet roads.pmtiles \
+  --simplify \
+  --drop-density high
+```
+
+**How they differ:**
+- `--simplify` reduces **vertex count** within each feature
+- `--drop-smallest-as-needed` removes **entire features** (smallest first)
+- `--drop-density` limits **features per grid cell**
+
+Use all three together for datasets with many complex linear features.
+
+---
+
 ## Feature Dropping
 
 Control how aggressively features are dropped at low zoom levels:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -26,6 +26,8 @@ gpq-tiles [OPTIONS] <INPUT> <OUTPUT>
 | `-y, --include <FIELD>` | (all) | Include property (repeatable) |
 | `-x, --exclude <FIELD>` | (none) | Exclude property (repeatable) |
 | `-X, --exclude-all` | false | Exclude all properties (geometry only) |
+| `--simplify` | false | Enable zoom-dependent geometry simplification |
+| `--simplify-factor <F>` | `1.0` | Simplification factor (pixel tolerance) |
 | `--no-parallel` | false | Disable parallel tile processing |
 | `--no-parallel-geoms` | false | Disable parallel geometry processing |
 | `-v, --verbose` | false | Show progress bars |
@@ -70,6 +72,7 @@ convert(
     streaming_mode: str = "fast",
     parallel_tiles: bool = True,
     parallel_geoms: bool = True,
+    simplify_factor: float | None = None,
     progress_callback: Callable[[dict], None] | None = None,
 ) -> None
 ```
@@ -91,6 +94,7 @@ convert(
 | `streaming_mode` | `str` | `"fast"` | Memory mode: `"fast"` or `"low-memory"` |
 | `parallel_tiles` | `bool` | `True` | Enable parallel tile generation |
 | `parallel_geoms` | `bool` | `True` | Enable parallel geometry processing |
+| `simplify_factor` | `float` | `None` | Simplification factor (None = disabled, 1.0 = 1 pixel tolerance) |
 | `progress_callback` | `Callable` | `None` | Callback for progress events |
 
 **Raises:**
@@ -124,6 +128,10 @@ convert("data.parquet", "out.pmtiles", exclude_all=True)  # geometry only
 
 # Large file handling
 convert("huge.parquet", "out.pmtiles", streaming_mode="low-memory")
+
+# Simplification for linear features
+convert("roads.parquet", "roads.pmtiles", simplify_factor=1.0)  # 1 pixel tolerance
+convert("roads.parquet", "roads.pmtiles", simplify_factor=0.5)  # More detail preserved
 
 # Progress callback
 def on_progress(event):
@@ -233,6 +241,11 @@ let config = TilerConfig::new(0, 14)
     .with_property_filter(PropertyFilter::Include(vec!["name".into()]))
     .with_layer_name("buildings");
 
+// With simplification for linear features
+let config_simplified = TilerConfig::new(0, 14)
+    .with_simplify(1.0)  // 1 pixel tolerance
+    .with_layer_name("roads");
+
 let tiles = generate_tiles(Path::new("input.parquet"), &config)?;
 
 for tile_result in tiles {
@@ -255,6 +268,7 @@ TilerConfig::new(min_zoom: u8, max_zoom: u8)
     .with_density_max_per_cell(max: usize)              // Default: 1
     .with_hilbert_sorting(enabled: bool)                // Default: true
     .with_property_filter(filter: PropertyFilter)       // Default: None
+    .with_simplify(factor: f64)                         // Default: None (disabled)
     .with_parallel_tiles(enabled: bool)                 // Default: true
     .with_parallel_geoms(enabled: bool)                 // Default: true
     .with_quiet(enabled: bool)                          // Default: false

--- a/docs/plans/2026-04-10-zoom-dependent-simplification.md
+++ b/docs/plans/2026-04-10-zoom-dependent-simplification.md
@@ -1,0 +1,1233 @@
+# Zoom-Dependent Geometry Simplification Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `--simplify` flag that enables zoom-dependent Douglas-Peucker simplification to reduce tile sizes for linear features at low zoom levels.
+
+**Architecture:** Simplification is applied per-tile in `encode_tile_from_raw()` after geometry deserialization, using existing `simplify_world_linestring()` / `simplify_world_ring()` functions. Tolerance scales with zoom level: `pixel_tolerance * simplify_factor` where `simplify_factor` defaults to 1.0 (1 pixel). Tile boundary points are marked as "necessary" to prevent tile-edge seams (matching tippecanoe's shared-node approach).
+
+**Tech Stack:** Rust, `geo::Simplify` (Douglas-Peucker), existing WorldCoord-based simplification in `simplify.rs`
+
+**Reference:** Tippecanoe `geometry.cpp:simplify_lines()`, `clip.cpp:douglas_peucker()`
+
+---
+
+## Task 1: Add simplify_factor to TilerConfig
+
+**Files:**
+- Modify: `crates/core/src/pipeline.rs:228-278` (TilerConfig struct)
+- Modify: `crates/core/src/pipeline.rs:412-470` (Default impl)
+- Modify: `crates/core/src/pipeline.rs:475+` (builder methods)
+
+**Step 1: Write failing test**
+
+Add to `crates/core/src/pipeline.rs` in the existing tests module (or create inline test):
+
+```rust
+#[test]
+fn test_tiler_config_simplify_factor() {
+    let config = TilerConfig::default();
+    assert_eq!(config.simplify_factor, None); // Disabled by default
+    
+    let config_enabled = TilerConfig::default().with_simplify(1.0);
+    assert_eq!(config_enabled.simplify_factor, Some(1.0));
+    
+    let config_custom = TilerConfig::default().with_simplify(0.5);
+    assert_eq!(config_custom.simplify_factor, Some(0.5));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cargo test --package gpq-tiles-core test_tiler_config_simplify_factor -- --nocapture
+```
+
+Expected: FAIL with "no field `simplify_factor` on type `TilerConfig`"
+
+**Step 3: Add simplify_factor field to TilerConfig**
+
+In `crates/core/src/pipeline.rs`, add after line 268 (`pub deterministic: bool,`):
+
+```rust
+    /// Simplification factor for zoom-dependent geometry simplification.
+    /// When Some, enables Douglas-Peucker simplification with tolerance = pixels * factor.
+    /// Default: None (disabled). Typical value: 1.0 (1 pixel tolerance).
+    /// Lower values (0.5) preserve more detail; higher values (2.0) simplify more aggressively.
+    pub simplify_factor: Option<f64>,
+```
+
+**Step 4: Add default value**
+
+In the `Default` impl (around line 437), add before the closing brace:
+
+```rust
+            // Zoom-dependent simplification disabled by default
+            simplify_factor: None,
+```
+
+**Step 5: Add builder method**
+
+After the existing builder methods (around line 600), add:
+
+```rust
+    /// Enable zoom-dependent geometry simplification.
+    ///
+    /// When enabled, geometries are simplified using Douglas-Peucker algorithm
+    /// with tolerance = pixel_tolerance * factor at each zoom level.
+    /// Lower zoom levels get more aggressive simplification.
+    ///
+    /// # Arguments
+    /// * `factor` - Simplification factor (typically 1.0 for 1-pixel tolerance)
+    pub fn with_simplify(mut self, factor: f64) -> Self {
+        self.simplify_factor = Some(factor);
+        self
+    }
+```
+
+**Step 6: Run test to verify it passes**
+
+```bash
+cargo test --package gpq-tiles-core test_tiler_config_simplify_factor -- --nocapture
+```
+
+Expected: PASS
+
+**Step 7: Commit**
+
+```bash
+git add crates/core/src/pipeline.rs
+git commit -m "feat(core): add simplify_factor to TilerConfig
+
+Add configuration for zoom-dependent geometry simplification.
+When enabled, Douglas-Peucker simplification is applied per-tile
+with tolerance scaling by zoom level.
+
+Refs: #156"
+```
+
+---
+
+## Task 2: Add boundary point detection to simplify.rs
+
+**Files:**
+- Modify: `crates/core/src/simplify.rs`
+
+This task adds a function to identify which points lie on tile boundaries. These points must be preserved during simplification to prevent tile-edge seams.
+
+**Step 1: Write failing test**
+
+Add to `crates/core/src/simplify.rs` in the tests module:
+
+```rust
+#[test]
+fn test_is_on_tile_boundary() {
+    use crate::tile::TileCoord;
+    use crate::world_coord::WorldCoord;
+    
+    let tile = TileCoord::new(0, 0, 1); // zoom 1, tile (0,0)
+    let extent = 4096u32;
+    
+    // Point clearly inside tile - not on boundary
+    let inside = WorldCoord::new(1 << 30, 1 << 30); // middle of tile
+    assert!(!is_on_tile_boundary(&inside, &tile, extent, 1.0));
+    
+    // Point on left edge (x = tile_min_x)
+    let on_left = WorldCoord::new(0, 1 << 30);
+    assert!(is_on_tile_boundary(&on_left, &tile, extent, 1.0));
+    
+    // Point on right edge (x = tile_max_x)
+    let on_right = WorldCoord::new(1 << 31, 1 << 30);
+    assert!(is_on_tile_boundary(&on_right, &tile, extent, 1.0));
+    
+    // Point on top edge (y = tile_min_y)
+    let on_top = WorldCoord::new(1 << 30, 0);
+    assert!(is_on_tile_boundary(&on_top, &tile, extent, 1.0));
+    
+    // Point on bottom edge (y = tile_max_y)
+    let on_bottom = WorldCoord::new(1 << 30, 1 << 31);
+    assert!(is_on_tile_boundary(&on_bottom, &tile, extent, 1.0));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cargo test --package gpq-tiles-core simplify::tests::test_is_on_tile_boundary -- --nocapture
+```
+
+Expected: FAIL with "cannot find function `is_on_tile_boundary`"
+
+**Step 3: Implement is_on_tile_boundary**
+
+Add after `tile_linestring_to_world_coords` function (around line 400):
+
+```rust
+/// Check if a WorldCoord lies on or near a tile boundary.
+///
+/// Points on tile boundaries must be preserved during simplification to prevent
+/// visible seams between adjacent tiles. This matches tippecanoe's approach of
+/// marking boundary-crossing points as "necessary".
+///
+/// # Arguments
+/// * `coord` - The world coordinate to check
+/// * `tile` - The tile to check boundaries against
+/// * `extent` - Tile extent (typically 4096)
+/// * `pixel_tolerance` - Distance in pixels to consider "on boundary"
+///
+/// # Returns
+/// `true` if the point is within `pixel_tolerance` pixels of any tile edge.
+pub fn is_on_tile_boundary(
+    coord: &WorldCoord,
+    tile: &TileCoord,
+    extent: u32,
+    pixel_tolerance: f64,
+) -> bool {
+    let (x, y) = world_to_tile_local_f64(*coord, tile, extent);
+    let extent_f = extent as f64;
+    
+    // Check if within tolerance of any edge (0, extent)
+    x < pixel_tolerance 
+        || x > extent_f - pixel_tolerance
+        || y < pixel_tolerance 
+        || y > extent_f - pixel_tolerance
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+cargo test --package gpq-tiles-core simplify::tests::test_is_on_tile_boundary -- --nocapture
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/core/src/simplify.rs
+git commit -m "feat(simplify): add tile boundary detection
+
+Add is_on_tile_boundary() to identify points that should be preserved
+during simplification. Points near tile edges are marked as necessary
+to prevent visible seams between adjacent tiles.
+
+Matches tippecanoe's shared-node preservation approach.
+
+Refs: #156"
+```
+
+---
+
+## Task 3: Add boundary-preserving simplification for linestrings
+
+**Files:**
+- Modify: `crates/core/src/simplify.rs`
+
+**Step 1: Write failing test**
+
+```rust
+#[test]
+fn test_simplify_world_linestring_preserve_boundaries() {
+    use crate::tile::TileCoord;
+    use crate::world_coord::WorldCoord;
+    
+    let tile = TileCoord::new(0, 0, 1);
+    let extent = 4096u32;
+    
+    // Create a linestring that crosses the tile boundary
+    // Points: start inside, cross boundary, end inside
+    let coords = vec![
+        WorldCoord::new(1 << 30, 1 << 30),       // inside
+        WorldCoord::new(1 << 30, 1 << 30 + 100), // small deviation (should be simplified away normally)
+        WorldCoord::new(1 << 31, 1 << 30),       // ON RIGHT BOUNDARY - must be preserved
+        WorldCoord::new(1 << 31, 1 << 30 + 100), // small deviation on boundary
+        WorldCoord::new(1 << 30 + (1 << 29), 1 << 30), // inside
+    ];
+    
+    // Simplify with boundary preservation
+    let simplified = simplify_world_linestring_preserve_boundaries(
+        &coords,
+        &tile,
+        extent,
+        10.0, // aggressive tolerance to trigger simplification
+    );
+    
+    // The boundary point (index 2) must be preserved
+    assert!(simplified.contains(&coords[2]), "Boundary point must be preserved");
+    
+    // First and last points are always preserved by Douglas-Peucker
+    assert_eq!(simplified.first(), Some(&coords[0]));
+    assert_eq!(simplified.last(), Some(&coords[4]));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cargo test --package gpq-tiles-core simplify::tests::test_simplify_world_linestring_preserve_boundaries -- --nocapture
+```
+
+Expected: FAIL with "cannot find function `simplify_world_linestring_preserve_boundaries`"
+
+**Step 3: Implement boundary-preserving simplification**
+
+Add after `simplify_world_ring` (around line 463):
+
+```rust
+/// Simplify a linestring while preserving points on tile boundaries.
+///
+/// This is the production simplification function that prevents tile-edge seams.
+/// Points within 1 pixel of tile boundaries are never removed, matching
+/// tippecanoe's behavior of marking boundary-crossing points as "necessary".
+///
+/// # Algorithm
+/// 1. Identify which points are on tile boundaries
+/// 2. Split the linestring at boundary points
+/// 3. Simplify each segment independently
+/// 4. Rejoin segments, preserving boundary points
+///
+/// # Arguments
+/// * `coords` - Polyline vertices in world coordinates
+/// * `tile` - The tile context for boundary detection and coordinate transformation
+/// * `extent` - Tile extent (typically 4096)
+/// * `pixel_tolerance` - Simplification tolerance in pixels
+///
+/// # Returns
+/// Simplified polyline with boundary points preserved.
+pub fn simplify_world_linestring_preserve_boundaries(
+    coords: &[WorldCoord],
+    tile: &TileCoord,
+    extent: u32,
+    pixel_tolerance: f64,
+) -> Vec<WorldCoord> {
+    if coords.len() < 2 {
+        return coords.to_vec();
+    }
+    
+    // Find indices of boundary points (these must be preserved)
+    let boundary_indices: Vec<usize> = coords
+        .iter()
+        .enumerate()
+        .filter(|(_, c)| is_on_tile_boundary(c, tile, extent, 1.0))
+        .map(|(i, _)| i)
+        .collect();
+    
+    // If no boundary points, use standard simplification
+    if boundary_indices.is_empty() {
+        return simplify_world_linestring(coords, tile, extent, pixel_tolerance);
+    }
+    
+    // Split at boundary points and simplify each segment
+    let mut result = Vec::new();
+    let mut segment_start = 0;
+    
+    for &boundary_idx in &boundary_indices {
+        if boundary_idx > segment_start {
+            // Simplify segment from segment_start to boundary_idx (inclusive)
+            let segment = &coords[segment_start..=boundary_idx];
+            let simplified_segment = simplify_world_linestring(segment, tile, extent, pixel_tolerance);
+            
+            // Add all but the last point (boundary point will be added next)
+            if result.is_empty() {
+                result.extend_from_slice(&simplified_segment[..simplified_segment.len() - 1]);
+            } else {
+                // Skip first point (duplicate of previous boundary)
+                result.extend_from_slice(&simplified_segment[1..simplified_segment.len() - 1]);
+            }
+        }
+        
+        // Always add the boundary point
+        result.push(coords[boundary_idx]);
+        segment_start = boundary_idx;
+    }
+    
+    // Handle final segment (from last boundary to end)
+    if segment_start < coords.len() - 1 {
+        let segment = &coords[segment_start..];
+        let simplified_segment = simplify_world_linestring(segment, tile, extent, pixel_tolerance);
+        // Skip first point (duplicate of boundary)
+        result.extend_from_slice(&simplified_segment[1..]);
+    }
+    
+    result
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+cargo test --package gpq-tiles-core simplify::tests::test_simplify_world_linestring_preserve_boundaries -- --nocapture
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/core/src/simplify.rs
+git commit -m "feat(simplify): add boundary-preserving linestring simplification
+
+Implement simplify_world_linestring_preserve_boundaries() that splits
+linestrings at tile boundaries, simplifies each segment independently,
+and rejoins while preserving boundary points.
+
+This prevents visible seams between adjacent tiles by ensuring points
+on tile edges are never removed during simplification.
+
+Refs: #156"
+```
+
+---
+
+## Task 4: Add boundary-preserving simplification for polygon rings
+
+**Files:**
+- Modify: `crates/core/src/simplify.rs`
+
+**Step 1: Write failing test**
+
+```rust
+#[test]
+fn test_simplify_world_ring_preserve_boundaries() {
+    use crate::tile::TileCoord;
+    use crate::world_coord::WorldCoord;
+    
+    let tile = TileCoord::new(0, 0, 1);
+    let extent = 4096u32;
+    
+    // Create a ring that crosses the tile boundary
+    // Square with one edge on the tile boundary
+    let ring = vec![
+        WorldCoord::new(1 << 30, 1 << 30),           // inside corner
+        WorldCoord::new(1 << 31, 1 << 30),           // ON RIGHT BOUNDARY
+        WorldCoord::new(1 << 31, 1 << 30 + (1<<28)), // ON RIGHT BOUNDARY  
+        WorldCoord::new(1 << 30, 1 << 30 + (1<<28)), // inside corner
+        WorldCoord::new(1 << 30, 1 << 30),           // close ring
+    ];
+    
+    let simplified = simplify_world_ring_preserve_boundaries(
+        &ring,
+        &tile,
+        extent,
+        10.0,
+    );
+    
+    // Boundary points must be preserved
+    assert!(simplified.contains(&ring[1]), "First boundary point must be preserved");
+    assert!(simplified.contains(&ring[2]), "Second boundary point must be preserved");
+    
+    // Ring must remain closed
+    assert_eq!(simplified.first(), simplified.last(), "Ring must be closed");
+    
+    // Ring must have at least 4 points (3 unique + closing)
+    assert!(simplified.len() >= 4, "Ring must have at least 4 points");
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cargo test --package gpq-tiles-core simplify::tests::test_simplify_world_ring_preserve_boundaries -- --nocapture
+```
+
+Expected: FAIL with "cannot find function `simplify_world_ring_preserve_boundaries`"
+
+**Step 3: Implement boundary-preserving ring simplification**
+
+Add after `simplify_world_linestring_preserve_boundaries`:
+
+```rust
+/// Simplify a polygon ring while preserving points on tile boundaries.
+///
+/// Same as [`simplify_world_linestring_preserve_boundaries`] but ensures the ring
+/// remains closed and has at least 4 points (3 unique + closing).
+pub fn simplify_world_ring_preserve_boundaries(
+    coords: &[WorldCoord],
+    tile: &TileCoord,
+    extent: u32,
+    pixel_tolerance: f64,
+) -> Vec<WorldCoord> {
+    if coords.len() < 4 {
+        return coords.to_vec();
+    }
+    
+    // Simplify as a linestring (excluding the closing point to avoid duplication)
+    let open_coords = if coords.first() == coords.last() && coords.len() > 1 {
+        &coords[..coords.len() - 1]
+    } else {
+        coords
+    };
+    
+    let mut simplified = simplify_world_linestring_preserve_boundaries(
+        open_coords,
+        tile,
+        extent,
+        pixel_tolerance,
+    );
+    
+    // Ensure minimum ring size (3 unique points)
+    // Douglas-Peucker might reduce below this; if so, return original
+    if simplified.len() < 3 {
+        return coords.to_vec();
+    }
+    
+    // Close the ring
+    if simplified.first() != simplified.last() {
+        simplified.push(simplified[0]);
+    }
+    
+    simplified
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+cargo test --package gpq-tiles-core simplify::tests::test_simplify_world_ring_preserve_boundaries -- --nocapture
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/core/src/simplify.rs
+git commit -m "feat(simplify): add boundary-preserving polygon ring simplification
+
+Implement simplify_world_ring_preserve_boundaries() that preserves
+boundary points while ensuring the ring remains closed and valid
+(at least 4 points).
+
+Refs: #156"
+```
+
+---
+
+## Task 5: Add simplify_geometry_for_tile helper
+
+**Files:**
+- Modify: `crates/core/src/simplify.rs`
+
+This task adds a high-level function that applies the correct simplification to any `WorldClippedGeometry`.
+
+**Step 1: Write failing test**
+
+```rust
+#[test]
+fn test_simplify_geometry_for_tile() {
+    use crate::hierarchical_clip::WorldClippedGeometry;
+    use crate::tile::TileCoord;
+    use crate::world_coord::WorldCoord;
+    
+    let tile = TileCoord::new(0, 0, 5);
+    let extent = 4096u32;
+    let factor = 1.0;
+    
+    // Test with a linestring
+    let line = WorldClippedGeometry::LineString(vec![
+        WorldCoord::new(1 << 26, 1 << 26),
+        WorldCoord::new(1 << 26 + 1, 1 << 26 + 1), // tiny deviation
+        WorldCoord::new(1 << 27, 1 << 27),
+    ]);
+    
+    let simplified = simplify_geometry_for_tile(&line, &tile, extent, factor);
+    
+    // Should have fewer or equal points
+    if let WorldClippedGeometry::LineString(coords) = simplified {
+        assert!(coords.len() <= 3);
+        assert!(coords.len() >= 2); // Minimum for valid linestring
+    } else {
+        panic!("Expected LineString");
+    }
+    
+    // Test that points pass through unchanged
+    let point = WorldClippedGeometry::Point(WorldCoord::new(1 << 26, 1 << 26));
+    let simplified_point = simplify_geometry_for_tile(&point, &tile, extent, factor);
+    assert!(matches!(simplified_point, WorldClippedGeometry::Point(_)));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cargo test --package gpq-tiles-core simplify::tests::test_simplify_geometry_for_tile -- --nocapture
+```
+
+Expected: FAIL with "cannot find function `simplify_geometry_for_tile`"
+
+**Step 3: Implement simplify_geometry_for_tile**
+
+Add necessary import at top of file:
+
+```rust
+use crate::hierarchical_clip::WorldClippedGeometry;
+```
+
+Add the function:
+
+```rust
+/// Simplify a WorldClippedGeometry for a specific tile.
+///
+/// This is the main entry point for tile-level simplification in the encoding
+/// pipeline. It applies boundary-preserving Douglas-Peucker simplification
+/// with zoom-appropriate tolerance.
+///
+/// # Arguments
+/// * `geom` - The clipped geometry to simplify
+/// * `tile` - The tile being encoded (for boundary detection and tolerance)
+/// * `extent` - Tile extent (typically 4096)
+/// * `simplify_factor` - Multiplier for pixel tolerance (typically 1.0)
+///
+/// # Returns
+/// Simplified geometry with boundary points preserved.
+pub fn simplify_geometry_for_tile(
+    geom: &WorldClippedGeometry,
+    tile: &TileCoord,
+    extent: u32,
+    simplify_factor: f64,
+) -> WorldClippedGeometry {
+    // Tolerance in pixels, scaled by factor
+    let pixel_tolerance = simplify_factor;
+    
+    match geom {
+        // Points cannot be simplified
+        WorldClippedGeometry::Point(p) => WorldClippedGeometry::Point(*p),
+        WorldClippedGeometry::MultiPoint(points) => {
+            WorldClippedGeometry::MultiPoint(points.clone())
+        }
+        
+        // Linestrings: use boundary-preserving simplification
+        WorldClippedGeometry::LineString(coords) => {
+            let simplified = simplify_world_linestring_preserve_boundaries(
+                coords,
+                tile,
+                extent,
+                pixel_tolerance,
+            );
+            WorldClippedGeometry::LineString(simplified)
+        }
+        
+        WorldClippedGeometry::MultiLineString(lines) => {
+            let simplified_lines: Vec<Vec<WorldCoord>> = lines
+                .iter()
+                .map(|line| {
+                    simplify_world_linestring_preserve_boundaries(
+                        line,
+                        tile,
+                        extent,
+                        pixel_tolerance,
+                    )
+                })
+                .filter(|line| line.len() >= 2) // Filter degenerate lines
+                .collect();
+            WorldClippedGeometry::MultiLineString(simplified_lines)
+        }
+        
+        // Polygons: use boundary-preserving ring simplification
+        WorldClippedGeometry::Polygon { exterior, interiors } => {
+            let simplified_exterior = simplify_world_ring_preserve_boundaries(
+                exterior,
+                tile,
+                extent,
+                pixel_tolerance,
+            );
+            
+            // Only keep interior rings that remain valid after simplification
+            let simplified_interiors: Vec<Vec<WorldCoord>> = interiors
+                .iter()
+                .map(|ring| {
+                    simplify_world_ring_preserve_boundaries(ring, tile, extent, pixel_tolerance)
+                })
+                .filter(|ring| ring.len() >= 4) // Filter degenerate rings
+                .collect();
+            
+            // If exterior becomes degenerate, return original
+            if simplified_exterior.len() < 4 {
+                return geom.clone();
+            }
+            
+            WorldClippedGeometry::Polygon {
+                exterior: simplified_exterior,
+                interiors: simplified_interiors,
+            }
+        }
+        
+        WorldClippedGeometry::MultiPolygon(polys) => {
+            let simplified_polys: Vec<(Vec<WorldCoord>, Vec<Vec<WorldCoord>>)> = polys
+                .iter()
+                .map(|(exterior, interiors)| {
+                    let simplified_exterior = simplify_world_ring_preserve_boundaries(
+                        exterior,
+                        tile,
+                        extent,
+                        pixel_tolerance,
+                    );
+                    
+                    let simplified_interiors: Vec<Vec<WorldCoord>> = interiors
+                        .iter()
+                        .map(|ring| {
+                            simplify_world_ring_preserve_boundaries(
+                                ring,
+                                tile,
+                                extent,
+                                pixel_tolerance,
+                            )
+                        })
+                        .filter(|ring| ring.len() >= 4)
+                        .collect();
+                    
+                    (simplified_exterior, simplified_interiors)
+                })
+                .filter(|(ext, _)| ext.len() >= 4) // Filter degenerate polygons
+                .collect();
+            
+            WorldClippedGeometry::MultiPolygon(simplified_polys)
+        }
+    }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+cargo test --package gpq-tiles-core simplify::tests::test_simplify_geometry_for_tile -- --nocapture
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/core/src/simplify.rs
+git commit -m "feat(simplify): add simplify_geometry_for_tile entry point
+
+Add high-level function that applies appropriate boundary-preserving
+simplification to any WorldClippedGeometry type. This is the main
+entry point for the encoding pipeline.
+
+Refs: #156"
+```
+
+---
+
+## Task 6: Export new functions from simplify module
+
+**Files:**
+- Modify: `crates/core/src/simplify.rs` (pub visibility)
+- Modify: `crates/core/src/lib.rs` (re-export)
+
+**Step 1: Verify functions are pub**
+
+Ensure all new functions have `pub` visibility (they should from previous tasks).
+
+**Step 2: Add re-export in lib.rs**
+
+In `crates/core/src/lib.rs`, find the simplify module export and ensure it includes the new functions. If there's a `pub use simplify::*;` this is automatic. Otherwise, add explicit exports:
+
+```rust
+pub use simplify::{
+    simplify_for_zoom,
+    simplify_in_tile_coords,
+    simplify_geometry_for_tile,
+    // ... existing exports
+};
+```
+
+**Step 3: Run cargo check**
+
+```bash
+cargo check --package gpq-tiles-core
+```
+
+Expected: No errors
+
+**Step 4: Commit**
+
+```bash
+git add crates/core/src/lib.rs crates/core/src/simplify.rs
+git commit -m "chore(core): export simplify functions from lib.rs
+
+Refs: #156"
+```
+
+---
+
+## Task 7: Integrate simplification into encode_tile_from_raw
+
+**Files:**
+- Modify: `crates/core/src/pipeline.rs:1852+` (encode_tile_from_raw function)
+
+This is the core integration. We add simplification right after geometry deserialization.
+
+**Step 1: Write failing test**
+
+Add to pipeline tests (or create new test file):
+
+```rust
+#[test]
+fn test_encode_tile_applies_simplification() {
+    use crate::pipeline::TilerConfig;
+    use crate::tile::TileCoord;
+    
+    // Create a config with simplification enabled
+    let config = TilerConfig::default()
+        .with_zoom_range(0, 6)
+        .with_simplify(1.0);
+    
+    assert!(config.simplify_factor.is_some());
+    // Further integration testing happens in Task 10
+}
+```
+
+**Step 2: Add simplify import to pipeline.rs**
+
+At the top of `crates/core/src/pipeline.rs`, add to the simplify import:
+
+```rust
+use crate::simplify::{simplify_for_zoom, simplify_geometry_for_tile};
+```
+
+**Step 3: Modify encode_tile_from_raw signature**
+
+The function needs access to `simplify_factor`. Add it as a parameter. Find the function at line 1852 and update:
+
+```rust
+fn encode_tile_from_raw(
+    tile_data: RawTileData,
+    layer_name: &str,
+    extent: u32,
+    enable_tiny_polygon_accumulation: bool,
+    cluster_config: Option<&ClusterConfig>,
+    coalesce_config: Option<&CoalesceConfig>,
+    coalesce_targets: Option<&CoalesceTargets>,
+    drop_smallest_as_needed: bool,
+    drop_smallest_threshold: f64,
+    gamma: Option<f64>,
+    mut gap_sampler: Option<&mut GapSampler>,
+    mut extent_sampler: Option<&mut ExtentSampler>,
+    simplify_factor: Option<f64>,  // NEW PARAMETER
+) -> Option<EncodedTile> {
+```
+
+**Step 4: Apply simplification after geometry deserialization**
+
+Find the line (around 2444):
+```rust
+let geom = match WorldClippedGeometry::from_bytes(&raw_feat.geometry_bytes) {
+    Some(g) => g,
+    None => continue,
+};
+```
+
+Replace with:
+```rust
+let geom = match WorldClippedGeometry::from_bytes(&raw_feat.geometry_bytes) {
+    Some(g) => g,
+    None => continue,
+};
+
+// Apply zoom-dependent simplification if enabled
+let geom = if let Some(factor) = simplify_factor {
+    simplify_geometry_for_tile(&geom, &coord, extent, factor)
+} else {
+    geom
+};
+```
+
+**Step 5: Update all call sites of encode_tile_from_raw**
+
+Search for all calls to `encode_tile_from_raw` and add the new parameter. There should be calls in:
+- The streaming pipeline
+- The batch processing path
+
+For each call site, pass `config.simplify_factor` as the last argument.
+
+**Step 6: Run cargo check**
+
+```bash
+cargo check --package gpq-tiles-core
+```
+
+Expected: No errors (all call sites updated)
+
+**Step 7: Commit**
+
+```bash
+git add crates/core/src/pipeline.rs
+git commit -m "feat(pipeline): integrate simplification into encode_tile_from_raw
+
+Apply zoom-dependent simplification after geometry deserialization
+in the tile encoding pipeline. Simplification is applied per-tile
+with boundary-preserving logic to prevent tile-edge seams.
+
+Refs: #156"
+```
+
+---
+
+## Task 8: Add CLI flags for simplification
+
+**Files:**
+- Modify: `crates/cli/src/main.rs`
+
+**Step 1: Add --simplify flag**
+
+Find the Args struct (around line 59) and add after the existing flags:
+
+```rust
+    /// Enable zoom-dependent geometry simplification.
+    ///
+    /// Applies Douglas-Peucker simplification with tolerance scaling by zoom level.
+    /// At lower zoom levels, geometries are simplified more aggressively.
+    /// This dramatically reduces tile sizes for linear features (roads, rivers, boundaries).
+    ///
+    /// Equivalent to tippecanoe's --simplification flag behavior.
+    #[arg(long)]
+    simplify: bool,
+
+    /// Simplification factor (default: 1.0 = 1 pixel tolerance).
+    ///
+    /// Controls simplification aggressiveness:
+    /// - 0.5: Preserve more detail (half-pixel tolerance)
+    /// - 1.0: Standard (1 pixel tolerance, tippecanoe default)
+    /// - 2.0: More aggressive (2 pixel tolerance)
+    ///
+    /// Only used when --simplify is enabled.
+    #[arg(long, default_value = "1.0")]
+    simplify_factor: f64,
+```
+
+**Step 2: Wire flags to TilerConfig**
+
+Find where TilerConfig is built from args (search for `TilerConfig::default()`) and add:
+
+```rust
+let config = TilerConfig::default()
+    // ... existing config ...
+    ;
+
+// Apply simplification if enabled
+let config = if args.simplify {
+    config.with_simplify(args.simplify_factor)
+} else {
+    config
+};
+```
+
+**Step 3: Run cargo check**
+
+```bash
+cargo check --package gpq-tiles
+```
+
+Expected: No errors
+
+**Step 4: Test CLI help**
+
+```bash
+cargo run --package gpq-tiles -- --help | grep -A3 simplify
+```
+
+Expected: Shows --simplify and --simplify-factor flags with descriptions
+
+**Step 5: Commit**
+
+```bash
+git add crates/cli/src/main.rs
+git commit -m "feat(cli): add --simplify and --simplify-factor flags
+
+Enable zoom-dependent geometry simplification from the command line.
+--simplify enables the feature, --simplify-factor controls aggressiveness.
+
+Usage:
+  gpq-tiles input.parquet output.pmtiles --simplify
+  gpq-tiles input.parquet output.pmtiles --simplify --simplify-factor 0.5
+
+Refs: #156"
+```
+
+---
+
+## Task 9: Add Python bindings for simplification
+
+**Files:**
+- Modify: `crates/python/src/lib.rs`
+
+**Step 1: Find PyTilerConfig or equivalent**
+
+Search for where Python bindings expose TilerConfig:
+
+```bash
+grep -n "simplify\|TilerConfig" crates/python/src/lib.rs
+```
+
+**Step 2: Add simplify parameter**
+
+Add `simplify_factor: Option<f64>` parameter to the Python-exposed configuration, following the existing pattern for other optional parameters.
+
+**Step 3: Run cargo check**
+
+```bash
+cd crates/python && cargo check
+```
+
+Expected: No errors
+
+**Step 4: Commit**
+
+```bash
+git add crates/python/src/lib.rs
+git commit -m "feat(python): add simplify_factor to Python bindings
+
+Expose zoom-dependent simplification configuration to Python API.
+
+Refs: #156"
+```
+
+---
+
+## Task 10: Add integration test with real GeoParquet data
+
+**Files:**
+- Modify: `crates/core/src/integration_tests.rs`
+
+**Step 1: Write integration test**
+
+```rust
+#[test]
+fn test_simplification_reduces_tile_size() {
+    use crate::pipeline::{TilerConfig, generate_tiles_to_writer};
+    use std::io::Cursor;
+    
+    // Use existing test fixture (or skip if not available)
+    let test_file = std::path::Path::new("tests/fixtures/roads.parquet");
+    if !test_file.exists() {
+        eprintln!("Skipping test: roads.parquet fixture not found");
+        return;
+    }
+    
+    // Generate tiles WITHOUT simplification
+    let config_no_simplify = TilerConfig::default()
+        .with_zoom_range(0, 6)
+        .with_layer_name("roads");
+    
+    let mut output_no_simplify = Cursor::new(Vec::new());
+    let stats_no_simplify = generate_tiles_to_writer(
+        test_file,
+        &mut output_no_simplify,
+        config_no_simplify,
+    ).expect("Tiling without simplification failed");
+    
+    // Generate tiles WITH simplification
+    let config_simplify = TilerConfig::default()
+        .with_zoom_range(0, 6)
+        .with_layer_name("roads")
+        .with_simplify(1.0);
+    
+    let mut output_simplify = Cursor::new(Vec::new());
+    let stats_simplify = generate_tiles_to_writer(
+        test_file,
+        &mut output_simplify,
+        config_simplify,
+    ).expect("Tiling with simplification failed");
+    
+    // Simplified output should be smaller (at least at low zoom levels)
+    let size_no_simplify = output_no_simplify.get_ref().len();
+    let size_simplify = output_simplify.get_ref().len();
+    
+    println!("Without simplification: {} bytes", size_no_simplify);
+    println!("With simplification: {} bytes", size_simplify);
+    println!("Reduction: {:.1}%", (1.0 - size_simplify as f64 / size_no_simplify as f64) * 100.0);
+    
+    // Expect at least some reduction for road data
+    assert!(
+        size_simplify <= size_no_simplify,
+        "Simplification should not increase output size"
+    );
+}
+```
+
+**Step 2: Run integration test**
+
+```bash
+cargo test --package gpq-tiles-core test_simplification_reduces_tile_size -- --nocapture
+```
+
+Expected: PASS (or skip if fixture unavailable)
+
+**Step 3: Commit**
+
+```bash
+git add crates/core/src/integration_tests.rs
+git commit -m "test(core): add integration test for simplification
+
+Verify that --simplify reduces output tile size for linear features.
+
+Refs: #156"
+```
+
+---
+
+## Task 11: Update documentation
+
+**Files:**
+- Modify: `docs/advanced-usage.md`
+- Modify: `docs/api-reference.md`
+
+**Step 1: Add simplification section to advanced-usage.md**
+
+```markdown
+## Geometry Simplification
+
+For datasets with complex linear features (roads, rivers, coastlines, boundaries),
+zoom-dependent simplification can dramatically reduce tile sizes at low zoom levels.
+
+### Basic Usage
+
+```bash
+# Enable with default settings (1 pixel tolerance)
+gpq-tiles roads.parquet roads.pmtiles --simplify
+
+# Custom tolerance (more aggressive)
+gpq-tiles roads.parquet roads.pmtiles --simplify --simplify-factor 2.0
+
+# Preserve more detail
+gpq-tiles roads.parquet roads.pmtiles --simplify --simplify-factor 0.5
+```
+
+### How It Works
+
+At each zoom level, Douglas-Peucker simplification is applied with a tolerance
+proportional to the pixel size at that zoom. Lower zoom levels (zoomed out) 
+have larger pixels, so more vertices are removed.
+
+**Tile boundary preservation**: Points on tile boundaries are never removed,
+preventing visible seams between adjacent tiles.
+
+### When to Use
+
+- **Linear features**: Roads, rivers, boundaries, coastlines
+- **Low zoom levels**: Where high vertex density causes oversized tiles
+- **CannotReduceFurther errors**: Simplification reduces geometry size, not feature count
+
+### Combining with Other Options
+
+```bash
+# Simplify + adaptive dropping for maximum size reduction
+gpq-tiles roads.parquet roads.pmtiles \
+  --simplify \
+  --drop-smallest-as-needed \
+  --max-tile-size 500K
+```
+```
+
+**Step 2: Update api-reference.md**
+
+Add to TilerConfig section:
+
+```markdown
+### simplify_factor
+
+- Type: `Option<f64>`
+- Default: `None` (disabled)
+- CLI: `--simplify`, `--simplify-factor`
+
+When set, enables zoom-dependent Douglas-Peucker simplification.
+The tolerance at each zoom level is `pixel_tolerance * factor`.
+
+```rust
+let config = TilerConfig::default()
+    .with_simplify(1.0);  // 1 pixel tolerance
+```
+```
+
+**Step 3: Commit**
+
+```bash
+git add docs/advanced-usage.md docs/api-reference.md
+git commit -m "docs: add simplification documentation
+
+Document --simplify and --simplify-factor CLI flags, explain when
+to use simplification, and how it interacts with other options.
+
+Refs: #156"
+```
+
+---
+
+## Task 12: Final verification and cleanup
+
+**Step 1: Run full test suite for affected modules**
+
+```bash
+cargo test --package gpq-tiles-core simplify:: -- --nocapture
+cargo test --package gpq-tiles-core test_tiler_config -- --nocapture
+```
+
+**Step 2: Run cargo fmt**
+
+```bash
+cargo fmt --all
+```
+
+**Step 3: Run cargo clippy**
+
+```bash
+cargo clippy --package gpq-tiles-core --package gpq-tiles -- -D warnings
+```
+
+**Step 4: Build release to verify optimization**
+
+```bash
+cargo build --release --package gpq-tiles
+```
+
+**Step 5: Manual test with real data (if available)**
+
+```bash
+# Test with Canada roads or similar linear dataset
+cargo run --release --package gpq-tiles -- \
+  /path/to/roads.parquet \
+  /tmp/roads-simplified.pmtiles \
+  --simplify \
+  --max-zoom 10
+
+# Compare sizes
+ls -la /tmp/roads*.pmtiles
+```
+
+**Step 6: Final commit**
+
+```bash
+git add -A
+git commit -m "chore: final cleanup for simplification feature
+
+Refs: #156"
+```
+
+---
+
+## Acceptance Criteria Checklist
+
+- [ ] `--simplify` flag enables zoom-dependent simplification
+- [ ] `--simplify-factor` controls tolerance (default: 1.0 = 1 pixel)
+- [ ] Simplification reduces tile sizes for linear features at low zoom
+- [ ] Canada roads dataset can be tiled with --simplify without CannotReduceFurther errors
+- [ ] Simplification is applied per-zoom (stricter at low zoom, gentler at high zoom)
+- [ ] Tile boundary points are preserved (no visible seams)
+- [ ] All tests pass
+- [ ] Documentation updated
+
+---
+
+## Summary of Changes
+
+| File | Changes |
+|------|---------|
+| `crates/core/src/pipeline.rs` | Add `simplify_factor` to TilerConfig, integrate into `encode_tile_from_raw` |
+| `crates/core/src/simplify.rs` | Add boundary detection, boundary-preserving simplification functions |
+| `crates/cli/src/main.rs` | Add `--simplify` and `--simplify-factor` CLI flags |
+| `crates/python/src/lib.rs` | Add `simplify_factor` to Python bindings |
+| `docs/advanced-usage.md` | Add simplification documentation |
+| `docs/api-reference.md` | Add simplify_factor API docs |


### PR DESCRIPTION
## Summary

Implements zoom-dependent Douglas-Peucker simplification to reduce tile sizes for linear features at low zoom levels.

- Adds `--simplify` flag to enable zoom-dependent simplification
- Adds `--simplify-factor` to control tolerance (default: 1.0 = 1 pixel)
- Boundary-preserving simplification prevents tile-edge seams
- Dramatically reduces tile sizes for roads, rivers, boundaries

## Problem

When tiling linear features like roads at low zoom levels, each feature can be 100-200KB+ due to high vertex counts. Even with adaptive threshold iteration, the system can only *drop features*, not *simplify geometries*:

```
Cannot reduce tile 6/17/23 (zoom 6): 3202KB with 30 features exceeds 500KB limit
Diagnosis: Each feature averages 106KB - geometries are too complex at this zoom level.
```

## Solution

Apply Douglas-Peucker simplification per-tile with zoom-appropriate tolerance. Lower zoom levels get more aggressive simplification.

## Implementation Plan

See `docs/plans/2026-04-10-zoom-dependent-simplification.md` for the detailed 12-task implementation plan.

## Test plan

- [ ] Unit tests for boundary detection
- [ ] Unit tests for boundary-preserving simplification
- [ ] Integration test verifying size reduction
- [ ] Manual test with Canada roads dataset

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)