### PR TITLE
feat(core): streaming bounded-memory overview convert + 12.8x speedup (H3)

### DIFF
--- a/benchmarks/overview/H3C_PROFILE.md
+++ b/benchmarks/overview/H3C_PROFILE.md
@@ -189,3 +189,71 @@ RUST_LOG=gpq_tiles_core::overview=debug \
 Phase lines are logged as `[profile] …` at debug level. This run: convert
 726.8 s / 335 MB peak RSS; export 271.8 s / 2.06 GB peak RSS (matches the
 uninstrumented H3 baselines within noise).
+
+## 7. Results after levers 1–4 (2026-07-03)
+
+Same dataset, same commands, same machine (16 cores), release build, after
+implementing the four ranked levers (§6 items 1–4; the cascade, §6 item 5,
+remains open):
+
+- **Lever 3 — validation cuts in `overview::simplify`**: skip candidate
+  `is_valid()` when RDP removed no vertices; never re-validate the original
+  on the fallback path; **fallback bug fixed** — an invalid RDP candidate now
+  retries at `eps/2, eps/4, eps/8` and only keeps the original geometry when
+  every retry self-intersects (counted, logged at debug level).
+- **Lever 1 — rayon in convert pass 2**: per-feature simplify parallelized
+  within each read batch (order-preserving collect; writer single-threaded).
+- **Lever 4 — export bbox fast path**: features whose bbox lies inside the
+  buffered tile bounds skip the BooleanOps clip entirely.
+- **Lever 2 — rayon in export**: per-feature clip and per-tile MVT encode
+  parallelized (order-preserving; grouping merge and write loop serial).
+
+### Wall / memory (Moldova, duplicating z0–14)
+
+Baselines are the H3 artifacts in `corpus/data/bench/h3/` (same commands).
+
+| Command | Wall before | Wall after | Speedup | RSS before | RSS after |
+|---|---:|---:|---:|---:|---:|
+| `overview` (convert) | 706.1 s | **55.3 s** | **12.8×** | 305.7 MB | 320.2 MB |
+| `export-pmtiles` | 288.5 s | **58.8 s** | **4.9×** | 2.16 GB | 2.38 GB |
+
+CPU utilization: convert 557 %, export 828 % (of 1600 %). Output validation:
+all 9 `gpq-tiles validate` checks pass; export reports **0 oversized tiles**
+(17,372 tiles in both runs).
+
+### Output size drop (the fallback fix, intended)
+
+Coarse/mid levels no longer quietly carry 3–9 % of features at full
+resolution. Features kept at full resolution (all epsilon retries
+self-intersecting): **3,664 total** — level 1: 7, level 2: 120, level 3: 633,
+level 4: 1,401, level 5: 1,502, level 6: 1, levels 7–10: 0 — versus the old
+behaviour where *every* invalid first candidate (e.g. ~9 % of a coarse-level
+sample, §4) fell back.
+
+| | Before | After | Δ |
+|---|---:|---:|---:|
+| Overview parquet | 360.7 MB | 293.6 MB | **−18.6 %** |
+| Total vertices | 118.3 M | 87.7 M | −25.9 % |
+| Level 6 vertices | 8.45 M | 1.35 M | −84 % |
+| Level 7 vertices | 9.76 M | 2.18 M | −78 % |
+| PMTiles archive | 130.7 MB | 123.3 MB | −5.7 % |
+
+Row-count deltas are tiny: 1,583,053 → 1,583,041 (−12 rows; retry candidates
+whose shoelace area collapsed below the sliver gate are now dropped instead
+of being kept at full resolution) and 1,807,912 → 1,807,901 exported tile
+features (−11, downstream of the same rows).
+
+### Where the remaining time goes (vs the Amdahl ceilings)
+
+- Convert (ceiling ~10.6× from lever 1 alone; achieved 12.8× because lever 3
+  multiplies): level 10 is now the bottleneck (26.1 s of the 53.6 s pass 2 —
+  candidate `is_valid()` on 383 k nearly-full-resolution polygons, imperfectly
+  load-balanced across the per-batch parallel sections). Read+decode+write
+  floor is ~12 s serial.
+- Export (ceiling ~8.4×; achieved 4.9×): z14 clip+group fell 168.2 s → 42.2 s
+  (4×, not the naive 16×·5×): the bbox fast path replaces most clips with a
+  geometry clone + regroup that is allocation-bound, and the per-zoom merge
+  into the `BTreeMap` stays serial. Export RSS rose ~10 % (per-feature clip
+  results are staged before the serial merge).
+- The §5 cascade (simplify level k from level k+1) remains the next lever for
+  convert level 10.

--- a/benchmarks/overview/H3C_PROFILE.md
+++ b/benchmarks/overview/H3C_PROFILE.md
@@ -1,0 +1,191 @@
+# H3(c) — Wall-time profile of the overview pipeline (Moldova)
+
+Where the ~12 min of `overview` convert and ~5 min of `export-pmtiles` actually
+go, measured on `corpus/data/gpio/polygons-ftw-moldova-large.parquet`
+(631,910 polygons), duplicating mode, z0–z14 (12 emitted levels), 16-core
+machine, release build.
+
+Method: `std::time::Instant` phase accumulators in
+`crates/core/src/overview/stream.rs` and `export.rs`, logged at
+`RUST_LOG=gpq_tiles_core::overview=debug` (instrumentation retained behind that
+log level), plus `/usr/bin/time -v` and live `ps`/`/proc/<pid>/task` sampling.
+`perf` was unavailable (`perf_event_paranoid=4`, no sudo); the simplify
+decomposition below came from a throwaway micro-benchmark on real Moldova
+geometries (not committed; described in §4).
+
+## 1. CPU utilization: strictly serial
+
+Both commands run **one thread at ~100% of one core** for their entire life
+(`/proc/<pid>/task` count = 1; `ps %cpu` = 99.9; `time` reports 99–100% CPU on
+a 16-core box). Neither pipeline has any parallelism today.
+
+## 2. Convert phase breakdown (total wall 726.8 s)
+
+| Phase | Wall (s) | Share |
+|---|---:|---:|
+| Pass 1 (stream + feature scan) | 1.3 | 0.2% |
+| Assignment + density budget | 0.5 | 0.1% |
+| Pass 2 — parquet read+decode (12 re-reads) | 9.4 | 1.3% |
+| Pass 2 — winner select + geometry decode | 2.2 | 0.3% |
+| **Pass 2 — simplification** | **704.6** | **96.9%** |
+| Pass 2 — output batch assembly | 1.2 | 0.2% |
+| Pass 2 — writer (Arrow→Parquet + ZSTD-3) | 7.6 | 1.0% |
+| Writer finish (footer) | 0.0 | 0.0% |
+
+Per level (pass 2; `rows` = rows written; duplicating mode simplifies the
+*cumulative* winner set at each non-canonical level from full resolution):
+
+| Level | GSD (m) | Rows | Total (s) | Read | Decode | Simplify | Build | Write |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 0 | 4892.0 | 1 | 0.8 | 0.76 | 0.00 | 0.00 | 0.00 | 0.00 |
+| 1 | 2446.0 | 41 | 6.6 | 0.79 | 0.00 | 5.78 | 0.01 | 0.01 |
+| 2 | 1223.0 | 994 | 26.2 | 0.77 | 0.02 | 25.32 | 0.02 | 0.06 |
+| 3 | 611.5 | 7,804 | 56.6 | 0.80 | 0.09 | 55.51 | 0.04 | 0.19 |
+| 4 | 305.7 | 18,633 | 80.7 | 0.83 | 0.14 | 79.34 | 0.05 | 0.31 |
+| 5 | 152.9 | 31,149 | 95.0 | 0.79 | 0.17 | 93.55 | 0.07 | 0.42 |
+| 6 | 76.4 | 51,559 | 107.4 | 0.79 | 0.22 | 105.74 | 0.09 | 0.56 |
+| 7 | 38.2 | 85,209 | 113.1 | 0.78 | 0.24 | 111.33 | 0.10 | 0.64 |
+| 8 | 19.1 | 140,670 | 92.9 | 0.78 | 0.26 | 91.05 | 0.11 | 0.65 |
+| 9 | 9.6 | 232,107 | 24.4 | 0.75 | 0.30 | 22.46 | 0.12 | 0.78 |
+| 10 | 4.8 | 382,976 | 117.7 | 0.77 | 0.36 | 114.51 | 0.28 | 1.77 |
+| 11 (verbatim) | 2.4 | 631,910 | 3.7 | 0.77 | 0.42 | 0.01 | 0.29 | 2.17 |
+
+Observations:
+
+- **Simplification is everything.** The canonical level (631,910 rows,
+  verbatim) takes 3.7 s end-to-end — reading, decoding, and ZSTD-writing the
+  whole dataset costs almost nothing. Every non-canonical level costs 24–118 s,
+  >98% of it inside `simplify_for_level`.
+- Cost is *not* proportional to row count: level 1 spends 5.8 s on **41
+  features** (141 ms/feature). Coarse-level winners are the largest
+  geometries, and per-feature cost is superlinear in vertex count (§4).
+- Level 9 is an anomaly (22.5 s for 232k rows vs 91 s for 141k at level 8);
+  its winner increment is dominated by small, few-vertex features. Level 10
+  jumps back up (114.5 s).
+
+## 3. Export phase breakdown (total wall 271.8 s)
+
+| Phase | Wall (s) | Share |
+|---|---:|---:|
+| Read + decode level bands | 3.4 | 1.3% |
+| **Clip + tile grouping (`clip_geometry` per feature×tile)** | **255.5** | **94.0%** |
+| MVT encode | 7.4 | 2.7% |
+| Writer add_tile (gzip) | 4.6 | 1.7% |
+| PMTiles finalize (directories) | 0.1 | 0.0% |
+
+Per zoom:
+
+| Zoom (level) | Feats | Tiles | Read | Clip+group | MVT | Write |
+|---|---:|---:|---:|---:|---:|---:|
+| z3 (0) | 1 | 1 | 0.00 | 0.00 | 0.00 | 0.00 |
+| z4 (1) | 41 | 1 | 0.01 | 0.34 | 0.00 | 0.00 |
+| z5 (2) | 994 | 1 | 0.04 | 1.68 | 0.03 | 0.02 |
+| z6 (3) | 7,804 | 2 | 0.08 | 3.51 | 0.09 | 0.07 |
+| z7 (4) | 18,633 | 4 | 0.12 | 4.96 | 0.16 | 0.15 |
+| z8 (5) | 31,149 | 11 | 0.17 | 6.67 | 0.24 | 0.25 |
+| z9 (6) | 51,559 | 27 | 0.23 | 8.21 | 0.30 | 0.35 |
+| z10 (7) | 85,209 | 76 | 0.25 | 10.01 | 0.39 | 0.40 |
+| z11 (8) | 140,670 | 252 | 0.27 | 11.06 | 0.49 | 0.37 |
+| z12 (9) | 232,107 | 901 | 0.34 | 2.80 | 0.73 | 0.39 |
+| z13 (10) | 382,976 | 3,363 | 0.82 | 38.01 | 1.77 | 1.01 |
+| z14 (11) | 631,910 | 12,733 | 1.08 | 168.20 | 3.18 | 1.54 |
+
+z13+z14 clip alone = 206 s = 76% of the export. At z14 the 631,910 features
+produce only 763,308 clipped copies (~21% seam duplication) — i.e. **~80% of
+features fall entirely inside one tile yet still pay a full BooleanOps
+intersection**. A bbox-containment fast path (feature bbox ⊂ buffered tile
+bounds ⇒ keep geometry unclipped) would skip most of that work. The same
+level-9/z12 anomaly appears here (2.8 s vs 11.1 s at z11).
+
+## 4. Inside "simplify": validation, not RDP
+
+Micro-benchmark on the first 20,000 Moldova polygons (1.10 M exterior
+vertices), timing the three components of `overview::simplify`'s polygon path
+separately at real level GSDs (EPSG:4326 tolerances):
+
+| GSD (m) | RDP `simplify()` | `is_valid()` on candidate | `is_valid()` on original (fallback path) | invalid candidates |
+|---:|---:|---:|---:|---:|
+| 152.87 | 0.04 s | 0.08 s | 3.98 s | 1,859 |
+| 76.44 | 0.05 s | 0.06 s | 4.03 s | 1,766 |
+| 38.22 | 0.05 s | 0.07 s | 3.83 s | 1,267 |
+| 19.11 | 0.06 s | 0.12 s | 2.97 s | 652 |
+| 9.55 | 0.10 s | 0.78 s | 0.00 s | 3 |
+| 4.78 | 0.15 s | 4.01 s | 0.00 s | 0 |
+
+- **RDP itself is 1–4% of simplify cost.** The rest is `geo::Validation`
+  (self-intersection checking, superlinear in ring vertices): at fine GSD the
+  candidate check dominates (many vertices survive), at coarse GSD 3–9% of
+  candidates come out self-intersecting and trigger a *full-resolution*
+  `is_valid()` on the original — the dominant term.
+- Side observation (correctness/size, not perf): those invalid candidates take
+  the boundary-preserving fallback, i.e. coarse levels quietly carry ~5–9% of
+  features at **full resolution**. This is likely why coarse-level
+  vertex/byte counts are higher than expected.
+- The absolute numbers here (≈4 s/20k) are much smaller than pass 2's per-level
+  cost because level winners at coarse levels are the *largest* features, not
+  a file-order sample; the split (validation ≫ RDP) is the robust finding.
+
+## 5. Redundant per-level decode + simplify (cascade potential)
+
+Duplicating mode re-reads the file and re-processes the cumulative winner set
+at every level: 1,583,053 rows processed for 631,910 inputs (**2.5× row
+redundancy**; winner counts per level in §2).
+
+- Redundant **decode** is worthless to eliminate: all 12 re-reads plus decode
+  total 11.6 s = 1.6% of convert wall.
+- Redundant **simplify** is the real cost: every non-canonical level
+  re-simplifies its winners from full resolution, so the big coarse-level
+  features are re-RDP'd and re-validated up to 11 times (levels 1–10 sum to
+  704.6 s). A cascade (simplify level k from level k+1's already-simplified
+  output) shrinks both the RDP input and — more importantly — the vertex count
+  seen by validation. Estimated from the per-level output vertex table
+  (level outputs sum to ~113 M vertices vs ~240 M full-res vertex re-reads):
+  roughly **1.5–3× on the simplify share**, more where validation's
+  superlinearity bites. Caveat: cascading changes output geometry slightly
+  (RDP is not idempotent across tolerances) — a documented divergence would be
+  needed.
+
+## 6. Ranked recommendation
+
+Amdahl ceilings assume 16 cores and the measured serial shares.
+
+1. **Rayon parallelism in pass 2 (lever 1) — do first.** Simplify is 96.9% of
+   convert wall and embarrassingly parallel per feature/batch. Ceiling
+   ≈ 1/(0.031 + 0.969/16) ≈ **10.6× convert** (12 min → ~70 s). Mechanical,
+   no output change.
+2. **Export per-tile / per-feature parallelism (lever 3) — same PR family.**
+   Clip is 94.0% of export wall, parallel per feature (grouping) or per tile
+   (encode). Ceiling ≈ 1/(0.06 + 0.94/16) ≈ **8.4× export** (4:32 → ~32 s).
+3. **Cut validation cost in `overview::simplify` (new lever, found here).**
+   RDP is 1–4% of simplify; `is_valid()` (candidate + full-res fallback) is
+   the rest. Options: bail out of validation early, use a topology-preserving
+   simplifier, or validate only the touched rings. Potential is another
+   **~5–10× on the simplify share**, multiplicative with lever 1 — together
+   they could put convert near the 15–20 s I/O+write floor.
+4. **Export clip bbox fast path (new lever).** ~80% of z14 features are
+   fully interior to one tile; skipping BooleanOps for bbox-contained features
+   plausibly cuts clip 2–5×, multiplicative with lever 2.
+5. **Cascade simplification (lever 2).** Est. 1.5–3× on simplify only, with a
+   behavioral divergence to document. Worth doing *after* 1+3; redundant
+   decode elimination alone is worthless (1.6% of wall).
+6. **Compression level (lever 4) — skip.** ZSTD-3 writing is 1.0% of convert;
+   gzip tiles are 1.7% of export. No headroom.
+
+## Reproduction
+
+```bash
+cargo build --release
+RUST_LOG=gpq_tiles_core::overview=debug \
+  /usr/bin/time -v target/release/gpq-tiles overview \
+  corpus/data/gpio/polygons-ftw-moldova-large.parquet \
+  /tmp/moldova.dup.parquet \
+  --mode duplicating --min-zoom 0 --max-zoom 14
+RUST_LOG=gpq_tiles_core::overview=debug \
+  /usr/bin/time -v target/release/gpq-tiles export-pmtiles \
+  /tmp/moldova.dup.parquet /tmp/moldova.pmtiles \
+  --layer-name fields
+```
+
+Phase lines are logged as `[profile] …` at debug level. This run: convert
+726.8 s / 335 MB peak RSS; export 271.8 s / 2.06 GB peak RSS (matches the
+uninstrumented H3 baselines within noise).

--- a/benchmarks/overview/H3_NOTES.md
+++ b/benchmarks/overview/H3_NOTES.md
@@ -1,0 +1,92 @@
+# H3 — Streaming / bounded-memory overview conversion
+
+Date: 2026-07-03. Branch: `feat/streaming-overviews`.
+
+Implements plan item **H3(a)** (Phase 5 / V4): the two-pass streaming
+convert pipeline (`crates/core/src/overview/stream.rs`). Pass 1 streams
+the input (geometry + ranking columns only) into per-feature winner
+tables (level assignment + Q2 density budget, O(occupied-cells) engine
+state, 1-byte-per-feature result). Pass 2 re-reads the seekable input
+once per level, filters each read batch against the winner table,
+simplifies only the selected rows, and writes batch-by-batch through
+the existing `OverviewWriter` (per-level row-group sizing via
+`level_row_hint` = winner count).
+
+Streaming is the **default**; `--no-streaming` keeps the original
+in-memory pipeline as the reference implementation (equivalence-tested
+in `overview::convert::tests::streaming_matches_*`).
+
+## Moldova before / after
+
+Dataset: `corpus/data/gpio/polygons-ftw-moldova-large.parquet`
+(631,910 polygons, 38 M canonical vertices). Command (identical to the
+V3 `run_conversion.sh` recipe):
+
+```bash
+/usr/bin/time -v target/release/gpq-tiles overview \
+  corpus/data/gpio/polygons-ftw-moldova-large.parquet \
+  out.parquet --mode duplicating \
+  --min-zoom 0 --max-zoom 14 [--no-streaming]
+```
+
+Both runs on the same release build, same machine, sequential
+(raw `time -v` logs: `corpus/data/bench/h3/moldova.{mem,stream}.time.txt`).
+
+| pipeline | wall time | Max RSS |
+|---|---|---|
+| in-memory (`--no-streaming`), this machine | 11:50.48 | **5.30 GB** (5,557,952 kB) |
+| in-memory, plan-recorded baseline (V1, 2026-07-02) | 10:57 | 5.44 GB |
+| **streaming (default)** | **11:46.07** | **305.7 MB** (312,996 kB) |
+
+- **Peak RSS: 5.30 GB → 305.7 MB (−94 %, 17.8×), well under the 1 GB
+  acceptance target.**
+- Wall time: unchanged (11:50 → 11:46). The per-level re-read +
+  re-decode of pass 2 costs about what the in-memory path's
+  whole-table `take()` + per-level geometry cloning did. The H3(c)
+  wall-time item (per-level decode→rebuild churn, WKB caching /
+  cascaded simplification) remains open and is orthogonal.
+
+## Output equivalence (Moldova, duplicating z0–14)
+
+- `geo:overviews` footer JSON: **byte-identical** between the two runs.
+- `geo` (GeoParquet 1.1) footer JSON: **byte-identical**.
+- Rows: 1,583,053 across 12 emitted levels in both; row groups: 167 in
+  both; per-level feature and vertex counts identical at every level.
+- Both files pass all 9 `gpq-tiles validate` checks.
+- Compressed level bytes differ marginally (e.g. canonical 97.25 vs
+  97.33 MiB): the streaming writer encodes many read-batch-sized
+  batches per row group instead of one level-sized batch, which
+  changes Parquet page framing, not values.
+
+## Knobs added (core `ConvertOptions` → CLI → docs)
+
+| flag | default | meaning |
+|---|---|---|
+| `--no-streaming` | off (streaming on) | revert to the in-memory reference pipeline |
+| `--read-batch-size ROWS` | 8192 | rows per Arrow read batch in both passes; bounds the transient working set |
+
+Documented in `docs/OVERVIEW_TUNING.md` § "Memory / streaming knobs".
+
+## Residual memory + behavior notes
+
+- Residual O(N) state in streaming mode: pass 1 holds the
+  `AssignFeature` vector (~48 B/feature) plus ranking-key vectors
+  (16 B/feature) while the assignment runs (freed before pass 2);
+  pass 2 carries only the 1 B/feature winner table. ~40 MB total for
+  Moldova; scales linearly but stays laptop-sized at planet tier.
+- The remaining per-batch hotspot is a single read batch of decoded
+  geometries (WKB → `geo::Geometry`); `--read-batch-size` bounds it.
+  There is **no** in-memory per-level sort in either path: Hilbert
+  order comes from the gpio-sorted input contract and input order is
+  preserved within each level.
+- One documented behavior divergence (see `stream.rs` module docs):
+  the in-memory path omits a level whose *post-simplification* output
+  is empty; the streaming path decides level omission from the winner
+  table (pre-simplification). They differ only if every winner of a
+  level degenerates during simplification — impossible under default
+  knobs (assign visibility gates 2–4×GSD are stricter than the 1×GSD
+  simplify drop gate) — in which case the streaming writer fails
+  loudly with `EmptyLevel` instead of silently renumbering.
+- H3(b) (export: flush finished tiles instead of holding a zoom map)
+  is **not** part of this change; export still holds one zoom in
+  memory.

--- a/context/OVERVIEWS_PLAN.md
+++ b/context/OVERVIEWS_PLAN.md
@@ -352,6 +352,14 @@ Human part: the merge buttons. Agent part: triage + fixes.
 - Still human: merge/close #158, retarget #168 → main, CI re-run.
 
 ### H3. V4 streaming — the big-files unlock  (the big ticket)
+(a) DONE 2026-07-03: two-pass streaming convert (`overview/stream.rs`),
+default on (`--no-streaming` keeps the in-memory reference path;
+`--read-batch-size`, default 8192). Moldova dup z0–14: 5.30 GB →
+305.7 MB peak RSS (−94 %), wall time unchanged (11:50 → 11:46),
+byte-identical `geo`/`geo:overviews` footers + identical per-level
+counts vs in-memory, all validate checks pass. See
+`benchmarks/overview/H3_NOTES.md`. (b) export and (c) wall-time
+profile remain open.
 Baseline to beat: Moldova 632k = 10m57s / 5.44 GB RSS (convert),
 and export holds one full zoom in memory (canonical zoom = whole
 dataset ⇒ same ceiling).

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1209,6 +1209,8 @@ fn run_validate(args: ValidateArgs) -> Result<()> {
 fn run_export_pmtiles(args: ExportPmtilesArgs) -> Result<()> {
     use gpq_tiles_core::overview::export::{export_pmtiles, ExportOptions};
 
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
     let opts = ExportOptions {
         layer_name: args.layer_name,
         tile_buffer: args.tile_buffer,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -313,6 +313,29 @@ struct OverviewArgs {
     #[arg(long)]
     full_column_stats: bool,
 
+    /// Disable the two-pass bounded-memory streaming pipeline (H3).
+    ///
+    /// By default the converter streams the input twice: pass 1 builds the
+    /// per-feature winner tables (level assignment + density budget) holding
+    /// only bboxes/kinds/sort-keys; pass 2 re-reads the input per level and
+    /// simplifies + writes batch-by-batch. Peak memory is O(read batch +
+    /// winner tables) instead of O(dataset) — e.g. Moldova (632k polygons)
+    /// drops from ~5.4 GB to well under 1 GB peak RSS. Output is equivalent
+    /// (same level assignments, rows, and footer). This flag reverts to the
+    /// original in-memory pipeline, which decodes the whole dataset once and
+    /// may be marginally faster on small inputs that comfortably fit in RAM.
+    #[arg(long)]
+    no_streaming: bool,
+
+    /// Rows per Arrow read batch in the streaming pipeline (both passes).
+    ///
+    /// LARGER batches amortize per-batch overhead (slightly faster) at the
+    /// cost of proportionally more peak memory; SMALLER batches bound memory
+    /// tighter. The default (8192) keeps per-batch transients in the tens of
+    /// MB even for vertex-heavy polygon data. No effect with --no-streaming.
+    #[arg(long, value_name = "ROWS", default_value = "8192")]
+    read_batch_size: usize,
+
     /// Write the JSON conversion report to this path.
     #[arg(long, value_name = "PATH")]
     report: Option<PathBuf>,
@@ -1057,6 +1080,8 @@ fn run_overview(args: OverviewArgs) -> Result<()> {
         cogp_compat_key: args.cogp_compat,
         max_row_group_size: args.row_group_size,
         full_column_stats: args.full_column_stats,
+        streaming: !args.no_streaming,
+        read_batch_size: args.read_batch_size,
     };
 
     let report = convert_to_overviews(&args.input, &args.output, &options)

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -1,13 +1,15 @@
-//! In-memory overview conversion pipeline (task P5).
+//! Overview conversion pipeline (task P5; streaming since H3).
 //!
 //! [`convert_to_overviews`] wires the existing overview modules into a single
-//! GeoParquet → GeoParquet overview build:
+//! GeoParquet → GeoParquet overview build. By default
+//! ([`ConvertOptions::streaming`]) it dispatches to the two-pass
+//! bounded-memory pipeline in [`super::stream`]; the in-memory reference
+//! implementation below (`streaming: false`) proceeds as:
 //!
 //! 1. **read** the whole input GeoParquet preserving the full property schema
-//!    (in-memory v1: the entire table is concatenated into one batch; the
-//!    streaming refactor is task V4). The CRS is detected from the `geo`
-//!    metadata and mapped to [`Crs`]; non-4326/3857 inputs and inputs that
-//!    already carry a `level` column are rejected (spec Q3, §4.1).
+//!    (the entire table is concatenated into one batch). The CRS is detected
+//!    from the `geo` metadata and mapped to [`Crs`]; non-4326/3857 inputs and
+//!    inputs that already carry a `level` column are rejected (spec Q3, §4.1).
 //! 2. **assign** every feature a coarsest level via [`assign::assign_levels`]
 //!    over per-feature bbox + [`FeatureKind`] + an optional sort key.
 //! 3. **generalize + write**, coarse→fine, feeding [`OverviewWriter`]:
@@ -22,8 +24,10 @@
 //!    totals, duration) is returned and is `serde` `Serialize` for the later
 //!    benchmark tasks.
 //!
-//! This is the correctness-first, in-memory implementation. Memory is
-//! `O(dataset)`; the bounded-memory streaming pipeline is a later task.
+//! The in-memory path is the correctness-first reference: memory is
+//! `O(dataset)`. The default streaming path ([`super::stream`]) produces
+//! equivalent output in `O(read batch + winner tables)` memory; equivalence
+//! is asserted by the `streaming_matches_*` tests below.
 
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -78,7 +82,7 @@ impl LevelPlan {
     /// per-zoom GSDs of a [`ZoomRange`](LevelPlan::ZoomRange) plan and has no
     /// effect on an explicit [`Gsds`](LevelPlan::Gsds) plan (those GSDs are
     /// already in meters).
-    fn resolve(&self, gsd_base: f64) -> Result<Vec<(f64, Option<u8>)>, ConvertError> {
+    pub(super) fn resolve(&self, gsd_base: f64) -> Result<Vec<(f64, Option<u8>)>, ConvertError> {
         match self {
             LevelPlan::ZoomRange { min_zoom, max_zoom } => {
                 if min_zoom > max_zoom {
@@ -192,7 +196,7 @@ pub fn overture_road_ranking(column: String) -> ClassRanking {
 /// decide whether an auto-detected `class`/`road_class` column is *actually* a
 /// road-class column (overlap gate). Includes rail/pedestrian values that the
 /// ranking itself leaves at `unknown_rank`.
-const KNOWN_ROAD_CLASSES: &[&str] = &[
+pub(super) const KNOWN_ROAD_CLASSES: &[&str] = &[
     "motorway",
     "trunk",
     "primary",
@@ -223,7 +227,7 @@ const KNOWN_ROAD_CLASSES: &[&str] = &[
 
 /// Minimum number of *distinct* known road classes a candidate column must
 /// contain before auto-detection treats it as Overture roads.
-const ROAD_VOCAB_MIN_DISTINCT: usize = 3;
+pub(super) const ROAD_VOCAB_MIN_DISTINCT: usize = 3;
 
 /// Options for [`convert_to_overviews`].
 #[derive(Debug, Clone)]
@@ -263,7 +267,24 @@ pub struct ConvertOptions {
     /// bbox covering and `level` column always keep their pruning stats. Set
     /// `true` for clients that push property predicates to the remote file.
     pub full_column_stats: bool,
+    /// Use the two-pass bounded-memory streaming pipeline (H3). Default `true`.
+    ///
+    /// Pass 1 streams the input once to build the per-feature winner tables
+    /// (level assignment + Q2 density budget); pass 2 streams the input again
+    /// per level, simplifying and writing batch-by-batch. Peak memory is
+    /// `O(read batch + winner tables)` instead of `O(dataset)`. Set `false`
+    /// to use the original in-memory pipeline (kept for comparison; produces
+    /// equivalent output).
+    pub streaming: bool,
+    /// Rows per Arrow read batch in the streaming pipeline (both passes).
+    /// Default [`DEFAULT_READ_BATCH_SIZE`]. Larger batches amortize per-batch
+    /// overhead at the cost of proportionally more peak memory; smaller
+    /// batches bound memory tighter. No effect when `streaming` is `false`.
+    pub read_batch_size: usize,
 }
+
+/// Default rows per read batch for the streaming pipeline (H3).
+pub const DEFAULT_READ_BATCH_SIZE: usize = 8192;
 
 impl Default for ConvertOptions {
     fn default() -> Self {
@@ -283,6 +304,8 @@ impl Default for ConvertOptions {
             cogp_compat_key: false,
             max_row_group_size: super::writer::DEFAULT_MAX_ROW_GROUP_SIZE,
             full_column_stats: false,
+            streaming: true,
+            read_batch_size: DEFAULT_READ_BATCH_SIZE,
         }
     }
 }
@@ -395,6 +418,16 @@ pub fn convert_to_overviews(
     output_path: impl AsRef<Path>,
     options: &ConvertOptions,
 ) -> Result<ConvertReport, ConvertError> {
+    // Two-pass bounded-memory pipeline (H3, default). The in-memory path below
+    // is kept as the reference implementation (`streaming: false`).
+    if options.streaming {
+        return super::stream::convert_streaming(
+            input_path.as_ref(),
+            output_path.as_ref(),
+            options,
+        );
+    }
+
     let start = Instant::now();
     let input_path = input_path.as_ref();
     let output_path = output_path.as_ref();
@@ -624,7 +657,7 @@ pub fn convert_to_overviews(
 
 /// Detect the input CRS and map it to [`Crs`], rejecting anything that is not
 /// EPSG:4326 or EPSG:3857 (spec Q3).
-fn detect_crs(path: &Path) -> Result<Crs, ConvertError> {
+pub(super) fn detect_crs(path: &Path) -> Result<Crs, ConvertError> {
     let info = crate::quality::extract_crs(path)?;
     if info.is_wgs84 {
         return Ok(Crs::Epsg4326);
@@ -645,7 +678,7 @@ fn detect_crs(path: &Path) -> Result<Crs, ConvertError> {
 }
 
 /// Find the primary geometry column index (name `geometry`, else first `geom*`).
-fn find_geometry_column(schema: &Schema) -> Option<usize> {
+pub(super) fn find_geometry_column(schema: &Schema) -> Option<usize> {
     schema
         .fields()
         .iter()
@@ -659,7 +692,7 @@ fn find_geometry_column(schema: &Schema) -> Option<usize> {
 }
 
 /// `[xmin, ymin, xmax, ymax]` of a geometry (`[0;4]` when the bbox is undefined).
-fn geometry_bbox(g: &Geometry<f64>) -> [f64; 4] {
+pub(super) fn geometry_bbox(g: &Geometry<f64>) -> [f64; 4] {
     match g.bounding_rect() {
         Some(r) => [r.min().x, r.min().y, r.max().x, r.max().y],
         None => [0.0, 0.0, 0.0, 0.0],
@@ -667,7 +700,7 @@ fn geometry_bbox(g: &Geometry<f64>) -> [f64; 4] {
 }
 
 /// Map a geometry to the [`FeatureKind`] used for thinning / visibility.
-fn feature_kind(g: &Geometry<f64>) -> FeatureKind {
+pub(super) fn feature_kind(g: &Geometry<f64>) -> FeatureKind {
     match g {
         Geometry::Point(_) | Geometry::MultiPoint(_) => FeatureKind::Point,
         Geometry::LineString(_) | Geometry::MultiLineString(_) | Geometry::Line(_) => {
@@ -678,14 +711,14 @@ fn feature_kind(g: &Geometry<f64>) -> FeatureKind {
 }
 
 /// Count coordinates (vertices) in a geometry.
-fn count_vertices(g: &Geometry<f64>) -> usize {
+pub(super) fn count_vertices(g: &Geometry<f64>) -> usize {
     use geo::coords_iter::CoordsIter;
     g.coords_count()
 }
 
 /// Extract an optional f64 sort key per row from a numeric Arrow column.
 /// Non-numeric columns and null values yield `None`.
-fn extract_sort_keys(col: &dyn Array) -> Vec<Option<f64>> {
+pub(super) fn extract_sort_keys(col: &dyn Array) -> Vec<Option<f64>> {
     use arrow_array::cast::AsArray;
     use arrow_array::types::{
         Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type,
@@ -724,7 +757,7 @@ fn extract_sort_keys(col: &dyn Array) -> Vec<Option<f64>> {
 }
 
 /// A mixed-`Geometry` GeoArrow field carrying the geoarrow extension metadata.
-fn mixed_geometry_field(name: &str) -> Arc<Field> {
+pub(super) fn mixed_geometry_field(name: &str) -> Arc<Field> {
     use geoarrow_array::GeoArrowArray;
     let typ = GeometryType::new(Default::default());
     let empty = GeometryBuilder::new(typ).with_prefer_multi(false).finish();
@@ -733,7 +766,7 @@ fn mixed_geometry_field(name: &str) -> Arc<Field> {
 
 /// Build the writer source schema: original fields, geometry field replaced by
 /// the geoarrow-typed field, no file-level metadata (the encoder regenerates it).
-fn build_source_schema(
+pub(super) fn build_source_schema(
     input_schema: &Schema,
     geom_idx: usize,
     geom_out_field: Arc<Field>,
@@ -755,7 +788,7 @@ fn build_source_schema(
 
 /// Assemble one level's record batch: non-geometry columns via `take` on the
 /// selected indices (preserving input order), geometry rebuilt from `geoms`.
-fn build_level_batch(
+pub(super) fn build_level_batch(
     source_schema: &Schema,
     full: &RecordBatch,
     non_geom_cols: &[usize],
@@ -787,7 +820,7 @@ fn build_level_batch(
 }
 
 /// Build informative generalization provenance (§3.5) from the emitted gsds.
-fn build_generalization(
+pub(super) fn build_generalization(
     gsds: &[f64],
     _crs: Crs,
     options: &ConvertOptions,
@@ -933,7 +966,7 @@ fn resolve_ranking(
 }
 
 /// Provenance for a categorical class ranking, echoing the map when small.
-fn class_ranking_provenance(mode: &str, cr: &ClassRanking) -> RankingProvenance {
+pub(super) fn class_ranking_provenance(mode: &str, cr: &ClassRanking) -> RankingProvenance {
     let ranks = if cr.ranks.len() <= MAX_PROVENANCE_RANKS {
         Some(cr.ranks.clone())
     } else {
@@ -950,7 +983,7 @@ fn class_ranking_provenance(mode: &str, cr: &ClassRanking) -> RankingProvenance 
 /// Map each row's string value to its class priority. Null values → `None`
 /// (they lose to every ranked feature). A present-but-unranked value maps to
 /// [`ClassRanking::unknown_rank`].
-fn extract_class_ranks(
+pub(super) fn extract_class_ranks(
     col: &dyn Array,
     ranking: &ClassRanking,
 ) -> Result<Vec<Option<f64>>, ConvertError> {
@@ -1071,7 +1104,7 @@ fn find_confidence_column(
 
 /// Fill each level report's byte sizes by summing its row-group band from the
 /// output file's Parquet footer.
-fn fill_level_bytes(
+pub(super) fn fill_level_bytes(
     output_path: &Path,
     meta: &super::level::OverviewsMeta,
     reports: &mut [LevelReport],
@@ -2001,6 +2034,197 @@ mod tests {
         for w in on.levels.windows(2) {
             assert!(w[0].feature_count <= w[1].feature_count);
         }
+    }
+
+    // --- H3 streaming / in-memory equivalence -------------------------------
+
+    /// Raw `geo:overviews` footer JSON of an overview file.
+    fn overviews_footer_json(path: &Path) -> String {
+        let file = std::fs::File::open(path).unwrap();
+        let b = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
+        b.metadata()
+            .file_metadata()
+            .key_value_metadata()
+            .unwrap()
+            .iter()
+            .find(|kv| kv.key == crate::overview::level::OVERVIEWS_KEY)
+            .expect("geo:overviews key")
+            .value
+            .clone()
+            .unwrap()
+    }
+
+    /// Convert the same input through the in-memory and streaming paths and
+    /// assert equivalent outputs: per-level feature/vertex counts, footer
+    /// metadata (byte-identical JSON), and row values in order at every level.
+    /// Assumes a `write_input`-shaped file (id/name/rank/geometry columns).
+    fn assert_streaming_equivalent(input: &Path, base: &ConvertOptions) {
+        let mem_out = tempfile::NamedTempFile::new().unwrap();
+        let stream_out = tempfile::NamedTempFile::new().unwrap();
+
+        let mem_opts = ConvertOptions {
+            streaming: false,
+            ..base.clone()
+        };
+        let stream_opts = ConvertOptions {
+            streaming: true,
+            ..base.clone()
+        };
+        let mem = convert_to_overviews(input, mem_out.path(), &mem_opts).unwrap();
+        let strm = convert_to_overviews(input, stream_out.path(), &stream_opts).unwrap();
+
+        // Reports agree on everything but duration.
+        assert_eq!(mem.mode, strm.mode);
+        assert_eq!(mem.input_features, strm.input_features);
+        assert_eq!(mem.total_rows, strm.total_rows);
+        assert_eq!(mem.total_vertices, strm.total_vertices);
+        assert_eq!(mem.levels.len(), strm.levels.len());
+        for (a, b) in mem.levels.iter().zip(&strm.levels) {
+            assert_eq!(a.level, b.level);
+            assert_eq!(a.gsd, b.gsd, "level {} gsd", a.level);
+            assert_eq!(a.zoom, b.zoom, "level {} zoom", a.level);
+            assert_eq!(
+                a.feature_count, b.feature_count,
+                "level {} feature count",
+                a.level
+            );
+            assert_eq!(
+                a.vertex_count, b.vertex_count,
+                "level {} vertex count",
+                a.level
+            );
+        }
+
+        // Footer metadata byte-identical; both files validate.
+        assert_eq!(
+            overviews_footer_json(mem_out.path()),
+            overviews_footer_json(stream_out.path()),
+            "geo:overviews footers differ"
+        );
+        assert!(validate_file(mem_out.path()).unwrap().is_valid());
+        assert!(validate_file(stream_out.path()).unwrap().is_valid());
+
+        // Row-level equality per level (ids, attributes, geometry, order).
+        let mr = OverviewReader::open(mem_out.path()).unwrap();
+        let sr = OverviewReader::open(stream_out.path()).unwrap();
+        assert_eq!(mr.num_levels(), sr.num_levels());
+        for level in 0..mr.num_levels() {
+            assert_eq!(
+                read_level_rows(&mr, level),
+                read_level_rows(&sr, level),
+                "level {level} rows differ"
+            );
+        }
+    }
+
+    #[test]
+    fn streaming_matches_in_memory_duplicating() {
+        let geoms = synthetic_geometries();
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        write_input(tin.path(), &geoms, false, None);
+
+        let base = ConvertOptions {
+            mode: Mode::Duplicating,
+            levels: LevelPlan::ZoomRange {
+                min_zoom: 1,
+                max_zoom: 10,
+            },
+            ..Default::default()
+        };
+        assert_streaming_equivalent(tin.path(), &base);
+    }
+
+    #[test]
+    fn streaming_matches_in_memory_partitioning() {
+        let geoms = synthetic_geometries();
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        write_input(tin.path(), &geoms, false, None);
+
+        let base = ConvertOptions {
+            mode: Mode::Partitioning,
+            levels: LevelPlan::ZoomRange {
+                min_zoom: 2,
+                max_zoom: 8,
+            },
+            ..Default::default()
+        };
+        assert_streaming_equivalent(tin.path(), &base);
+    }
+
+    #[test]
+    fn streaming_matches_with_small_read_batches_and_density_budget() {
+        // Many features + a tiny read batch: exercises batch-boundary handling
+        // in both passes AND the Q2 density-budget cuts in the winner tables.
+        let geoms = grid_points(600);
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        write_input(tin.path(), &geoms, false, None);
+
+        let base = ConvertOptions {
+            levels: LevelPlan::ZoomRange {
+                min_zoom: 0,
+                max_zoom: 8,
+            },
+            read_batch_size: 7,
+            ..Default::default()
+        };
+        assert_streaming_equivalent(tin.path(), &base);
+    }
+
+    #[test]
+    fn streaming_matches_with_explicit_sort_key() {
+        let geoms = synthetic_geometries();
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        write_input(tin.path(), &geoms, false, None);
+
+        let base = ConvertOptions {
+            levels: LevelPlan::ZoomRange {
+                min_zoom: 2,
+                max_zoom: 8,
+            },
+            sort_key: Some("rank".to_string()),
+            ..Default::default()
+        };
+        assert_streaming_equivalent(tin.path(), &base);
+    }
+
+    #[test]
+    fn streaming_auto_rank_matches_in_memory() {
+        // Auto-detected Overture road-class ranking must resolve identically in
+        // the streaming pass-1 (incremental vocab scan) and in-memory paths.
+        let (geoms, classes) = overture_line_geoms();
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        write_class_input(tin.path(), &geoms, &classes);
+
+        let base = ConvertOptions {
+            levels: LevelPlan::ZoomRange {
+                min_zoom: 4,
+                max_zoom: 10,
+            },
+            read_batch_size: 2,
+            ..Default::default()
+        };
+        let mem_out = tempfile::NamedTempFile::new().unwrap();
+        let stream_out = tempfile::NamedTempFile::new().unwrap();
+        convert_to_overviews(
+            tin.path(),
+            mem_out.path(),
+            &ConvertOptions {
+                streaming: false,
+                ..base.clone()
+            },
+        )
+        .unwrap();
+        convert_to_overviews(tin.path(), stream_out.path(), &base).unwrap();
+
+        assert_eq!(ranking_mode_of(mem_out.path()), "auto-overture-roads");
+        assert_eq!(ranking_mode_of(stream_out.path()), "auto-overture-roads");
+        assert_eq!(
+            overviews_footer_json(mem_out.path()),
+            overviews_footer_json(stream_out.path())
+        );
+        let mr = OverviewReader::open(mem_out.path()).unwrap();
+        let sr = OverviewReader::open(stream_out.path()).unwrap();
+        assert_eq!(min_level_by_id(&mr), min_level_by_id(&sr));
     }
 
     #[test]

--- a/crates/core/src/overview/export.rs
+++ b/crates/core/src/overview/export.rs
@@ -252,7 +252,9 @@ pub fn export_pmtiles(
 
         // Read the whole level band into memory (v1). The reader already applies
         // duplicating (single band) vs partitioning (prefix) semantics.
+        let t_read = Instant::now();
         let features = read_level_features(&reader, level_idx, crs)?;
+        let read_secs = t_read.elapsed().as_secs_f64();
         let level_feature_count = features.len();
 
         // Expand the overall geographic bounds from feature bboxes.
@@ -266,8 +268,11 @@ pub fn export_pmtiles(
             }
         }
 
+        let t_encode = Instant::now();
         let tiles = encode_level_tiles(&features, zoom, options);
+        let encode_secs = t_encode.elapsed().as_secs_f64();
 
+        let t_write = Instant::now();
         let mut tile_feature_count = 0usize;
         let mut oversized = 0usize;
         for t in &tiles {
@@ -277,6 +282,12 @@ pub fn export_pmtiles(
             }
             writer.add_tile_with_count(zoom, t.x, t.y, &t.data, t.feature_count)?;
         }
+        log::debug!(
+            "[profile] z{zoom} (level {level_idx}, {level_feature_count} feats, {} tiles): \
+             read={read_secs:.2}s clip+encode={encode_secs:.2}s write(gzip)={:.2}s",
+            tiles.len(),
+            t_write.elapsed().as_secs_f64(),
+        );
 
         zooms.push(ZoomReport {
             zoom,
@@ -291,7 +302,12 @@ pub fn export_pmtiles(
     if let Some(b) = &overall_bounds {
         writer.set_bounds(b);
     }
+    let t_finalize = Instant::now();
     writer.finalize(output_path.as_ref())?;
+    log::debug!(
+        "[profile] pmtiles finalize: {:.2}s",
+        t_finalize.elapsed().as_secs_f64()
+    );
 
     let total_tiles = zooms.iter().map(|z| z.tile_count).sum();
     let total_tile_features = zooms.iter().map(|z| z.tile_feature_count).sum();
@@ -328,6 +344,7 @@ fn encode_level_tiles(features: &[Feature], zoom: u8, opts: &ExportOptions) -> V
     // tile (x,y) -> list of (clipped geometry, property index into `features`).
     let mut grouped: GroupedTileGeoms = BTreeMap::new();
 
+    let t_clip = Instant::now();
     for (fi, feat) in features.iter().enumerate() {
         let Some(rect) = feat.geom.bounding_rect() else {
             continue;
@@ -342,6 +359,9 @@ fn encode_level_tiles(features: &[Feature], zoom: u8, opts: &ExportOptions) -> V
         }
     }
 
+    let clip_secs = t_clip.elapsed().as_secs_f64();
+
+    let t_mvt = Instant::now();
     let mut out = Vec::with_capacity(grouped.len());
     for ((x, y), members) in grouped {
         let tc = TileCoord::new(x, y, zoom);
@@ -358,6 +378,10 @@ fn encode_level_tiles(features: &[Feature], zoom: u8, opts: &ExportOptions) -> V
             oversized,
         });
     }
+    log::debug!(
+        "[profile]   z{zoom} clip+group={clip_secs:.2}s mvt-encode={:.2}s",
+        t_mvt.elapsed().as_secs_f64(),
+    );
     out
 }
 

--- a/crates/core/src/overview/export.rs
+++ b/crates/core/src/overview/export.rs
@@ -353,7 +353,16 @@ fn encode_level_tiles(features: &[Feature], zoom: u8, opts: &ExportOptions) -> V
         for tc in tiles_for_bbox(&bbox, zoom) {
             let tb = tc.bounds();
             let buffer_deg = tb.width() * opts.tile_buffer as f64 / opts.extent as f64;
-            if let Some(clipped) = clip_geometry(&feat.geom, &tb, buffer_deg) {
+            // Fast path (H3(c) lever 4): a feature whose bbox lies entirely
+            // within the buffered tile bounds is unaffected by clipping —
+            // skip the BooleanOps intersection and emit the geometry as-is.
+            // At z14 ~80% of features are interior to a single tile.
+            if bbox_within_buffered(&bbox, &tb, buffer_deg) {
+                grouped
+                    .entry((tc.x, tc.y))
+                    .or_default()
+                    .push((feat.geom.clone(), fi));
+            } else if let Some(clipped) = clip_geometry(&feat.geom, &tb, buffer_deg) {
                 grouped.entry((tc.x, tc.y)).or_default().push((clipped, fi));
             }
         }
@@ -383,6 +392,17 @@ fn encode_level_tiles(features: &[Feature], zoom: u8, opts: &ExportOptions) -> V
         t_mvt.elapsed().as_secs_f64(),
     );
     out
+}
+
+/// `true` when `bbox` lies entirely within `tb` expanded by `buffer` on every
+/// side. Clipping such a feature to the buffered tile is a geometric no-op, so
+/// the clip can be skipped (and BooleanOps ring normalization avoided).
+#[inline]
+fn bbox_within_buffered(bbox: &TileBounds, tb: &TileBounds, buffer: f64) -> bool {
+    bbox.lng_min >= tb.lng_min - buffer
+        && bbox.lat_min >= tb.lat_min - buffer
+        && bbox.lng_max <= tb.lng_max + buffer
+        && bbox.lat_max <= tb.lat_max + buffer
 }
 
 /// Encode a single tile's members to MVT bytes, applying the oversized valve.
@@ -939,6 +959,67 @@ mod tests {
                     assert!(
                         y >= -slack - extent && y <= extent + slack + extent,
                         "y {y} outside buffered tile bounds"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn bbox_contained_feature_bypasses_clip_with_identical_output() {
+        // A concave polygon fully inside one z4 tile (z4 tile width 22.5°; the
+        // tile containing lng -100..., lat ~40 spans well past this 2° shape).
+        // The fast path must emit the geometry as-is: the encoded tile bytes
+        // must equal an MVT built from the *unclipped* geometry.
+        let poly = Geometry::Polygon(geo::Polygon::new(
+            LineString::from(vec![
+                (-100.0, 25.0),
+                (-98.0, 25.0),
+                (-98.0, 27.0),
+                (-99.0, 25.5), // concavity: BooleanOps clip normalizes rings
+                (-100.0, 27.0),
+                (-100.0, 25.0),
+            ]),
+            vec![],
+        ));
+        let feats = vec![Feature {
+            geom: poly.clone(),
+            props: vec![],
+        }];
+        let opts = ExportOptions::default();
+        let tiles = encode_level_tiles(&feats, 4, &opts);
+        assert_eq!(tiles.len(), 1, "fully-contained feature => exactly 1 tile");
+        assert_eq!(tiles[0].feature_count, 1);
+
+        let tc = TileCoord::new(tiles[0].x, tiles[0].y, 4);
+        let expected = build_mvt(&[(poly.clone(), 0)], &feats, &tc.bounds(), &opts);
+        assert_eq!(
+            tiles[0].data, expected,
+            "contained feature must bypass the clip (geometry emitted as-is)"
+        );
+    }
+
+    #[test]
+    fn seam_crossing_feature_still_clips() {
+        // A line spanning several z4 tiles must still be clipped per tile:
+        // it lands in >= 2 tiles and no tile carries the full-extent geometry.
+        let line = Geometry::LineString(LineString::from(vec![(-100.0, 10.0), (-40.0, 11.0)]));
+        let feats = vec![Feature {
+            geom: line,
+            props: vec![],
+        }];
+        let opts = ExportOptions::default();
+        let tiles = encode_level_tiles(&feats, 4, &opts);
+        assert!(tiles.len() >= 2, "seam-crossing line must span tiles");
+        let extent = opts.extent as i32;
+        let slack = (opts.tile_buffer as i32) + 4;
+        for t in &tiles {
+            let decoded = decode_tile(&t.data);
+            for f in &decoded.layers[0].features {
+                for (x, y) in decode_coords(&f.geometry) {
+                    assert!(
+                        x >= -slack && x <= extent + slack && y >= -slack && y <= extent + slack,
+                        "({x},{y}) outside buffered tile: geometry was not clipped"
                     );
                 }
             }

--- a/crates/core/src/overview/export.rs
+++ b/crates/core/src/overview/export.rs
@@ -61,6 +61,7 @@ use geo::{BoundingRect, CoordsIter, Geometry, MapCoords};
 use geoarrow::array::from_arrow_array;
 use geoarrow_array::GeoArrowArray;
 use prost::Message;
+use rayon::prelude::*;
 use serde::Serialize;
 
 use crate::batch_processor::extract_geometries_from_array;
@@ -329,9 +330,15 @@ pub fn export_pmtiles(
 // Tiling + encoding
 // ============================================================================
 
-/// Per-tile working map: tile `(x, y)` -> list of `(clipped geometry, property
-/// index into the level's `features`)`.
-type GroupedTileGeoms = BTreeMap<(u32, u32), Vec<(Geometry<f64>, usize)>>;
+/// One tile's members: list of `(clipped geometry, property index into the
+/// level's `features`)`.
+type TileMembers = Vec<(Geometry<f64>, usize)>;
+
+/// Per-tile working map: tile `(x, y)` -> members.
+type GroupedTileGeoms = BTreeMap<(u32, u32), TileMembers>;
+
+/// Per-feature clip results: list of `(tile (x, y), clipped geometry)`.
+type FeatureTileGeoms = Vec<((u32, u32), Geometry<f64>)>;
 
 /// Group a level's features into tiles at `zoom`, clip each to its tile bounds
 /// plus the pixel buffer, and MVT-encode. Applies the optional oversized valve.
@@ -341,52 +348,70 @@ type GroupedTileGeoms = BTreeMap<(u32, u32), Vec<(Geometry<f64>, usize)>>;
 /// load-bearing — the `BTreeMap` is used for deterministic, locality-friendly
 /// grouping and a bounded per-zoom working set).
 fn encode_level_tiles(features: &[Feature], zoom: u8, opts: &ExportOptions) -> Vec<EncodedTile> {
+    // Clip in parallel per feature (H3(c) lever 2: clipping is 94% of export
+    // wall and independent per feature). `par_iter().map().collect()`
+    // preserves feature order, so the sequential merge below pushes members
+    // into each tile's vector in exactly the serial order — grouping, and
+    // therefore the encoded tile bytes, are unchanged.
+    let t_clip = Instant::now();
+    let per_feature: Vec<FeatureTileGeoms> = features
+        .par_iter()
+        .map(|feat| {
+            let Some(rect) = feat.geom.bounding_rect() else {
+                return Vec::new();
+            };
+            let bbox = TileBounds::new(rect.min().x, rect.min().y, rect.max().x, rect.max().y);
+            let mut out = Vec::new();
+            for tc in tiles_for_bbox(&bbox, zoom) {
+                let tb = tc.bounds();
+                let buffer_deg = tb.width() * opts.tile_buffer as f64 / opts.extent as f64;
+                // Fast path (H3(c) lever 4): a feature whose bbox lies entirely
+                // within the buffered tile bounds is unaffected by clipping —
+                // skip the BooleanOps intersection and emit the geometry as-is.
+                // At z14 ~80% of features are interior to a single tile.
+                if bbox_within_buffered(&bbox, &tb, buffer_deg) {
+                    out.push(((tc.x, tc.y), feat.geom.clone()));
+                } else if let Some(clipped) = clip_geometry(&feat.geom, &tb, buffer_deg) {
+                    out.push(((tc.x, tc.y), clipped));
+                }
+            }
+            out
+        })
+        .collect();
+
     // tile (x,y) -> list of (clipped geometry, property index into `features`).
     let mut grouped: GroupedTileGeoms = BTreeMap::new();
-
-    let t_clip = Instant::now();
-    for (fi, feat) in features.iter().enumerate() {
-        let Some(rect) = feat.geom.bounding_rect() else {
-            continue;
-        };
-        let bbox = TileBounds::new(rect.min().x, rect.min().y, rect.max().x, rect.max().y);
-        for tc in tiles_for_bbox(&bbox, zoom) {
-            let tb = tc.bounds();
-            let buffer_deg = tb.width() * opts.tile_buffer as f64 / opts.extent as f64;
-            // Fast path (H3(c) lever 4): a feature whose bbox lies entirely
-            // within the buffered tile bounds is unaffected by clipping —
-            // skip the BooleanOps intersection and emit the geometry as-is.
-            // At z14 ~80% of features are interior to a single tile.
-            if bbox_within_buffered(&bbox, &tb, buffer_deg) {
-                grouped
-                    .entry((tc.x, tc.y))
-                    .or_default()
-                    .push((feat.geom.clone(), fi));
-            } else if let Some(clipped) = clip_geometry(&feat.geom, &tb, buffer_deg) {
-                grouped.entry((tc.x, tc.y)).or_default().push((clipped, fi));
-            }
+    for (fi, items) in per_feature.into_iter().enumerate() {
+        for (key, geom) in items {
+            grouped.entry(key).or_default().push((geom, fi));
         }
     }
 
     let clip_secs = t_clip.elapsed().as_secs_f64();
 
+    // Encode tiles in parallel; the indexed collect preserves the BTreeMap's
+    // (x, y) order, and the caller's serial write loop consumes `out` in that
+    // order, so PMTiles tile ordering and bytes are unchanged.
     let t_mvt = Instant::now();
-    let mut out = Vec::with_capacity(grouped.len());
-    for ((x, y), members) in grouped {
-        let tc = TileCoord::new(x, y, zoom);
-        let tb = tc.bounds();
-        let (data, count, oversized) = encode_tile(&members, features, &tb, opts);
-        if count == 0 {
-            continue;
-        }
-        out.push(EncodedTile {
-            x,
-            y,
-            data,
-            feature_count: count,
-            oversized,
-        });
-    }
+    let entries: Vec<((u32, u32), TileMembers)> = grouped.into_iter().collect();
+    let out: Vec<EncodedTile> = entries
+        .into_par_iter()
+        .filter_map(|((x, y), members)| {
+            let tc = TileCoord::new(x, y, zoom);
+            let tb = tc.bounds();
+            let (data, count, oversized) = encode_tile(&members, features, &tb, opts);
+            if count == 0 {
+                return None;
+            }
+            Some(EncodedTile {
+                x,
+                y,
+                data,
+                feature_count: count,
+                oversized,
+            })
+        })
+        .collect();
     log::debug!(
         "[profile]   z{zoom} clip+group={clip_secs:.2}s mvt-encode={:.2}s",
         t_mvt.elapsed().as_secs_f64(),

--- a/crates/core/src/overview/mod.rs
+++ b/crates/core/src/overview/mod.rs
@@ -15,4 +15,5 @@ pub mod export;
 pub mod level;
 pub mod reader;
 pub mod simplify;
+mod stream;
 pub mod writer;

--- a/crates/core/src/overview/simplify.rs
+++ b/crates/core/src/overview/simplify.rs
@@ -54,12 +54,27 @@
 //! [`simplify_for_level`] with no simplification, gating, or dropping — an
 //! explicit, tested identity path rather than an emergent one.
 
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use geo::{
     Area, BoundingRect, Centroid, Geometry, LineString, MultiLineString, MultiPolygon, Point,
     Polygon, Rect, Simplify, Validation,
 };
 
 pub use super::level::{Crs, METERS_PER_DEGREE};
+
+/// Process-wide count of polygons that exhausted every epsilon-backoff retry
+/// (see [`simplify_polygon_impl`]) and were kept at full resolution.
+///
+/// Callers (e.g. the streaming convert loop) log deltas of
+/// [`full_resolution_fallback_count`] at debug level to expose how often the
+/// last-resort path fires.
+static FULL_RES_FALLBACKS: AtomicU64 = AtomicU64::new(0);
+
+/// Snapshot of the process-wide full-resolution fallback counter.
+pub fn full_resolution_fallback_count() -> u64 {
+    FULL_RES_FALLBACKS.load(Ordering::Relaxed)
+}
 
 /// Default simplification factor: `tolerance = factor * gsd`.
 ///
@@ -262,6 +277,27 @@ fn simplify_linestring_impl(ls: &LineString<f64>, tol: f64) -> Option<LineString
     Some(simplified)
 }
 
+/// Number of epsilon halvings tried when RDP produces an invalid
+/// (self-intersecting) candidate before giving up and keeping the original
+/// geometry. Attempts run at `tol, tol/2, tol/4, tol/8`.
+const INVALID_RETRY_HALVINGS: u32 = 3;
+
+/// `true` when RDP removed nothing: the candidate has the same ring count and
+/// per-ring vertex counts as the original. RDP output vertices are always an
+/// ordered subset of the input (endpoints included), so equal counts imply an
+/// identical geometry — validation of the candidate is then redundant (the
+/// input is assumed valid, and re-checking it is exactly the H3(c) profile's
+/// dominant cost at fine GSDs).
+fn polygon_unchanged(candidate: &Polygon<f64>, original: &Polygon<f64>) -> bool {
+    candidate.exterior().0.len() == original.exterior().0.len()
+        && candidate.interiors().len() == original.interiors().len()
+        && candidate
+            .interiors()
+            .iter()
+            .zip(original.interiors())
+            .all(|(a, b)| a.0.len() == b.0.len())
+}
+
 /// Simplify a Polygon in world space with ring-validity guards.
 ///
 /// - Below the visibility gate ⇒ collapse (drop, or representative point when
@@ -271,44 +307,67 @@ fn simplify_linestring_impl(ls: &LineString<f64>, tol: f64) -> Option<LineString
 ///   fall below the gate are dropped.
 /// - If the exterior collapses (too few points or sub-tolerance area) ⇒
 ///   collapse.
-/// - If RDP introduces an invalid (self-intersecting) polygon, fall back to
-///   the original geometry (boundary-preserving: never emit an invalid ring).
+/// - If RDP introduces an invalid (self-intersecting) polygon, retry with a
+///   progressively halved epsilon ([`INVALID_RETRY_HALVINGS`] retries): a
+///   smaller tolerance keeps more vertices and usually restores validity while
+///   still shedding sub-tolerance detail. Only when every retry fails is the
+///   original geometry kept verbatim (boundary-preserving last resort, counted
+///   in [`full_resolution_fallback_count`]).
+///
+/// Validation-cost notes (H3(c) profile, lever 3): the candidate skips
+/// `is_valid()` entirely when RDP removed no vertices (identical to the
+/// assumed-valid input), and the original is **never** re-validated — the old
+/// code ran a full-resolution `is_valid()` on the fallback path, which was
+/// ~96% of coarse-level simplification cost. A consequence: an *invalid
+/// source* polygon whose candidates all fail validation is now kept verbatim
+/// (like the canonical level does) instead of being collapsed/dropped.
 fn simplify_polygon_impl(poly: &Polygon<f64>, tol: f64, collapse: bool) -> Simplified {
     if polygon_diag(poly) < tol {
         return collapse_polygon(poly, collapse);
     }
 
-    let simplified = poly.simplify(tol);
-
-    // Drop interior rings that collapsed below the gate.
-    let interiors: Vec<LineString<f64>> = simplified
-        .interiors()
-        .iter()
-        .filter(|ring| linestring_diag(ring) >= tol)
-        .cloned()
-        .collect();
-
-    let exterior = simplified.exterior().clone();
-    let candidate = Polygon::new(exterior, interiors);
-
-    // Exterior collapse: too few points, or area smaller than a
-    // tolerance-sized cell (catches slivers / zero-area rings).
+    // Gates are level properties, so they stay at `tol` even when the RDP
+    // epsilon backs off below it.
     let min_area = tol * tol;
-    if candidate.exterior().0.len() < MIN_POLYGON_RING_POINTS
-        || candidate.unsigned_area() < min_area
-    {
-        return collapse_polygon(poly, collapse);
+
+    let mut eps = tol;
+    for _ in 0..=INVALID_RETRY_HALVINGS {
+        let simplified = poly.simplify(eps);
+
+        // Drop interior rings that collapsed below the gate.
+        let interiors: Vec<LineString<f64>> = simplified
+            .interiors()
+            .iter()
+            .filter(|ring| linestring_diag(ring) >= tol)
+            .cloned()
+            .collect();
+
+        let exterior = simplified.exterior().clone();
+        let candidate = Polygon::new(exterior, interiors);
+
+        // Exterior collapse: too few points, or area smaller than a
+        // tolerance-sized cell (catches slivers / zero-area rings).
+        if candidate.exterior().0.len() < MIN_POLYGON_RING_POINTS
+            || candidate.unsigned_area() < min_area
+        {
+            return collapse_polygon(poly, collapse);
+        }
+
+        if polygon_unchanged(&candidate, poly) || candidate.is_valid() {
+            return Simplified::Keep(Geometry::Polygon(candidate));
+        }
+        eps *= 0.5;
     }
 
-    if candidate.is_valid() {
-        Simplified::Keep(Geometry::Polygon(candidate))
-    } else if poly.is_valid() {
-        // Boundary-preserving fallback: RDP made it self-intersect; keep the
-        // original valid geometry rather than emit an invalid ring.
-        Simplified::Keep(Geometry::Polygon(poly.clone()))
-    } else {
-        collapse_polygon(poly, collapse)
-    }
+    // Every retry self-intersected: keep the original geometry rather than
+    // emit an invalid ring.
+    FULL_RES_FALLBACKS.fetch_add(1, Ordering::Relaxed);
+    log::trace!(
+        "overview simplify: RDP candidate invalid after {} epsilon retries; \
+         keeping full-resolution geometry",
+        INVALID_RETRY_HALVINGS + 1
+    );
+    Simplified::Keep(Geometry::Polygon(poly.clone()))
 }
 
 /// Resolve a collapsed polygon: drop by default, or (opt-in) a representative
@@ -663,6 +722,70 @@ mod tests {
             simplify_for_level(&Geometry::Polygon(sliver), 100.0, Crs::Epsg3857, &opts),
             Simplified::Dropped
         );
+    }
+
+    // ---- invalid-candidate progressive retry -------------------------------
+
+    /// A polygon whose RDP output at `tol = 4` self-intersects: a square with
+    /// a shallow downward notch in the bottom edge and a thin finger from the
+    /// top descending into the notch pocket. RDP at 4 removes the sub-tolerance
+    /// notch, leaving the finger tip below the straightened bottom edge (the
+    /// finger edges then cross it). At `tol = 2` the notch survives and the
+    /// ring is valid again. The sub-tolerance wobble vertices on the right and
+    /// left edges are removed at *both* tolerances, so the epsilon-backoff
+    /// retry still yields a genuinely simplified (not full-resolution) result.
+    fn notch_finger_polygon() -> Polygon<f64> {
+        let c = |x: f64, y: f64| Coord { x, y };
+        Polygon::new(
+            LineString::new(vec![
+                c(0.0, 0.0),
+                c(45.0, 0.0),
+                c(50.0, -3.0),
+                c(55.0, 0.0),
+                c(100.0, 0.0),
+                c(100.1, 30.0), // sub-tolerance wobble (removed at tol >= ~0.1)
+                c(100.0, 60.0),
+                c(99.9, 80.0), // sub-tolerance wobble
+                c(100.0, 100.0),
+                c(52.0, 100.0),
+                c(50.0, -1.0),
+                c(48.0, 100.0),
+                c(0.0, 100.0),
+                c(0.1, 50.0), // sub-tolerance wobble
+                c(0.0, 0.0),
+            ]),
+            vec![],
+        )
+    }
+
+    #[test]
+    fn test_invalid_rdp_candidate_retries_to_simplified_valid() {
+        let poly = notch_finger_polygon();
+        let orig_len = poly.exterior().0.len();
+        assert!(poly.is_valid(), "fixture must start valid");
+        assert!(
+            !poly.simplify(4.0).is_valid(),
+            "fixture must self-intersect at the full tolerance (precondition)"
+        );
+
+        // gsd 4 m in EPSG:3857 (meters) with factor 1.0 => tol = 4.0.
+        let opts = SimplifyOptions::default();
+        match simplify_for_level(&Geometry::Polygon(poly), 4.0, Crs::Epsg3857, &opts) {
+            Simplified::Keep(Geometry::Polygon(p)) => {
+                assert!(
+                    p.is_valid(),
+                    "retry output must be valid, got {:?}",
+                    p.exterior()
+                );
+                assert!(
+                    p.exterior().0.len() < orig_len,
+                    "retry output must be simplified, not the full-resolution \
+                     fallback ({} !< {orig_len})",
+                    p.exterior().0.len()
+                );
+            }
+            other => panic!("expected Keep(Polygon), got {other:?}"),
+        }
     }
 
     // ---- multi-geometry part dropping -------------------------------------

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -69,7 +69,9 @@ use super::convert::{
     KNOWN_ROAD_CLASSES, ROAD_VOCAB_MIN_DISTINCT,
 };
 use super::level::{Crs, Mode, RankingProvenance};
-use super::simplify::{simplify_for_level, Simplified, SimplifyOptions};
+use super::simplify::{
+    full_resolution_fallback_count, simplify_for_level, Simplified, SimplifyOptions,
+};
 use super::writer::{LevelSpec, OverviewWriter, OverviewWriterOptions, LEVEL_COLUMN};
 
 /// A level actually emitted to the output (levels with zero winners are
@@ -655,6 +657,7 @@ fn write_level_streaming(
     let vertices = Cell::new(0usize);
     let mut row_offset = 0usize;
     let timers = Pass2Timers::default();
+    let fallbacks_before = full_resolution_fallback_count();
     let t_level = Instant::now();
 
     let batches = std::iter::from_fn(|| loop {
@@ -705,6 +708,13 @@ fn write_level_streaming(
         timers.build.get().as_secs_f64(),
         total.saturating_sub(accounted).as_secs_f64(),
     );
+    let fallbacks = full_resolution_fallback_count() - fallbacks_before;
+    if fallbacks > 0 {
+        log::debug!(
+            "[profile] level {level_idx}: {fallbacks} feature(s) kept at full \
+             resolution (invalid RDP candidate after all epsilon retries)"
+        );
+    }
     Ok((rows.get(), vertices.get()))
 }
 

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -1,0 +1,721 @@
+//! Two-pass bounded-memory streaming overview conversion (task V4 / H3).
+//!
+//! The in-memory pipeline in [`super::convert`] materializes the entire input
+//! table, every decoded geometry, and a cloned geometry set per level — `O(N)`
+//! memory (Moldova, 632k polygons: 5.44 GB peak RSS). This module implements
+//! the same conversion in bounded memory:
+//!
+//! - **Pass 1** streams the input once (row batches of
+//!   [`ConvertOptions::read_batch_size`] rows, geometry + ranking columns
+//!   only): per feature it keeps only the bbox, [`FeatureKind`], and sort key
+//!   — a small [`AssignFeature`] — plus the incremental state for Q1 ranking
+//!   auto-detection. [`assign_levels`] and [`apply_density_budget`] then run
+//!   over those (the assign engine's own state is `O(occupied cells)` per
+//!   level), producing the **winner table**: one `min_level` byte per feature.
+//! - **Pass 2** re-reads the (seekable) input once **per level**, coarse →
+//!   fine: each batch is filtered against the winner table, simplified for the
+//!   level (non-canonical duplicating levels only), and handed straight to the
+//!   [`OverviewWriter`]. Nothing is retained across batches.
+//!
+//! Peak memory is `O(read batch + winner tables)`: the winner table is 1 byte
+//! per feature; pass 1 additionally holds the `AssignFeature` vector (~48
+//! bytes/feature) and per-candidate ranking keys (16 bytes/feature) while the
+//! assignment runs, all freed before pass 2. Residual `O(N)` state is
+//! therefore ~50–80 bytes per input feature — for 632k features, a few tens of
+//! MB — far below the geometry payload the in-memory path holds.
+//!
+//! Hilbert order: input order is preserved within each level (the documented
+//! gpio-sorted input contract, spec §4.3), exactly as in the in-memory path —
+//! no in-memory per-level sort exists in either path.
+//!
+//! # Behavior parity with the in-memory path
+//!
+//! Level assignments, density-budget cuts, ranking resolution (explicit /
+//! auto-detected / fallback), footer metadata, and per-level row values are
+//! identical (tested in `convert::tests`). One documented divergence: the
+//! in-memory path omits (and renumbers past) a level whose *simplified*
+//! output is empty, whereas this path decides level omission from the winner
+//! table before simplification. The two only differ when **every** winner of
+//! a level degenerates during simplification — impossible under the default
+//! knobs (the assign visibility gates, 2–4 × GSD, are stricter than the
+//! simplify drop gate at 1 × GSD) and pathological otherwise; if it ever
+//! happens the writer reports [`WriterError::EmptyLevel`] instead of silently
+//! renumbering.
+//!
+//! [`WriterError::EmptyLevel`]: super::writer::WriterError::EmptyLevel
+
+use std::cell::{Cell, RefCell};
+use std::collections::HashSet;
+use std::fs::File;
+use std::path::Path;
+use std::time::Instant;
+
+use arrow_array::{Array, RecordBatch, UInt32Array};
+use arrow_schema::{DataType, Schema, SchemaRef};
+use arrow_select::take::take;
+use geo::Geometry;
+use geoarrow::array::from_arrow_array;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::arrow::ProjectionMask;
+
+use crate::batch_processor::extract_geometries_from_array;
+
+use super::assign::{apply_density_budget, assign_levels, AssignFeature, FeatureKind};
+use super::convert::{
+    build_generalization, build_level_batch, build_source_schema, class_ranking_provenance,
+    count_vertices, detect_crs, extract_class_ranks, extract_sort_keys, feature_kind,
+    fill_level_bytes, find_geometry_column, geometry_bbox, mixed_geometry_field,
+    overture_road_ranking, ClassRanking, ConvertError, ConvertOptions, ConvertReport, LevelReport,
+    KNOWN_ROAD_CLASSES, ROAD_VOCAB_MIN_DISTINCT,
+};
+use super::level::{Crs, Mode, RankingProvenance};
+use super::simplify::{simplify_for_level, Simplified, SimplifyOptions};
+use super::writer::{LevelSpec, OverviewWriter, OverviewWriterOptions, LEVEL_COLUMN};
+
+/// A level actually emitted to the output (levels with zero winners are
+/// omitted and renumbered, spec §7.3, matching the in-memory path).
+struct EmitLevel {
+    /// Index in the *resolved* level plan (drives winner-table membership).
+    orig: u8,
+    gsd: f64,
+    zoom: Option<u8>,
+    /// Winner count — the writer's `level_row_hint` for row-group sizing.
+    hint: usize,
+}
+
+/// Streaming counterpart of [`super::convert::convert_to_overviews`].
+pub(super) fn convert_streaming(
+    input_path: &Path,
+    output_path: &Path,
+    options: &ConvertOptions,
+) -> Result<ConvertReport, ConvertError> {
+    let start = Instant::now();
+
+    if options.sort_key.is_some() && options.class_ranking.is_some() {
+        return Err(ConvertError::RankingConflict);
+    }
+
+    // CRS detection + rejection (spec Q3) — footer-only read.
+    let crs = detect_crs(input_path)?;
+
+    // Schema checks (level column, geometry column) — footer-only read.
+    let file = File::open(input_path)?;
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
+    let input_schema: SchemaRef = builder.schema().clone();
+    drop(builder);
+
+    if input_schema
+        .fields()
+        .iter()
+        .any(|f| f.name().eq_ignore_ascii_case(LEVEL_COLUMN))
+    {
+        return Err(ConvertError::LevelColumnPresent);
+    }
+    let geom_idx = find_geometry_column(&input_schema).ok_or(ConvertError::NoGeometryColumn)?;
+    let geom_field = input_schema.field(geom_idx).clone();
+
+    // --- Pass 1: stream → AssignFeatures + resolved ranking. -----------------
+    let (mut features, ranking_provenance) =
+        run_pass1(input_path, &input_schema, geom_idx, options)?;
+    let num_features = features.len();
+
+    // --- Winner tables (assignment + Q2 density budget). ---------------------
+    let level_specs = options.levels.resolve(options.gsd_base)?;
+    let level_gsds: Vec<f64> = level_specs.iter().map(|(g, _)| *g).collect();
+
+    let assignment = assign_levels(&features, &level_gsds, &options.assign, crs);
+    let assignment = if options.density.enabled {
+        apply_density_budget(
+            &assignment,
+            &features,
+            &level_gsds,
+            &options.assign,
+            &options.density,
+            crs,
+        )
+    } else {
+        assignment
+    };
+
+    // The winner table: per input row, the coarsest level it appears at.
+    // 1 byte per feature — the only O(N) state carried into pass 2.
+    let min_levels: Vec<u8> = assignment.assignments.iter().map(|a| a.min_level).collect();
+    drop(assignment);
+    features.clear();
+    features.shrink_to_fit(); // free the pass-1 O(N)·48B scratch before pass 2
+
+    let num_levels = level_gsds.len();
+    let finest = num_levels.saturating_sub(1);
+
+    // Per-level winner counts (exact row counts in partitioning mode; in
+    // duplicating mode exact up to simplification drops — used as the writer's
+    // row-group sizing hint and for empty-level omission).
+    let mut hist = vec![0usize; num_levels];
+    for &ml in &min_levels {
+        hist[(ml as usize).min(finest)] += 1;
+    }
+    let counts: Vec<usize> = match options.mode {
+        Mode::Duplicating => hist
+            .iter()
+            .scan(0usize, |acc, &c| {
+                *acc += c;
+                Some(*acc)
+            })
+            .collect(),
+        Mode::Partitioning => hist,
+    };
+
+    let emitted: Vec<EmitLevel> = level_specs
+        .iter()
+        .enumerate()
+        .filter(|&(l, _)| counts[l] > 0)
+        .map(|(l, &(gsd, zoom))| EmitLevel {
+            orig: l as u8,
+            gsd,
+            zoom,
+            hint: counts[l],
+        })
+        .collect();
+    if emitted.is_empty() {
+        return Err(ConvertError::NoData);
+    }
+
+    // --- Writer setup (identical to the in-memory path). ---------------------
+    let geom_name = geom_field.name().clone();
+    let geom_out_field = mixed_geometry_field(&geom_name);
+    let source_schema = build_source_schema(&input_schema, geom_idx, geom_out_field);
+
+    let writer_levels: Vec<LevelSpec> = emitted
+        .iter()
+        .map(|e| LevelSpec::new(e.gsd, e.zoom))
+        .collect();
+    let emitted_gsds: Vec<f64> = emitted.iter().map(|e| e.gsd).collect();
+    let mut writer_opts = OverviewWriterOptions::new(options.mode, writer_levels);
+    writer_opts.max_row_group_size = options.max_row_group_size;
+    writer_opts.full_column_stats = options.full_column_stats;
+    writer_opts.cogp_compat_key = options.cogp_compat_key;
+    writer_opts.generalization = Some(build_generalization(
+        &emitted_gsds,
+        crs,
+        options,
+        ranking_provenance,
+    ));
+
+    let mut writer = OverviewWriter::create(output_path, &source_schema, writer_opts)?;
+
+    let non_geom_cols: Vec<usize> = (0..input_schema.fields().len())
+        .filter(|&c| c != geom_idx)
+        .collect();
+
+    // --- Pass 2: per level, stream → filter → simplify → write. --------------
+    let mut level_reports = Vec::with_capacity(emitted.len());
+    for (level_idx, e) in emitted.iter().enumerate() {
+        // Verbatim path: partitioning at every level (§2.3), and duplicating at
+        // the canonical (finest) level (§2.4).
+        let verbatim = matches!(options.mode, Mode::Partitioning) || e.orig as usize == finest;
+        let ctx = LevelStreamCtx {
+            source_schema: &source_schema,
+            non_geom_cols: &non_geom_cols,
+            geom_idx,
+            min_levels: &min_levels,
+            orig_level: e.orig,
+            duplicating: matches!(options.mode, Mode::Duplicating),
+            verbatim,
+            gsd_m: e.gsd,
+            crs,
+            simplify: &options.simplify,
+        };
+        let (rows, vertices) = write_level_streaming(
+            &mut writer,
+            level_idx,
+            e.hint,
+            input_path,
+            options.read_batch_size,
+            &ctx,
+        )?;
+        level_reports.push(LevelReport {
+            level: level_idx,
+            gsd: e.gsd,
+            zoom: e.zoom,
+            feature_count: rows,
+            vertex_count: vertices,
+            uncompressed_bytes: 0,
+            compressed_bytes: 0,
+        });
+    }
+
+    let meta = writer.finish()?;
+    fill_level_bytes(output_path, &meta, &mut level_reports)?;
+
+    let total_rows: usize = level_reports.iter().map(|l| l.feature_count).sum();
+    let total_vertices: usize = level_reports.iter().map(|l| l.vertex_count).sum();
+    let total_compressed_bytes: i64 = level_reports.iter().map(|l| l.compressed_bytes).sum();
+
+    Ok(ConvertReport {
+        mode: options.mode,
+        levels: level_reports,
+        input_features: num_features,
+        total_rows,
+        total_vertices,
+        total_compressed_bytes,
+        duration_secs: start.elapsed().as_secs_f64(),
+    })
+}
+
+// ============================================================================
+// Pass 1: streaming feature scan + ranking resolution
+// ============================================================================
+
+/// A candidate Overture road-class column tracked incrementally during pass 1.
+struct RoadCandidate {
+    idx: usize,
+    ranking: ClassRanking,
+    /// Distinct known-vocabulary classes seen so far (detection gate).
+    found: HashSet<&'static str>,
+    /// Per-row class-rank keys, extracted as we stream.
+    keys: Vec<Option<f64>>,
+}
+
+/// The ranking tier resolved from the options + schema *before* reading data
+/// (Q1). Mirrors `convert::resolve_ranking`'s tier order; the auto tier needs
+/// data (vocab overlap, point majority) so its decision lands after pass 1.
+enum RankPlan {
+    ExplicitSort {
+        idx: usize,
+        name: String,
+    },
+    ExplicitClass {
+        idx: usize,
+        ranking: ClassRanking,
+    },
+    Auto {
+        roads: Vec<RoadCandidate>,
+        confidence: Option<(usize, String)>,
+    },
+    SizeFallback,
+}
+
+/// Build the [`RankPlan`] from the schema, validating explicit columns eagerly
+/// (same error variants as the in-memory path).
+fn build_rank_plan(schema: &Schema, options: &ConvertOptions) -> Result<RankPlan, ConvertError> {
+    if let Some(name) = &options.sort_key {
+        let idx = schema
+            .index_of(name)
+            .map_err(|_| ConvertError::SortKeyColumnMissing { name: name.clone() })?;
+        return Ok(RankPlan::ExplicitSort {
+            idx,
+            name: name.clone(),
+        });
+    }
+    if let Some(cr) = &options.class_ranking {
+        let idx =
+            schema
+                .index_of(&cr.column)
+                .map_err(|_| ConvertError::ClassRankColumnMissing {
+                    name: cr.column.clone(),
+                })?;
+        let dt = schema.field(idx).data_type();
+        if !matches!(dt, DataType::Utf8 | DataType::LargeUtf8) {
+            return Err(ConvertError::ClassRankColumnNotString {
+                name: cr.column.clone(),
+                data_type: format!("{dt:?}"),
+            });
+        }
+        return Ok(RankPlan::ExplicitClass {
+            idx,
+            ranking: cr.clone(),
+        });
+    }
+    if !options.no_auto_rank {
+        // Candidate Overture road-class columns, in schema order (the first
+        // one passing the vocab-overlap gate wins, as in the in-memory path).
+        let roads: Vec<RoadCandidate> = schema
+            .fields()
+            .iter()
+            .enumerate()
+            .filter(|(_, f)| {
+                let lname = f.name().to_ascii_lowercase();
+                (lname == "road_class" || lname == "class")
+                    && matches!(f.data_type(), DataType::Utf8 | DataType::LargeUtf8)
+            })
+            .map(|(idx, f)| RoadCandidate {
+                idx,
+                ranking: overture_road_ranking(f.name().clone()),
+                found: HashSet::new(),
+                keys: Vec::new(),
+            })
+            .collect();
+        // Candidate Overture places confidence column (point-majority gate is
+        // decided after pass 1, once kinds are known).
+        let confidence = schema
+            .fields()
+            .iter()
+            .enumerate()
+            .find(|(_, f)| {
+                f.name().eq_ignore_ascii_case("confidence")
+                    && matches!(f.data_type(), DataType::Float32 | DataType::Float64)
+            })
+            .map(|(idx, f)| (idx, f.name().clone()));
+        if !roads.is_empty() || confidence.is_some() {
+            return Ok(RankPlan::Auto { roads, confidence });
+        }
+    }
+    Ok(RankPlan::SizeFallback)
+}
+
+/// Incrementally scan a string column for known road classes, growing `found`
+/// until it reaches [`ROAD_VOCAB_MIN_DISTINCT`] (then stops scanning).
+fn scan_road_vocab(col: &dyn Array, found: &mut HashSet<&'static str>) {
+    use arrow_array::cast::AsArray;
+
+    if found.len() >= ROAD_VOCAB_MIN_DISTINCT {
+        return;
+    }
+    let vocab: HashSet<&'static str> = KNOWN_ROAD_CLASSES.iter().copied().collect();
+
+    macro_rules! scan {
+        ($arr:expr) => {{
+            let a = $arr;
+            for i in 0..a.len() {
+                if a.is_null(i) {
+                    continue;
+                }
+                if let Some(&hit) = vocab.get(a.value(i)) {
+                    found.insert(hit);
+                    if found.len() >= ROAD_VOCAB_MIN_DISTINCT {
+                        return;
+                    }
+                }
+            }
+        }};
+    }
+    match col.data_type() {
+        DataType::Utf8 => scan!(col.as_string::<i32>()),
+        DataType::LargeUtf8 => scan!(col.as_string::<i64>()),
+        _ => {}
+    }
+}
+
+/// Pass 1: stream the input (geometry + ranking columns only) and produce the
+/// per-feature [`AssignFeature`]s (with resolved sort keys) plus the ranking
+/// provenance block (§3.5). Memory: `O(read batch)` transient +
+/// `O(N)` small per-feature records.
+fn run_pass1(
+    input_path: &Path,
+    input_schema: &Schema,
+    geom_idx: usize,
+    options: &ConvertOptions,
+) -> Result<(Vec<AssignFeature>, RankingProvenance), ConvertError> {
+    let mut plan = build_rank_plan(input_schema, options)?;
+
+    // Project only the columns pass 1 needs: geometry + ranking candidates.
+    let mut cols: Vec<usize> = vec![geom_idx];
+    match &plan {
+        RankPlan::ExplicitSort { idx, .. } | RankPlan::ExplicitClass { idx, .. } => cols.push(*idx),
+        RankPlan::Auto { roads, confidence } => {
+            cols.extend(roads.iter().map(|r| r.idx));
+            if let Some((idx, _)) = confidence {
+                cols.push(*idx);
+            }
+        }
+        RankPlan::SizeFallback => {}
+    }
+    cols.sort_unstable();
+    cols.dedup();
+    // Original schema index → projected batch column index.
+    let proj = |orig: usize| cols.binary_search(&orig).expect("projected column");
+
+    let file = File::open(input_path)?;
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
+    let mask = ProjectionMask::roots(builder.parquet_schema(), cols.iter().copied());
+    let reader = builder
+        .with_projection(mask)
+        .with_batch_size(options.read_batch_size.max(1))
+        .build()?;
+
+    let mut features: Vec<AssignFeature> = Vec::new();
+    let mut point_count = 0usize;
+    let mut explicit_keys: Vec<Option<f64>> = Vec::new();
+    let mut confidence_keys: Vec<Option<f64>> = Vec::new();
+    let mut geoms_buf: Vec<Geometry<f64>> = Vec::new();
+
+    for batch in reader {
+        let batch = batch?;
+        let gcol_idx = proj(geom_idx);
+        let schema = batch.schema();
+        let gfield = schema.field(gcol_idx);
+        let garr = from_arrow_array(batch.column(gcol_idx).as_ref(), gfield)
+            .map_err(|e| crate::Error::GeoParquetRead(format!("geometry decode: {e}")))?;
+        geoms_buf.clear();
+        extract_geometries_from_array(garr.as_ref(), &mut geoms_buf)?;
+
+        let base = features.len();
+        for (i, g) in geoms_buf.iter().enumerate() {
+            let kind = feature_kind(g);
+            if matches!(kind, FeatureKind::Point) {
+                point_count += 1;
+            }
+            features.push(AssignFeature {
+                index: base + i,
+                bbox: geometry_bbox(g),
+                kind,
+                sort_key: None, // filled below once the ranking tier resolves
+            });
+        }
+
+        match &mut plan {
+            RankPlan::ExplicitSort { idx, .. } => {
+                explicit_keys.extend(extract_sort_keys(batch.column(proj(*idx)).as_ref()));
+            }
+            RankPlan::ExplicitClass { idx, ranking } => {
+                explicit_keys.extend(extract_class_ranks(
+                    batch.column(proj(*idx)).as_ref(),
+                    ranking,
+                )?);
+            }
+            RankPlan::Auto { roads, confidence } => {
+                for cand in roads.iter_mut() {
+                    let col = batch.column(proj(cand.idx));
+                    scan_road_vocab(col.as_ref(), &mut cand.found);
+                    cand.keys
+                        .extend(extract_class_ranks(col.as_ref(), &cand.ranking)?);
+                }
+                if let Some((idx, _)) = confidence {
+                    confidence_keys.extend(extract_sort_keys(batch.column(proj(*idx)).as_ref()));
+                }
+            }
+            RankPlan::SizeFallback => {}
+        }
+    }
+
+    let n = features.len();
+    let size_fallback = || {
+        log::info!(
+            "overview ranking: no sort key specified or auto-detected; using size + \
+             deterministic-hash fallback"
+        );
+        RankingProvenance {
+            mode: "size-fallback".to_string(),
+            column: None,
+            ranks: None,
+            unknown_rank: None,
+        }
+    };
+
+    // Resolve the tier (same order + logging as the in-memory path).
+    let (keys, provenance): (Option<Vec<Option<f64>>>, RankingProvenance) = match plan {
+        RankPlan::ExplicitSort { name, .. } => {
+            log::info!("overview ranking: explicit numeric sort-key column {name:?}");
+            (
+                Some(explicit_keys),
+                RankingProvenance {
+                    mode: "explicit-sort-key".to_string(),
+                    column: Some(name),
+                    ranks: None,
+                    unknown_rank: None,
+                },
+            )
+        }
+        RankPlan::ExplicitClass { ranking, .. } => {
+            log::info!(
+                "overview ranking: explicit class-ranking on column {:?} ({} named classes, unknown_rank={})",
+                ranking.column,
+                ranking.ranks.len(),
+                ranking.unknown_rank
+            );
+            (
+                Some(explicit_keys),
+                class_ranking_provenance("class-ranking", &ranking),
+            )
+        }
+        RankPlan::Auto { roads, confidence } => {
+            if let Some(cand) = roads
+                .into_iter()
+                .find(|c| c.found.len() >= ROAD_VOCAB_MIN_DISTINCT)
+            {
+                log::info!(
+                    "overview ranking: auto-detected Overture road classes in column {:?}; \
+                     applying built-in ranking (motorway > … > service > tail)",
+                    cand.ranking.column
+                );
+                let prov = class_ranking_provenance("auto-overture-roads", &cand.ranking);
+                (Some(cand.keys), prov)
+            } else if let Some((_, col_name)) = confidence.filter(|_| n > 0 && point_count * 2 >= n)
+            {
+                log::info!(
+                    "overview ranking: auto-detected Overture places confidence column {col_name:?} \
+                     (numeric point ranking)"
+                );
+                (
+                    Some(confidence_keys),
+                    RankingProvenance {
+                        mode: "auto-confidence".to_string(),
+                        column: Some(col_name),
+                        ranks: None,
+                        unknown_rank: None,
+                    },
+                )
+            } else {
+                (None, size_fallback())
+            }
+        }
+        RankPlan::SizeFallback => (None, size_fallback()),
+    };
+
+    if let Some(keys) = keys {
+        debug_assert_eq!(keys.len(), features.len());
+        for (f, k) in features.iter_mut().zip(keys) {
+            f.sort_key = k;
+        }
+    }
+
+    Ok((features, provenance))
+}
+
+// ============================================================================
+// Pass 2: per-level streaming filter → simplify → write
+// ============================================================================
+
+/// Immutable context for one level's pass-2 stream.
+struct LevelStreamCtx<'a> {
+    source_schema: &'a Schema,
+    non_geom_cols: &'a [usize],
+    geom_idx: usize,
+    /// Winner table: per input row, its coarsest level.
+    min_levels: &'a [u8],
+    /// Level index in the *resolved* plan (membership is tested against this,
+    /// not the emitted/renumbered index).
+    orig_level: u8,
+    duplicating: bool,
+    verbatim: bool,
+    gsd_m: f64,
+    crs: Crs,
+    simplify: &'a SimplifyOptions,
+}
+
+/// Stream one level from the input file into the writer. Returns
+/// `(rows_written, vertex_count)`.
+fn write_level_streaming(
+    writer: &mut OverviewWriter<File>,
+    level_idx: usize,
+    hint: usize,
+    input_path: &Path,
+    read_batch_size: usize,
+    ctx: &LevelStreamCtx<'_>,
+) -> Result<(usize, usize), ConvertError> {
+    let file = File::open(input_path)?;
+    let mut reader = ParquetRecordBatchReaderBuilder::try_new(file)?
+        .with_batch_size(read_batch_size.max(1))
+        .build()?;
+
+    // `write_level` consumes an infallible batch iterator; errors inside the
+    // stream are parked in `err` (fusing the iterator) and re-raised after.
+    let err: RefCell<Option<ConvertError>> = RefCell::new(None);
+    let rows = Cell::new(0usize);
+    let vertices = Cell::new(0usize);
+    let mut row_offset = 0usize;
+
+    let batches = std::iter::from_fn(|| loop {
+        let batch = match reader.next() {
+            None => return None,
+            Some(Err(e)) => {
+                *err.borrow_mut() = Some(e.into());
+                return None;
+            }
+            Some(Ok(b)) => b,
+        };
+        let offset = row_offset;
+        row_offset += batch.num_rows();
+        match process_level_batch(&batch, offset, ctx) {
+            Ok(None) => continue, // no members of this level in the batch
+            Ok(Some((out, verts))) => {
+                rows.set(rows.get() + out.num_rows());
+                vertices.set(vertices.get() + verts);
+                return Some(out);
+            }
+            Err(e) => {
+                *err.borrow_mut() = Some(e);
+                return None;
+            }
+        }
+    });
+
+    let res = writer.write_level(level_idx, Some(hint), batches);
+    if let Some(e) = err.borrow_mut().take() {
+        return Err(e); // stream error takes precedence over the writer's
+    }
+    res?;
+    Ok((rows.get(), vertices.get()))
+}
+
+/// Process one input batch for one level: select the level's members from the
+/// winner table, decode only their geometries, simplify (unless verbatim), and
+/// assemble the output batch. Returns `None` when no member row survives.
+fn process_level_batch(
+    batch: &RecordBatch,
+    row_offset: usize,
+    ctx: &LevelStreamCtx<'_>,
+) -> Result<Option<(RecordBatch, usize)>, ConvertError> {
+    let n = batch.num_rows();
+    let selected: Vec<usize> = (0..n)
+        .filter(|&i| {
+            let ml = ctx.min_levels[row_offset + i];
+            if ctx.duplicating {
+                ml <= ctx.orig_level
+            } else {
+                ml == ctx.orig_level
+            }
+        })
+        .collect();
+    if selected.is_empty() {
+        return Ok(None);
+    }
+
+    // Decode only the selected rows' geometries (take → decode, not
+    // decode-all → filter).
+    let take_idx = UInt32Array::from(selected.iter().map(|&i| i as u32).collect::<Vec<_>>());
+    let geom_taken = take(batch.column(ctx.geom_idx).as_ref(), &take_idx, None)?;
+    let schema = batch.schema();
+    let gfield = schema.field(ctx.geom_idx);
+    let garr = from_arrow_array(geom_taken.as_ref(), gfield)
+        .map_err(|e| crate::Error::GeoParquetRead(format!("geometry decode: {e}")))?;
+    let mut geoms: Vec<Geometry<f64>> = Vec::with_capacity(selected.len());
+    extract_geometries_from_array(garr.as_ref(), &mut geoms)?;
+
+    let mut kept_idx: Vec<usize> = Vec::with_capacity(selected.len());
+    let mut verts = 0usize;
+
+    let kept_geoms: Vec<Geometry<f64>> = if ctx.verbatim {
+        for (g, &i) in geoms.iter().zip(&selected) {
+            verts += count_vertices(g);
+            kept_idx.push(i);
+        }
+        geoms
+    } else {
+        let mut out = Vec::with_capacity(selected.len());
+        for (g, &i) in geoms.iter().zip(&selected) {
+            match simplify_for_level(g, ctx.gsd_m, ctx.crs, ctx.simplify) {
+                Simplified::Keep(s) => {
+                    verts += count_vertices(&s);
+                    kept_idx.push(i);
+                    out.push(s);
+                }
+                Simplified::Dropped => {}
+            }
+        }
+        if out.is_empty() {
+            return Ok(None);
+        }
+        out
+    };
+
+    let out_batch = build_level_batch(
+        ctx.source_schema,
+        batch,
+        ctx.non_geom_cols,
+        ctx.geom_idx,
+        &kept_idx,
+        &kept_geoms,
+    )?;
+    Ok(Some((out_batch, verts)))
+}

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -57,6 +57,7 @@ use geo::Geometry;
 use geoarrow::array::from_arrow_array;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::arrow::ProjectionMask;
+use rayon::prelude::*;
 
 use crate::batch_processor::extract_geometries_from_array;
 
@@ -766,9 +767,18 @@ fn process_level_batch(
         }
         geoms
     } else {
+        // Simplification is >95% of pass-2 wall time (H3(c) profile) and
+        // embarrassingly parallel per feature. `par_iter().map().collect()`
+        // preserves within-batch order, so the output stays byte-identical to
+        // the serial path; the writer (our single caller) remains
+        // single-threaded, and memory stays bounded by one read batch.
+        let simplified: Vec<Simplified> = geoms
+            .par_iter()
+            .map(|g| simplify_for_level(g, ctx.gsd_m, ctx.crs, ctx.simplify))
+            .collect();
         let mut out = Vec::with_capacity(selected.len());
-        for (g, &i) in geoms.iter().zip(&selected) {
-            match simplify_for_level(g, ctx.gsd_m, ctx.crs, ctx.simplify) {
+        for (s, &i) in simplified.into_iter().zip(&selected) {
+            match s {
                 Simplified::Keep(s) => {
                     verts += count_vertices(&s);
                     kept_idx.push(i);

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -48,7 +48,7 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
 use std::fs::File;
 use std::path::Path;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use arrow_array::{Array, RecordBatch, UInt32Array};
 use arrow_schema::{DataType, Schema, SchemaRef};
@@ -115,14 +115,20 @@ pub(super) fn convert_streaming(
     let geom_field = input_schema.field(geom_idx).clone();
 
     // --- Pass 1: stream → AssignFeatures + resolved ranking. -----------------
+    let t_pass1 = Instant::now();
     let (mut features, ranking_provenance) =
         run_pass1(input_path, &input_schema, geom_idx, options)?;
     let num_features = features.len();
+    log::debug!(
+        "[profile] pass1 stream+scan: {:.2}s",
+        t_pass1.elapsed().as_secs_f64()
+    );
 
     // --- Winner tables (assignment + Q2 density budget). ---------------------
     let level_specs = options.levels.resolve(options.gsd_base)?;
     let level_gsds: Vec<f64> = level_specs.iter().map(|(g, _)| *g).collect();
 
+    let t_assign = Instant::now();
     let assignment = assign_levels(&features, &level_gsds, &options.assign, crs);
     let assignment = if options.density.enabled {
         apply_density_budget(
@@ -136,6 +142,10 @@ pub(super) fn convert_streaming(
     } else {
         assignment
     };
+    log::debug!(
+        "[profile] assignment+budget: {:.2}s",
+        t_assign.elapsed().as_secs_f64()
+    );
 
     // The winner table: per input row, the coarsest level it appears at.
     // 1 byte per feature — the only O(N) state carried into pass 2.
@@ -208,6 +218,7 @@ pub(super) fn convert_streaming(
         .collect();
 
     // --- Pass 2: per level, stream → filter → simplify → write. --------------
+    let t_pass2 = Instant::now();
     let mut level_reports = Vec::with_capacity(emitted.len());
     for (level_idx, e) in emitted.iter().enumerate() {
         // Verbatim path: partitioning at every level (§2.3), and duplicating at
@@ -244,7 +255,17 @@ pub(super) fn convert_streaming(
         });
     }
 
+    log::debug!(
+        "[profile] pass2 total: {:.2}s",
+        t_pass2.elapsed().as_secs_f64()
+    );
+
+    let t_finish = Instant::now();
     let meta = writer.finish()?;
+    log::debug!(
+        "[profile] writer.finish: {:.2}s",
+        t_finish.elapsed().as_secs_f64()
+    );
     fill_level_bytes(output_path, &meta, &mut level_reports)?;
 
     let total_rows: usize = level_reports.iter().map(|l| l.feature_count).sum();
@@ -576,6 +597,25 @@ fn run_pass1(
 // Pass 2: per-level streaming filter → simplify → write
 // ============================================================================
 
+/// Wall-time accumulators for one level's pass-2 stream ([profile] logging).
+#[derive(Default)]
+struct Pass2Timers {
+    /// Parquet read + Arrow decode of the raw batch (`reader.next()`).
+    read: Cell<Duration>,
+    /// Winner selection + geometry take/decode to `geo::Geometry`.
+    decode: Cell<Duration>,
+    /// Simplification (or verbatim vertex counting at the canonical level).
+    simplify: Cell<Duration>,
+    /// Output batch assembly (`build_level_batch`).
+    build: Cell<Duration>,
+}
+
+impl Pass2Timers {
+    fn add(cell: &Cell<Duration>, start: Instant) {
+        cell.set(cell.get() + start.elapsed());
+    }
+}
+
 /// Immutable context for one level's pass-2 stream.
 struct LevelStreamCtx<'a> {
     source_schema: &'a Schema,
@@ -614,8 +654,11 @@ fn write_level_streaming(
     let rows = Cell::new(0usize);
     let vertices = Cell::new(0usize);
     let mut row_offset = 0usize;
+    let timers = Pass2Timers::default();
+    let t_level = Instant::now();
 
     let batches = std::iter::from_fn(|| loop {
+        let t_read = Instant::now();
         let batch = match reader.next() {
             None => return None,
             Some(Err(e)) => {
@@ -624,9 +667,10 @@ fn write_level_streaming(
             }
             Some(Ok(b)) => b,
         };
+        Pass2Timers::add(&timers.read, t_read);
         let offset = row_offset;
         row_offset += batch.num_rows();
-        match process_level_batch(&batch, offset, ctx) {
+        match process_level_batch(&batch, offset, ctx, &timers) {
             Ok(None) => continue, // no members of this level in the batch
             Ok(Some((out, verts))) => {
                 rows.set(rows.get() + out.num_rows());
@@ -645,6 +689,22 @@ fn write_level_streaming(
         return Err(e); // stream error takes precedence over the writer's
     }
     res?;
+    let total = t_level.elapsed();
+    let accounted =
+        timers.read.get() + timers.decode.get() + timers.simplify.get() + timers.build.get();
+    log::debug!(
+        "[profile] level {} ({}, {} rows): total={:.2}s read={:.2}s decode={:.2}s \
+         simplify={:.2}s build={:.2}s write={:.2}s",
+        level_idx,
+        if ctx.verbatim { "verbatim" } else { "simplify" },
+        rows.get(),
+        total.as_secs_f64(),
+        timers.read.get().as_secs_f64(),
+        timers.decode.get().as_secs_f64(),
+        timers.simplify.get().as_secs_f64(),
+        timers.build.get().as_secs_f64(),
+        total.saturating_sub(accounted).as_secs_f64(),
+    );
     Ok((rows.get(), vertices.get()))
 }
 
@@ -655,8 +715,10 @@ fn process_level_batch(
     batch: &RecordBatch,
     row_offset: usize,
     ctx: &LevelStreamCtx<'_>,
+    timers: &Pass2Timers,
 ) -> Result<Option<(RecordBatch, usize)>, ConvertError> {
     let n = batch.num_rows();
+    let t_decode = Instant::now();
     let selected: Vec<usize> = (0..n)
         .filter(|&i| {
             let ml = ctx.min_levels[row_offset + i];
@@ -681,7 +743,9 @@ fn process_level_batch(
         .map_err(|e| crate::Error::GeoParquetRead(format!("geometry decode: {e}")))?;
     let mut geoms: Vec<Geometry<f64>> = Vec::with_capacity(selected.len());
     extract_geometries_from_array(garr.as_ref(), &mut geoms)?;
+    Pass2Timers::add(&timers.decode, t_decode);
 
+    let t_simplify = Instant::now();
     let mut kept_idx: Vec<usize> = Vec::with_capacity(selected.len());
     let mut verts = 0usize;
 
@@ -704,11 +768,14 @@ fn process_level_batch(
             }
         }
         if out.is_empty() {
+            Pass2Timers::add(&timers.simplify, t_simplify);
             return Ok(None);
         }
         out
     };
+    Pass2Timers::add(&timers.simplify, t_simplify);
 
+    let t_build = Instant::now();
     let out_batch = build_level_batch(
         ctx.source_schema,
         batch,
@@ -717,5 +784,6 @@ fn process_level_batch(
         &kept_idx,
         &kept_geoms,
     )?;
+    Pass2Timers::add(&timers.build, t_build);
     Ok(Some((out_batch, verts)))
 }

--- a/docs/OVERVIEW_TUNING.md
+++ b/docs/OVERVIEW_TUNING.md
@@ -311,6 +311,57 @@ you trade a bigger footer for that pushdown.
 
 ---
 
+## Memory / streaming knobs: `--no-streaming`, `--read-batch-size`
+
+Like the [file layout knobs](#file-layout-knobs---row-group-size---full-column-stats),
+these never change the output's content: level assignments, geometry,
+attributes, and footer metadata are equivalent either way. They control **how
+much memory the conversion itself uses**.
+
+By default the converter runs a **two-pass streaming pipeline** (H3):
+
+1. **Pass 1** streams the input once and keeps only a tiny record per feature
+   (bbox, geometry kind, ranking key — no geometry). The level-assignment
+   engine and density budget run over those records to build the **winner
+   table**: one byte per feature saying which levels it survives at.
+2. **Pass 2** re-reads the input once per level (Parquet is seekable, so
+   re-reads are cheap), filters each read batch against the winner table,
+   simplifies only the selected rows, and writes batch-by-batch.
+
+Peak memory is `O(read batch + winner tables)` instead of `O(dataset)`: on the
+Moldova corpus file (632k polygons, 38M vertices) peak RSS drops from ~5.4 GB
+(in-memory) to well under 1 GB, with equivalent output.
+
+| Knob | Default | Units | Direction |
+|------|---------|-------|-----------|
+| `--read-batch-size N` | `8192` | rows per read batch | **bigger = faster-ish, more memory** |
+| `--no-streaming` | off | flag | revert to the one-pass in-memory pipeline |
+
+**`--read-batch-size`** bounds the transient working set of both passes: each
+batch is decoded, filtered, simplified, and written before the next is read.
+LARGER batches amortize per-batch overhead (marginally faster) at the cost of
+proportionally more peak memory; SMALLER batches bound memory tighter. The
+default 8192 keeps per-batch transients in the tens of MB even for
+vertex-heavy polygon data; you rarely need to change it. LOWER it (e.g. 1024)
+on very memory-constrained machines or for monster geometries (a single batch
+of coastline-sized multipolygons can be large); RAISE it (e.g. 65536) only if
+profiling shows per-batch overhead dominating on a machine with RAM to spare.
+
+**`--no-streaming`** runs the original in-memory pipeline: the whole table and
+every decoded geometry are held at once (`O(dataset)` memory). It reads the
+input exactly once instead of once per level, so it can be marginally faster
+on *small* inputs that comfortably fit in RAM; on large inputs it is both
+slower and enormously more memory-hungry. It is kept as the reference
+implementation — the two paths are equivalence-tested against each other —
+and as an escape hatch; there is no output-quality reason to use it.
+
+Residual per-feature memory in streaming mode (the "winner tables") is ~50–80
+bytes per input feature during pass 1 and 1 byte per feature during pass 2 —
+about 40 MB / 0.6 MB for a 632k-feature file — so even planet-tier inputs
+stay laptop-sized.
+
+---
+
 ## Worked scenarios
 
 | Symptom | Fix |
@@ -326,6 +377,7 @@ you trade a bigger footer for that pushdown.
 | Every remote query fetches a huge footer before any data | default already suppresses string/geometry stats; do NOT pass `--full-column-stats` |
 | Need server-side row-group skipping on a property predicate | pass `--full-column-stats` (bigger footer, gains column pruning) |
 | Tiny viewports over high-latency storage fetch too much | LOWER `--row-group-size` for tighter bbox pruning |
+| Conversion runs out of memory / swaps on a big file | streaming is already the default; LOWER `--read-batch-size`; make sure `--no-streaming` is NOT set |
 
 See `corpus/SWEEP_NOTES.md` for an empirical `--line-thinning` ×
 `--simplify-factor` sweep on Portland roads, and the Q2 section there for the


### PR DESCRIPTION
## Summary

H3 from the Phase 5 hardening roadmap (`context/OVERVIEWS_PLAN.md`), in two waves on this branch: **bounded-memory streaming convert** and **profile-driven speed work** across convert and export.

### Headline: Moldova, 632k polygons, duplicating z0–14

| | before this PR | after | change |
|---|---|---|---|
| convert wall | 11m 50s | **55.3 s** | **12.8×** |
| convert peak RSS | 5.30 GB | **320 MB** | **−94%** |
| export wall | 4m 48s | **58.8 s** | **4.9×** |
| overview parquet size | 360.7 MB | **293.6 MB** | −18.6% |
| PMTiles size | 130.7 MB | 123.3 MB | −5.7% |

**Full GeoParquet → overviews → PMTiles pipeline: ~17 minutes → under 2 minutes, in bounded memory.** All 9 `gpq-tiles validate` checks pass, 0 oversized tiles; the exported PMTiles renders correctly on pmtiles.io.

## Wave 1 — two-pass streaming convert (default)

- **Pass 1** streams the input row-group by row-group reading only geometry + ranking columns (Parquet column projection), runs cell-winner assignment (Q1 resolved incrementally) and density budgets (Q2) → 1-byte-per-feature winner table.
- **Pass 2** re-reads the seekable input once per level (coarse→fine), decodes/simplifies only winning rows, writes batch-by-batch through `OverviewWriter`.
- Knobs (documented in `docs/OVERVIEW_TUNING.md`): `--no-streaming` (in-memory reference path), `--read-batch-size` (default 8192).
- 5 equivalence tests (`streaming_matches_*`): identical per-level rows/vertex counts and byte-identical footers vs the in-memory path across duplicating, partitioning, density budgets, explicit sort-key, auto-rank.

## Wave 2 — profiled speed levers (`benchmarks/overview/H3C_PROFILE.md`)

Profiling showed 96.9% of convert in simplification and 94% of export in clipping, all single-core:

- **Validation waste + fallback bug fix** (`6b716c2`): `is_valid()` dominated simplify cost; skipped where provably unnecessary. Fixed a real quality bug — invalid RDP candidates were silently kept at **full resolution** (~3–9% of coarse-level candidates); now retried at progressively smaller epsilon (3,664 total legitimate fallbacks remain, counted + logged). This is the −18.6% file size and up-to-84% mid-level vertex reduction.
- **Rayon pass-2 simplification** (`9ae7679`): order-preserving, memory still bounded by one read batch.
- **Export bbox fast path** (`7afe7fe`): features fully inside the buffered tile skip BooleanOps clip (~79% of z14 features).
- **Rayon export clip + MVT encode** (`2b4a388`): deterministic tile order/bytes.

## Behavior notes

- Intended output change from the fallback fix: previously-unsimplified coarse features are now properly simplified; −12 rows (degenerate slivers dropped instead of kept full-res).
- A level whose winners all degenerate fails loudly (`EmptyLevel`) instead of silent renumbering (impossible under default knobs).
- Export logger initialization fixed (export diagnostics were silently dropped).

## Follow-ups (not this PR)

- H3(b): export-side tile flushing — export RSS 2.38 GB is now the last memory hotspot; same refactor addresses the serial grouping merge that capped export at 4.9× of its 8.4× ceiling.
- Q4 point clustering + aggregation (next on the quality ladder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)