### PR TITLE
feat(core): opt-in point clustering with point_count + attribute aggregation (Q4)

### DIFF
--- a/context/OVERVIEWS_SPEC.md
+++ b/context/OVERVIEWS_SPEC.md
@@ -619,8 +619,9 @@ This spec explicitly does NOT address:
 - **Mandating a specific thinning/simplification algorithm.** The spec
   constrains layout and metadata; the generalization engine is
   implementation-defined (gpq-tiles supplies one).
-- **Attribute aggregation** (summing/averaging attributes of dropped
-  features). Deferred to a later `generalization` v0.2.
+- ~~**Attribute aggregation** (summing/averaging attributes of dropped
+  features). Deferred to a later `generalization` v0.2.~~ Now specified as
+  the opt-in point-clustering extension, §12 (v0.2.0-draft).
 
 ---
 
@@ -747,3 +748,112 @@ Migration plan:
 - **Q7 APPROVED:** `mode` stays **SHOULD with documented
   `partitioning` default** (the safe reader assumption), not REQUIRED.
 ```
+
+---
+
+## 12. Point clustering extension (v0.2.0-draft)
+
+Status: draft addition targeted at spec v0.2.0; implemented by gpq-tiles
+behind the opt-in `--cluster` flag (2026-07-03). Additive: files written
+with clustering remain valid v0.1.0 overview files (an extra optional
+column + an optional provenance block that v0.1 readers MUST ignore per
+§3.8); the section is versioned v0.2.0-draft because it introduces new
+normative requirements for files that opt in.
+
+### 12.1 Model
+
+Clustering applies to **point features only** (Point/MultiPoint rows;
+lines and polygons are unaffected) and to **`duplicating` mode only**
+(§12.5). It is **opt-in, default off** (consistent with §11 Q4's
+opt-in-collapse posture).
+
+At each level, the generalization engine's per-cell survivor **absorbs**
+the point features that were thinned out of its cell at that level's
+grid, instead of them simply vanishing:
+
+- Every source point feature is represented by exactly one row at every
+  level: itself if present, else an absorbing winner. Consequently, at
+  each level, the sum of `point_count` over the level's point rows
+  equals the total source point-feature count.
+- Absorption is **per level**: a feature absorbed at level `k` may
+  itself be a row (with its own, smaller cluster) at level `k+1`.
+- The winner keeps its **own geometry** and its own values for every
+  non-accumulated column. (DIVERGENCE from supercluster, which
+  re-centers a cluster at its members' centroid: keeping the winner's
+  geometry is deterministic and anchors the cluster at a real feature.)
+
+### 12.2 `point_count` column (normative when clustering)
+
+A clustered file MUST contain a physical column:
+
+- **Name**: `point_count` (recorded in metadata, §12.4, so readers need
+  not hard-code it).
+- **Type**: Parquet `INT64`. **Nullability**: NOT NULL.
+- **Domain**: `>= 1`. Non-point rows and unclustered (singleton) point
+  rows carry `1`.
+- At the **canonical level** every value MUST be `1` (clusters would
+  violate canonical value-identity, §2.4 — the canonical band remains
+  verbatim source data plus the constant `point_count = 1`).
+
+Writers MUST reject source data whose schema already contains a column
+named `point_count` under case-insensitive comparison (same rationale
+as the `level` column rule, §4.1).
+
+### 12.3 Attribute accumulation (optional)
+
+A writer MAY additionally aggregate **numeric** columns across each
+cluster (tippecanoe `--accumulate-attribute` convention): the winner's
+value of the column becomes `sum` | `max` | `min` | `mean` over itself
+plus the absorbed features at that level.
+
+- Aggregates MUST be computed per level **from source values** (never
+  from a coarser level's already-aggregated values), so `mean` is exact
+  at every level.
+- Null member values do not contribute; a cluster with no non-null
+  member keeps the winner's null.
+- Canonical-level values remain verbatim (§2.4; every canonical cluster
+  is a singleton).
+- The aggregated column keeps its declared type; producers SHOULD
+  prefer floating-point columns for `mean`.
+
+### 12.4 Metadata
+
+Clustering is recorded in the `generalization` provenance block (§3.5):
+
+```
+Generalization += {
+  "clustering": {                       // OPTIONAL
+    "enabled":            true,
+    "point_count_column": "point_count",
+    "accumulated": [ { "column": string, "op": "sum"|"max"|"min"|"mean" } ]
+  }
+}
+```
+
+Unlike the rest of §3.5, when `clustering.enabled` is true a validator
+MUST enforce §12.2 structurally: the named column exists as INT64 NOT
+NULL, all values are `>= 1` (checkable via row-group statistics), and
+the canonical band's values are exactly `1`.
+
+### 12.5 Partitioning mode is excluded (normative)
+
+`--cluster` MUST be rejected for `partitioning`-mode files. Rationale:
+a partitioning feature has exactly **one** row but is *displayed* at
+every zoom `z >= min_level` (prefix reads, §2.3). A single stored
+`point_count` can only describe one level's grid, so it would be wrong
+at every other display zoom; worse, a feature absorbed at a coarse
+level reappears as its own row in a finer band while remaining counted
+in the coarse winner, so `Σ point_count` over any prefix double-counts.
+There is no non-contorted single-column encoding of per-level counts in
+a feature-once layout; producers who need clustering use `duplicating`
+mode.
+
+---
+
+## 13. Changelog
+
+- **v0.2.0-draft (2026-07-03)**: added §12 point clustering extension
+  (`point_count` column, numeric attribute accumulation,
+  `generalization.clustering` metadata, duplicating-mode-only rule);
+  struck attribute aggregation from the §8 non-goals.
+- **v0.1.0 (2026-07-02)**: initial draft; §11 design decisions approved.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -226,16 +226,20 @@ struct OverviewArgs {
     #[arg(long)]
     cogp_compat: bool,
 
-    /// Point thinning factor: grid cell size = factor * gsd (default 4.0).
+    /// Point thinning factor: grid cell size = factor * gsd.
+    ///
+    /// Default 4.0, or 16.0 when --cluster is enabled (absorbed points are
+    /// summarized via point_count rather than dropped, so a coarser grid
+    /// gives the familiar graduated-cluster look; chosen from the NYC
+    /// pt={4,16,48} sweep).
     ///
     /// One feature survives per grid cell per level, so BIGGER factor = BIGGER
-    /// cells = FEWER survivors = SPARSER map; SMALLER = denser. Points thin
-    /// hardest by default (4.0) since they clutter fastest. This multiplies the
-    /// GSD cell size, so it interacts with --gsd-base (which sets the GSD).
+    /// cells = FEWER survivors = SPARSER map; SMALLER = denser. This multiplies
+    /// the GSD cell size, so it interacts with --gsd-base (which sets the GSD).
     ///
     /// Cheat sheet: coarse levels too sparse → LOWER the thinning factors.
-    #[arg(long, default_value = "4.0")]
-    point_thinning: f64,
+    #[arg(long)]
+    point_thinning: Option<f64>,
 
     /// Line thinning factor: grid cell size = factor * gsd (default 1.0).
     ///
@@ -1067,8 +1071,16 @@ fn run_overview(args: OverviewArgs) -> Result<()> {
         }
     };
 
+    // Cluster-conditional default: with --cluster, absorbed points are
+    // summarized (point_count), so the sparser 16.0 grid is the better look.
+    let point_thinning = args.point_thinning.unwrap_or(if args.cluster {
+        gpq_tiles_core::overview::assign::CLUSTER_POINT_THINNING_DEFAULT
+    } else {
+        AssignConfig::default().point_thinning
+    });
+
     let assign = AssignConfig {
-        point_thinning: args.point_thinning,
+        point_thinning,
         line_thinning: args.line_thinning,
         polygon_thinning: args.polygon_thinning,
         line_visibility: args.line_visibility,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -197,6 +197,31 @@ struct OverviewArgs {
     #[arg(long)]
     collapse: bool,
 
+    /// Enable point clustering (duplicating mode only; opt-in).
+    ///
+    /// At each overview level, the surviving point in each thinning grid cell
+    /// ABSORBS the other points in its cell instead of them simply vanishing:
+    /// the output gains a `point_count` INT64 NOT NULL column recording how
+    /// many source features each row represents at its level (tippecanoe /
+    /// supercluster convention; always 1 at the canonical level). The winner
+    /// keeps its own geometry and attribute values. Lines and polygons are
+    /// unaffected (their rows carry point_count = 1). Use for graduated-dot
+    /// rendering of dense point data. See docs/OVERVIEW_TUNING.md.
+    #[arg(long)]
+    cluster: bool,
+
+    /// Aggregate a numeric column across clustered points: COL:OP where OP is
+    /// sum, max, min, or mean. Repeatable. Requires --cluster.
+    ///
+    /// At each level the winner's value of COL becomes the aggregate over
+    /// itself + the points it absorbed at that level (computed per level from
+    /// SOURCE values — mean is exact, never a mean of means). All other
+    /// columns keep the winner's own values. Example:
+    /// --accumulate-attribute population:sum
+    /// --accumulate-attribute confidence:mean
+    #[arg(long = "accumulate-attribute", value_name = "COL:OP")]
+    accumulate_attribute: Vec<String>,
+
     /// Emit the optional COGP compatibility footer key (partitioning mode).
     #[arg(long)]
     cogp_compat: bool,
@@ -1060,6 +1085,23 @@ fn run_overview(args: OverviewArgs) -> Result<()> {
         None => None,
     };
 
+    // Clustering flags (Q4; also enforced in core).
+    if !args.accumulate_attribute.is_empty() && !args.cluster {
+        anyhow::bail!("--accumulate-attribute requires --cluster");
+    }
+    if args.cluster && mode == Mode::Partitioning {
+        anyhow::bail!(
+            "--cluster requires --mode duplicating: a partitioning-mode feature has \
+             one row read across many zoom prefixes, so a per-level point_count \
+             cannot be represented without double counting"
+        );
+    }
+    let accumulate = args
+        .accumulate_attribute
+        .iter()
+        .map(|s| parse_accumulate(s))
+        .collect::<Result<Vec<_>>>()?;
+
     let options = ConvertOptions {
         mode,
         levels,
@@ -1082,6 +1124,8 @@ fn run_overview(args: OverviewArgs) -> Result<()> {
         full_column_stats: args.full_column_stats,
         streaming: !args.no_streaming,
         read_batch_size: args.read_batch_size,
+        cluster: args.cluster,
+        accumulate,
     };
 
     let report = convert_to_overviews(&args.input, &args.output, &options)
@@ -1178,6 +1222,31 @@ fn parse_class_rank(spec: &str) -> Result<gpq_tiles_core::overview::convert::Cla
         column: column.to_string(),
         ranks,
         unknown_rank: min_rank - 1.0,
+    })
+}
+
+/// Parse an `--accumulate-attribute` spec: `COL:OP` with OP one of
+/// `sum`, `max`, `min`, `mean` (case-insensitive).
+fn parse_accumulate(spec: &str) -> Result<gpq_tiles_core::overview::cluster::AccumulateSpec> {
+    use gpq_tiles_core::overview::cluster::{AccumulateOp, AccumulateSpec};
+
+    let (column, op) = spec.rsplit_once(':').ok_or_else(|| {
+        anyhow::anyhow!("invalid --accumulate-attribute '{spec}': expected COL:OP (missing ':')")
+    })?;
+    let column = column.trim();
+    if column.is_empty() {
+        anyhow::bail!("invalid --accumulate-attribute '{spec}': empty column name");
+    }
+    let op = AccumulateOp::parse(op.trim()).ok_or_else(|| {
+        anyhow::anyhow!(
+            "invalid --accumulate-attribute '{spec}': unknown op {:?} \
+             (expected sum, max, min, or mean)",
+            op.trim()
+        )
+    })?;
+    Ok(AccumulateSpec {
+        column: column.to_string(),
+        op,
     })
 }
 
@@ -1456,4 +1525,35 @@ fn run_with_progress(
     // Standard pipeline handles both files and directories transparently
     generate_tiles_to_writer_with_progress(input_path, config, writer, progress_callback)
         .context("Failed to generate tiles")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpq_tiles_core::overview::cluster::AccumulateOp;
+
+    #[test]
+    fn parse_accumulate_valid_specs() {
+        let s = parse_accumulate("population:sum").unwrap();
+        assert_eq!(s.column, "population");
+        assert_eq!(s.op, AccumulateOp::Sum);
+
+        // Case-insensitive op, trimmed parts.
+        let s = parse_accumulate(" confidence : MEAN ").unwrap();
+        assert_eq!(s.column, "confidence");
+        assert_eq!(s.op, AccumulateOp::Mean);
+
+        let s = parse_accumulate("x:min").unwrap();
+        assert_eq!(s.op, AccumulateOp::Min);
+        let s = parse_accumulate("x:max").unwrap();
+        assert_eq!(s.op, AccumulateOp::Max);
+    }
+
+    #[test]
+    fn parse_accumulate_rejects_bad_specs() {
+        assert!(parse_accumulate("population").is_err(), "missing op");
+        assert!(parse_accumulate(":sum").is_err(), "empty column");
+        assert!(parse_accumulate("pop:median").is_err(), "unknown op");
+        assert!(parse_accumulate("pop:").is_err(), "empty op");
+    }
 }

--- a/crates/core/src/memory.rs
+++ b/crates/core/src/memory.rs
@@ -555,6 +555,13 @@ mod tests {
     /// 3. Independent of add() calls - only reflects actual allocations
     #[test]
     fn test_rss_tracker_samples_actual_memory() {
+        // The OS query itself can be unavailable (some CI runners/sandboxes);
+        // that is an environment limitation, not the property under test.
+        if memory_stats::memory_stats().is_none() {
+            eprintln!("skipping: memory_stats unavailable in this environment");
+            return;
+        }
+
         let mut tracker = RssTracker::new();
 
         // Sample initial RSS

--- a/crates/core/src/overview/assign.rs
+++ b/crates/core/src/overview/assign.rs
@@ -110,7 +110,7 @@ pub struct AssignFeature {
 impl AssignFeature {
     /// Bbox center — the representative point used for grid placement.
     #[inline]
-    fn center(&self) -> (f64, f64) {
+    pub(super) fn center(&self) -> (f64, f64) {
         let [xmin, ymin, xmax, ymax] = self.bbox;
         ((xmin + xmax) * 0.5, (ymin + ymax) * 0.5)
     }
@@ -253,8 +253,10 @@ type CellKey = (u8, i64, i64);
 
 /// Priority of a feature within a cell. Higher is better. Compared
 /// lexicographically to yield a strict total order (see [`Priority::cmp`]).
+/// `pub(super)` so the clustering stage (`super::cluster`) can rank present
+/// features with the exact order the cell-winner stage used.
 #[derive(Debug, Clone, Copy)]
-struct Priority {
+pub(super) struct Priority {
     /// Encoded sort key: `Some` sorts above `None`; direction already applied
     /// so that "larger `sort_bits` wins".
     sort_rank: Option<f64>,
@@ -265,7 +267,7 @@ struct Priority {
 }
 
 impl Priority {
-    fn new(feat: &AssignFeature, dir: SortDirection) -> Self {
+    pub(super) fn new(feat: &AssignFeature, dir: SortDirection) -> Self {
         // Apply direction so a plain "larger wins" comparison is correct.
         let sort_rank = feat.sort_key.map(|k| match dir {
             SortDirection::Desc => k,
@@ -280,7 +282,7 @@ impl Priority {
     }
 
     /// Returns `true` if `self` is strictly better (should win) than `other`.
-    fn beats(&self, other: &Priority) -> bool {
+    pub(super) fn beats(&self, other: &Priority) -> bool {
         // 1. sort_rank: Some beats None; both Some compares larger-wins.
         match (self.sort_rank, other.sort_rank) {
             (Some(a), Some(b)) => {

--- a/crates/core/src/overview/assign.rs
+++ b/crates/core/src/overview/assign.rs
@@ -151,6 +151,19 @@ pub struct AssignConfig {
     pub sort_direction: SortDirection,
 }
 
+/// Default `point_thinning` when point clustering is enabled.
+///
+/// With clustering, absorbed points are *summarized* (`point_count` +
+/// accumulated attributes) rather than dropped, so a much coarser grid is
+/// pure win: one dot per ~16 display pixels approaches the supercluster
+/// look (radius 40 px) while the non-clustered default (4.0) preserves
+/// density for thin-only output. Chosen by maintainer review of the
+/// 2026-07-03 NYC pt={4,16,48} sweep (corpus/data/bench/q4/).
+///
+/// Callers that expose a user-facing `point_thinning` knob should apply
+/// this default only when the user did not set the knob explicitly.
+pub const CLUSTER_POINT_THINNING_DEFAULT: f64 = 16.0;
+
 impl Default for AssignConfig {
     fn default() -> Self {
         Self {

--- a/crates/core/src/overview/check.rs
+++ b/crates/core/src/overview/check.rs
@@ -260,6 +260,16 @@ pub fn validate_metadata(metadata: &ParquetMetaData) -> ValidationReport {
         check_level_footer_consistency(metadata, meta, idx, &mut report);
     }
 
+    // --- clustering metadata (Q4): point_count column + canonical values. ----
+    if let Some(cl) = meta
+        .as_ref()
+        .and_then(|m| m.generalization.as_ref())
+        .and_then(|g| g.clustering.as_ref())
+        .filter(|c| c.enabled)
+    {
+        check_clustering(metadata, meta.as_ref().unwrap(), cl, &mut report);
+    }
+
     // --- covering column per-RG min/max stats present (§4.4). ----------------
     match &covering {
         None => { /* already failed geoparquet_covering_declared */ }
@@ -336,6 +346,111 @@ fn check_mode_canonical(meta: &OverviewsMeta, report: &mut ValidationReport) {
                 );
             }
         }
+    }
+}
+
+/// Clustering conformance (Q4, spec §12 draft): when the footer's
+/// `generalization.clustering` block is present and enabled,
+/// - the mode must be `duplicating` (clustering cannot be represented in
+///   partitioning mode without double counting);
+/// - the named point-count column must exist as INT64 NOT NULL;
+/// - every row group's point_count stats must have `min >= 1`, and the
+///   canonical level band's must be exactly `min == max == 1` (every
+///   canonical cluster is a singleton).
+fn check_clustering(
+    metadata: &ParquetMetaData,
+    meta: &OverviewsMeta,
+    clustering: &crate::overview::level::ClusteringProvenance,
+    report: &mut ValidationReport,
+) {
+    // Mode: duplicating only.
+    match meta.mode {
+        Some(Mode::Duplicating) => report.pass(
+            "cluster_mode",
+            "clustering metadata on a duplicating-mode file",
+        ),
+        other => {
+            report.fail(
+                "cluster_mode",
+                format!(
+                    "clustering metadata requires duplicating mode, found {other:?} \
+                     (a partitioning row is read across many zoom prefixes; a \
+                     per-level point_count would double count)"
+                ),
+            );
+            return;
+        }
+    }
+
+    // Column exists, INT64, NOT NULL.
+    let name = clustering.point_count_column.as_str();
+    let descr = metadata.file_metadata().schema_descr();
+    let col_idx = (0..descr.num_columns()).find(|&i| descr.column(i).path().string() == name);
+    let col_idx = match col_idx {
+        None => {
+            report.fail(
+                "cluster_point_count_column",
+                format!("clustering metadata names column {name:?} but it is absent"),
+            );
+            return;
+        }
+        Some(idx) => {
+            let col = descr.column(idx);
+            let phys_ok = col.physical_type() == PhysicalType::INT64;
+            let required = col.max_def_level() == 0;
+            if phys_ok && required {
+                report.pass(
+                    "cluster_point_count_column",
+                    format!("{name:?} is INT64 NOT NULL"),
+                );
+                idx
+            } else {
+                report.fail(
+                    "cluster_point_count_column",
+                    format!(
+                        "{name:?} must be INT64 NOT NULL (physical={:?}, max_def_level={})",
+                        col.physical_type(),
+                        col.max_def_level()
+                    ),
+                );
+                return;
+            }
+        }
+    };
+
+    // Values: min >= 1 everywhere; canonical band exactly 1 (via RG stats).
+    let canonical = meta.canonical_level;
+    let mut problems: Vec<String> = Vec::new();
+    for rg in 0..metadata.num_row_groups() {
+        let is_canonical = level_for_rg(meta, rg).map(|k| k as i64) == canonical;
+        let chunk = metadata.row_group(rg).column(col_idx);
+        match chunk.statistics() {
+            Some(Statistics::Int64(s)) => match (s.min_opt(), s.max_opt()) {
+                (Some(&min), Some(&max)) => {
+                    if min < 1 {
+                        problems.push(format!("RG {rg}: point_count min={min} < 1"));
+                    }
+                    if is_canonical && (min != 1 || max != 1) {
+                        problems.push(format!(
+                            "RG {rg} (canonical): point_count min={min} max={max}, expected 1"
+                        ));
+                    }
+                }
+                _ => problems.push(format!("RG {rg}: point_count has no min/max stats")),
+            },
+            Some(other) => {
+                problems.push(format!("RG {rg}: point_count stats not Int64 ({other:?})"))
+            }
+            None => problems.push(format!("RG {rg}: point_count column has no statistics")),
+        }
+    }
+    if problems.is_empty() {
+        report.pass(
+            "cluster_point_count_values",
+            "point_count >= 1 everywhere; canonical level all 1",
+        );
+    } else {
+        report.fail("cluster_point_count_values", problems.join("; "));
     }
 }
 
@@ -637,6 +752,161 @@ mod tests {
         assert_eq!(report.check_passed("overviews_key_present"), Some(false));
         assert_eq!(report.check_passed("geoparquet_geo_metadata"), Some(false));
         assert_eq!(report.check_passed("level_column"), Some(false));
+    }
+
+    // --- Q4 clustering checks -------------------------------------------------
+
+    /// Write a 2-level duplicating fixture whose footer carries clustering
+    /// provenance. `point_counts` supplies per-level `point_count` values
+    /// (parallel to `level_ids`); `None` omits the column entirely.
+    fn write_cluster_fixture(
+        path: &std::path::Path,
+        level_ids: &[Vec<i64>],
+        point_counts: Option<&[Vec<i64>]>,
+    ) {
+        use crate::overview::level::{AccumulatedColumn, ClusteringProvenance, Generalization};
+        use arrow_array::Int64Array as I64;
+
+        let mut fields = vec![
+            Arc::new(Field::new("id", DataType::Int64, false)),
+            Arc::new(Field::new("name", DataType::Utf8, false)),
+            Arc::new(geometry_field()),
+        ];
+        if point_counts.is_some() {
+            fields.push(Arc::new(Field::new("point_count", DataType::Int64, false)));
+        }
+        let schema = Arc::new(Schema::new(fields));
+
+        let specs: Vec<LevelSpec> = (0..level_ids.len())
+            .map(|k| {
+                let z = (2 + 2 * k) as u8;
+                LevelSpec::new(gsd(z), Some(z))
+            })
+            .collect();
+        let mut opts = OverviewWriterOptions::new(Mode::Duplicating, specs);
+        opts.generalization = Some(Generalization {
+            engine: "gpq-tiles test".to_string(),
+            gsd_base: None,
+            levels: vec![],
+            ranking: None,
+            density_drop: None,
+            clustering: Some(ClusteringProvenance {
+                enabled: true,
+                point_count_column: "point_count".to_string(),
+                accumulated: vec![AccumulatedColumn {
+                    column: "id".to_string(),
+                    op: "sum".to_string(),
+                }],
+            }),
+        });
+
+        let mut writer = OverviewWriter::create(path, &schema, opts).unwrap();
+        for (k, ids) in level_ids.iter().enumerate() {
+            let id_array = I64::from(ids.to_vec());
+            let name_array =
+                StringArray::from(ids.iter().map(|id| format!("f{id}")).collect::<Vec<_>>());
+            let geom_array = build_geometry_array(ids);
+            let mut columns: Vec<Arc<dyn arrow_array::Array>> = vec![
+                Arc::new(id_array),
+                Arc::new(name_array),
+                Arc::new(geom_array.to_array_ref()),
+            ];
+            if let Some(counts) = point_counts {
+                columns.push(Arc::new(I64::from(counts[k].clone())));
+            }
+            let batch = RecordBatch::try_new(schema.clone(), columns).unwrap();
+            writer
+                .write_level(k, Some(ids.len()), std::iter::once(batch))
+                .unwrap();
+        }
+        writer.finish().unwrap();
+    }
+
+    #[test]
+    fn clustering_good_file_passes() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        write_cluster_fixture(
+            tmp.path(),
+            &[vec![0], vec![0, 1, 2]],
+            Some(&[vec![3], vec![1, 1, 1]]),
+        );
+        let report = validate_file(tmp.path()).unwrap();
+        assert!(
+            report.is_valid(),
+            "unexpected failures: {:?}",
+            report.failures().collect::<Vec<_>>()
+        );
+        assert_eq!(report.check_passed("cluster_mode"), Some(true));
+        assert_eq!(
+            report.check_passed("cluster_point_count_column"),
+            Some(true)
+        );
+        assert_eq!(
+            report.check_passed("cluster_point_count_values"),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn clustering_metadata_without_column_fails() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        write_cluster_fixture(tmp.path(), &[vec![0], vec![0, 1, 2]], None);
+        let report = validate_file(tmp.path()).unwrap();
+        assert!(!report.is_valid());
+        assert_eq!(
+            report.check_passed("cluster_point_count_column"),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn clustering_canonical_count_not_one_fails() {
+        // Canonical level carries a point_count of 2 → conformance failure.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        write_cluster_fixture(
+            tmp.path(),
+            &[vec![0], vec![0, 1, 2]],
+            Some(&[vec![3], vec![1, 2, 1]]),
+        );
+        let report = validate_file(tmp.path()).unwrap();
+        assert!(!report.is_valid());
+        assert_eq!(
+            report.check_passed("cluster_point_count_values"),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn clustering_zero_count_fails() {
+        // A point_count of 0 anywhere violates the >= 1 invariant.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        write_cluster_fixture(
+            tmp.path(),
+            &[vec![0], vec![0, 1, 2]],
+            Some(&[vec![0], vec![1, 1, 1]]),
+        );
+        let report = validate_file(tmp.path()).unwrap();
+        assert!(!report.is_valid());
+        assert_eq!(
+            report.check_passed("cluster_point_count_values"),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn no_clustering_metadata_skips_checks() {
+        // A plain duplicating fixture never runs the cluster_* checks.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        write_fixture(
+            tmp.path(),
+            Mode::Duplicating,
+            &[vec![0, 2], vec![0, 1, 2, 3]],
+            false,
+        );
+        let report = validate_file(tmp.path()).unwrap();
+        assert!(report.is_valid());
+        assert_eq!(report.check_passed("cluster_mode"), None);
+        assert_eq!(report.check_passed("cluster_point_count_column"), None);
     }
 
     #[test]

--- a/crates/core/src/overview/cluster.rs
+++ b/crates/core/src/overview/cluster.rs
@@ -1,0 +1,756 @@
+//! Point clustering + attribute aggregation for overview levels (plan Q4/Q6).
+//!
+//! This is a **pure** stage layered on top of the final level assignment
+//! (cell-winner + density budget). It answers, per level: *which present
+//! point row represents each source point feature, how many features does
+//! each present row represent (`point_count`), and what are the aggregated
+//! attribute values of the features it absorbed?*
+//!
+//! # Model (duplicating mode only)
+//!
+//! At each overview level `L` the cell-winner assignment keeps one winner
+//! point per occupied grid cell; with clustering enabled the winner **absorbs**
+//! the losers in its cell at that level instead of them simply vanishing:
+//!
+//! - Every source point feature is assigned exactly one representative among
+//!   the rows *present* at `L` (`min_level <= L`): itself if present, else the
+//!   best-priority present point feature in its level-`L` grid cell (the same
+//!   cell size and [`Priority`] order the cell-winner stage used).
+//! - `point_count` of a present row at level `L` = the number of source
+//!   features it represents at that level (itself + absorbed). At the
+//!   canonical (finest) level every cluster is a singleton (`point_count = 1`).
+//! - Absorption is **per level, from source values**: a feature absorbed at
+//!   level `L` may itself be a winner at finer level `L+1`, and each level's
+//!   aggregates are computed over the full set of *source* features in the
+//!   winner's cell at that level's grid — never from already-aggregated
+//!   values, so `mean` is numerically exact at every level.
+//!
+//! Lines and polygons are unaffected (their rows carry `point_count = 1`).
+//!
+//! # Orphan cells (density-budget interaction)
+//!
+//! Without the Q2 density budget, every occupied point cell's winner is
+//! present at the level it won, so every source point finds a representative
+//! in its own cell. The budget, however, can *defer* a cell winner to a finer
+//! level, leaving the cell with no present row ("orphan cell"). Orphan cells
+//! are resolved deterministically: the cell's features attach to the present
+//! point feature nearest to the orphan cell's center, found by an expanding
+//! ring search over the level grid (ties broken by [`Priority`]). This keeps
+//! the invariant *Σ point_count over a level's point rows = total source
+//! point count* whenever the level has at least one point row.
+//!
+//! # DIVERGENCE FROM SUPERCLUSTER
+//!
+//! The winner keeps its **own geometry** (and its own values for every
+//! non-accumulated column). Supercluster re-centers a cluster at the weighted
+//! centroid of its members; we deliberately do not — keeping the winner's
+//! geometry is deterministic, preserves a real feature location, and requires
+//! no geometry rewrite at coarse levels.
+
+use std::collections::HashMap;
+
+use super::assign::{AssignConfig, AssignFeature, FeatureKind, Priority};
+use super::level::Crs;
+
+/// Name of the mandatory cluster-size column written when clustering is
+/// enabled (tippecanoe / supercluster convention).
+pub const POINT_COUNT_COLUMN: &str = "point_count";
+
+/// Numeric aggregation operators for `--accumulate-attribute` (Q6).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccumulateOp {
+    /// Sum of the non-null values.
+    Sum,
+    /// Maximum of the non-null values.
+    Max,
+    /// Minimum of the non-null values.
+    Min,
+    /// Arithmetic mean of the non-null values (sum + count accumulated
+    /// internally; exact per level, never a mean of means).
+    Mean,
+}
+
+impl AccumulateOp {
+    /// Parse an operator name (case-insensitive): `sum`, `max`, `min`, `mean`.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "sum" => Some(Self::Sum),
+            "max" => Some(Self::Max),
+            "min" => Some(Self::Min),
+            "mean" => Some(Self::Mean),
+            _ => None,
+        }
+    }
+
+    /// Canonical lower-case name (footer provenance / display).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Sum => "sum",
+            Self::Max => "max",
+            Self::Min => "min",
+            Self::Mean => "mean",
+        }
+    }
+}
+
+/// One `--accumulate-attribute col:op` request.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AccumulateSpec {
+    /// Numeric source column whose values are aggregated across a cluster.
+    pub column: String,
+    /// Aggregation operator.
+    pub op: AccumulateOp,
+}
+
+/// A non-singleton cluster at one level: the winner's `point_count` and its
+/// finalized per-spec aggregates.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ClusterEntry {
+    /// Number of source features this row represents at the level (>= 2;
+    /// singleton winners are omitted from the table and default to 1).
+    pub point_count: i64,
+    /// Finalized aggregate per [`AccumulateSpec`], parallel to the spec list.
+    /// `None` = no non-null contributor; the winner's own (null) value stands.
+    pub aggregates: Vec<Option<f64>>,
+}
+
+/// Per-level cluster tables, parallel to `level_gsds`. Keyed by the winner's
+/// [`AssignFeature::index`]. Only non-singleton clusters are stored (memory is
+/// `O(actual clusters)`), and the canonical (finest) level's table is always
+/// empty: every cluster there is a singleton and rows pass through verbatim
+/// (spec §2.4 value-identity).
+pub type ClusterTables = Vec<HashMap<usize, ClusterEntry>>;
+
+/// Per-cluster running aggregate state for one [`AccumulateSpec`].
+#[derive(Debug, Clone, Copy)]
+struct AggState {
+    sum: f64,
+    min: f64,
+    max: f64,
+    /// Non-null contributors.
+    count: u64,
+}
+
+impl AggState {
+    fn new() -> Self {
+        Self {
+            sum: 0.0,
+            min: f64::INFINITY,
+            max: f64::NEG_INFINITY,
+            count: 0,
+        }
+    }
+
+    fn add(&mut self, v: f64) {
+        self.sum += v;
+        self.min = self.min.min(v);
+        self.max = self.max.max(v);
+        self.count += 1;
+    }
+
+    fn finalize(&self, op: AccumulateOp) -> Option<f64> {
+        if self.count == 0 {
+            return None;
+        }
+        Some(match op {
+            AccumulateOp::Sum => self.sum,
+            AccumulateOp::Max => self.max,
+            AccumulateOp::Min => self.min,
+            AccumulateOp::Mean => self.sum / self.count as f64,
+        })
+    }
+}
+
+/// Build the per-level cluster tables from the **final** level assignment.
+///
+/// - `features`: the exact inputs given to the assignment engine (any kinds;
+///   only [`FeatureKind::Point`] features participate in clustering).
+/// - `min_levels`: final per-feature coarsest level, parallel to `features`
+///   (after [`assign_levels`](super::assign::assign_levels) and any
+///   [`apply_density_budget`](super::assign::apply_density_budget)).
+/// - `level_gsds`: level GSDs in meters, coarse→fine, as used for assignment.
+/// - `config` / `crs`: the assignment configuration (point thinning factor
+///   drives the grid; sort direction drives the priority order).
+/// - `values`: per [`AccumulateSpec`], the per-feature source values
+///   (parallel to `features`; `None` = null).
+/// - `ops`: the operators, parallel to `values`.
+///
+/// Duplicating-mode semantics: a feature is *present* at level `L` iff
+/// `min_levels <= L`. Partitioning mode is not supported (see
+/// `ConvertError::ClusterPartitioningUnsupported`).
+pub fn build_cluster_tables(
+    features: &[AssignFeature],
+    min_levels: &[u8],
+    level_gsds: &[f64],
+    config: &AssignConfig,
+    crs: Crs,
+    values: &[Vec<Option<f64>>],
+    ops: &[AccumulateOp],
+) -> ClusterTables {
+    debug_assert_eq!(features.len(), min_levels.len());
+    debug_assert_eq!(values.len(), ops.len());
+
+    let num_levels = level_gsds.len();
+    let mut tables: ClusterTables = vec![HashMap::new(); num_levels];
+    if num_levels == 0 || features.is_empty() {
+        return tables;
+    }
+    let finest = num_levels - 1;
+
+    // Positions of the point features (the only clustering participants).
+    let point_pos: Vec<usize> = features
+        .iter()
+        .enumerate()
+        .filter(|(_, f)| f.kind == FeatureKind::Point)
+        .map(|(p, _)| p)
+        .collect();
+    if point_pos.is_empty() {
+        return tables;
+    }
+
+    let prio: Vec<Priority> = features
+        .iter()
+        .map(|f| Priority::new(f, config.sort_direction))
+        .collect();
+
+    // Non-canonical levels only: at the finest level every point is present,
+    // every cluster is a singleton, and rows pass through verbatim.
+    for level in 0..finest {
+        let cell_size = crs.meters_to_units(level_gsds[level]) * config.point_thinning;
+        if cell_size <= 0.0 || cell_size.is_nan() {
+            continue;
+        }
+        let cell = |pos: usize| -> (i64, i64) {
+            let (cx, cy) = features[pos].center();
+            (
+                (cx / cell_size).floor() as i64,
+                (cy / cell_size).floor() as i64,
+            )
+        };
+
+        // Best-priority PRESENT point feature per occupied grid cell.
+        let mut present: HashMap<(i64, i64), usize> = HashMap::new();
+        for &pos in &point_pos {
+            if min_levels[pos] as usize > level {
+                continue;
+            }
+            let key = cell(pos);
+            present
+                .entry(key)
+                .and_modify(|best| {
+                    if prio[pos].beats(&prio[*best]) {
+                        *best = pos;
+                    }
+                })
+                .or_insert(pos);
+        }
+        if present.is_empty() {
+            // No point row at this level at all (pathological: e.g. every
+            // point deferred in a mixed dataset): nothing to attach counts to.
+            continue;
+        }
+
+        // Representative per source point feature: itself if present, else the
+        // best present feature in its cell, else (orphan cell) resolved below.
+        let mut rep: Vec<usize> = Vec::with_capacity(point_pos.len());
+        let mut orphan_cells: HashMap<(i64, i64), Vec<usize>> = HashMap::new();
+        for &pos in &point_pos {
+            if min_levels[pos] as usize <= level {
+                rep.push(pos); // a present row always represents itself
+                continue;
+            }
+            let key = cell(pos);
+            match present.get(&key) {
+                Some(&w) => rep.push(w),
+                None => {
+                    orphan_cells.entry(key).or_default().push(pos);
+                    rep.push(usize::MAX); // patched after orphan resolution
+                }
+            }
+        }
+
+        // Resolve orphan cells (density-budget deferrals): nearest present
+        // feature by expanding ring search over the level grid, deterministic.
+        if !orphan_cells.is_empty() {
+            let mut orphan_keys: Vec<(i64, i64)> = orphan_cells.keys().copied().collect();
+            orphan_keys.sort_unstable();
+            let mut resolved: HashMap<(i64, i64), usize> = HashMap::new();
+            for key in orphan_keys {
+                let w = nearest_present(key, &present, features, &prio, cell_size);
+                resolved.insert(key, w);
+            }
+            for (i, &pos) in point_pos.iter().enumerate() {
+                if rep[i] == usize::MAX {
+                    rep[i] = resolved[&cell(pos)];
+                }
+            }
+        }
+
+        // Accumulate counts + aggregates per representative.
+        let mut acc: HashMap<usize, (i64, Vec<AggState>)> = HashMap::new();
+        for (i, &pos) in point_pos.iter().enumerate() {
+            let w = rep[i];
+            let entry = acc
+                .entry(w)
+                .or_insert_with(|| (0, vec![AggState::new(); ops.len()]));
+            entry.0 += 1;
+            for (s, vals) in values.iter().enumerate() {
+                if let Some(v) = vals[pos] {
+                    entry.1[s].add(v);
+                }
+            }
+        }
+
+        // Keep only non-singleton clusters (singletons pass through verbatim).
+        let table = &mut tables[level];
+        for (w, (count, states)) in acc {
+            if count <= 1 {
+                continue;
+            }
+            table.insert(
+                features[w].index,
+                ClusterEntry {
+                    point_count: count,
+                    aggregates: states
+                        .iter()
+                        .zip(ops)
+                        .map(|(st, &op)| st.finalize(op))
+                        .collect(),
+                },
+            );
+        }
+    }
+
+    tables
+}
+
+/// Deterministic nearest present point feature to the center of `cell_key`,
+/// searched over expanding Chebyshev rings of the level grid. Among the
+/// candidates of the first non-empty ring, the one with the smallest squared
+/// distance to the orphan cell's center wins; exact ties fall back to the
+/// cell-winner [`Priority`] order. `present` is non-empty (checked by caller),
+/// so the search terminates within the present cells' key bounds.
+fn nearest_present(
+    cell_key: (i64, i64),
+    present: &HashMap<(i64, i64), usize>,
+    features: &[AssignFeature],
+    prio: &[Priority],
+    cell_size: f64,
+) -> usize {
+    let center = (
+        (cell_key.0 as f64 + 0.5) * cell_size,
+        (cell_key.1 as f64 + 0.5) * cell_size,
+    );
+    let dist_sq = |pos: usize| -> f64 {
+        let (x, y) = features[pos].center();
+        let dx = x - center.0;
+        let dy = y - center.1;
+        dx * dx + dy * dy
+    };
+    let better = |a: usize, b: usize| -> bool {
+        let (da, db) = (dist_sq(a), dist_sq(b));
+        if da != db {
+            da < db
+        } else {
+            prio[a].beats(&prio[b])
+        }
+    };
+
+    // Maximum useful ring radius: the farthest present cell (Chebyshev).
+    let max_r = present
+        .keys()
+        .map(|&(x, y)| (x - cell_key.0).abs().max((y - cell_key.1).abs()))
+        .max()
+        .expect("present is non-empty");
+
+    let mut best: Option<usize> = None;
+    for r in 1..=max_r {
+        for (dx, dy) in ring_offsets(r) {
+            if let Some(&w) = present.get(&(cell_key.0 + dx, cell_key.1 + dy)) {
+                if best.map_or(true, |b| better(w, b)) {
+                    best = Some(w);
+                }
+            }
+        }
+        if let Some(b) = best {
+            // A feature in ring r can be nearer than one in ring r+1's cells,
+            // but never farther than ring r+2's; one extra ring guarantees the
+            // true nearest. Scan ring r+1 then stop.
+            let rr = r + 1;
+            if rr <= max_r {
+                for (dx, dy) in ring_offsets(rr) {
+                    if let Some(&w) = present.get(&(cell_key.0 + dx, cell_key.1 + dy)) {
+                        if better(w, b) {
+                            best = Some(w);
+                        }
+                    }
+                }
+            }
+            return best.expect("best set");
+        }
+    }
+    // Unreachable when present is non-empty and max_r bounds the search, but
+    // fall back to a global scan for absolute safety.
+    let mut all: Vec<usize> = present.values().copied().collect();
+    all.sort_unstable();
+    all.into_iter()
+        .reduce(|a, b| if better(b, a) { b } else { a })
+        .expect("present is non-empty")
+}
+
+/// The Chebyshev ring of radius `r` around the origin (the 8r cells whose
+/// max-coordinate distance is exactly `r`), in deterministic order.
+fn ring_offsets(r: i64) -> Vec<(i64, i64)> {
+    debug_assert!(r >= 1);
+    let mut out = Vec::with_capacity((8 * r) as usize);
+    for dx in -r..=r {
+        out.push((dx, -r));
+        out.push((dx, r));
+    }
+    for dy in (-r + 1)..r {
+        out.push((-r, dy));
+        out.push((r, dy));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::overview::assign::{assign_levels, SortDirection};
+
+    fn gsd(z: u32) -> f64 {
+        40_075_016.69 / 1024.0 / 2f64.powi(z as i32)
+    }
+
+    fn point(index: usize, x: f64, y: f64) -> AssignFeature {
+        AssignFeature {
+            index,
+            bbox: [x, y, x, y],
+            kind: FeatureKind::Point,
+            sort_key: None,
+        }
+    }
+
+    /// Sum of point_count over a level's PRESENT point rows (singletons = 1).
+    fn level_count_sum(
+        features: &[AssignFeature],
+        min_levels: &[u8],
+        table: &HashMap<usize, ClusterEntry>,
+        level: u8,
+    ) -> i64 {
+        features
+            .iter()
+            .zip(min_levels)
+            .filter(|(f, &ml)| f.kind == FeatureKind::Point && ml <= level)
+            .map(|(f, _)| table.get(&f.index).map_or(1, |e| e.point_count))
+            .sum()
+    }
+
+    #[test]
+    fn accumulate_op_parse_and_names() {
+        assert_eq!(AccumulateOp::parse("sum"), Some(AccumulateOp::Sum));
+        assert_eq!(AccumulateOp::parse("MAX"), Some(AccumulateOp::Max));
+        assert_eq!(AccumulateOp::parse("Min"), Some(AccumulateOp::Min));
+        assert_eq!(AccumulateOp::parse("mean"), Some(AccumulateOp::Mean));
+        assert_eq!(AccumulateOp::parse("median"), None);
+        assert_eq!(AccumulateOp::Mean.as_str(), "mean");
+    }
+
+    /// 10 points in 2 far-apart clumps (6 + 4) with one coarse level whose
+    /// point cell swallows each clump whole: the two winners get point_count
+    /// 6 and 4, and the canonical table is empty (all singletons).
+    #[test]
+    fn ten_points_two_cells_counts_six_and_four() {
+        // Level 0: gsd(2) ≈ 9784 m; point cell = 4·gsd ≈ 39 km. Clump A at
+        // origin (spread 1 km), clump B at x = 10_000 km.
+        let mut feats: Vec<AssignFeature> = Vec::new();
+        for i in 0..6 {
+            feats.push(point(i, i as f64 * 200.0, 0.0));
+        }
+        for j in 0..4 {
+            feats.push(point(6 + j, 1.0e7 + j as f64 * 200.0, 0.0));
+        }
+        let gsds = [gsd(2), gsd(10)];
+        let cfg = AssignConfig::default();
+        let assignment = assign_levels(&feats, &gsds, &cfg, Crs::Epsg3857);
+        let min_levels: Vec<u8> = assignment.assignments.iter().map(|a| a.min_level).collect();
+
+        let tables =
+            build_cluster_tables(&feats, &min_levels, &gsds, &cfg, Crs::Epsg3857, &[], &[]);
+        assert_eq!(tables.len(), 2);
+
+        // Exactly two present rows at level 0, with counts {6, 4}.
+        let present0: Vec<usize> = (0..feats.len()).filter(|&i| min_levels[i] == 0).collect();
+        assert_eq!(present0.len(), 2, "one winner per clump at level 0");
+        let mut counts: Vec<i64> = present0
+            .iter()
+            .map(|&i| tables[0].get(&feats[i].index).map_or(1, |e| e.point_count))
+            .collect();
+        counts.sort_unstable();
+        assert_eq!(counts, vec![4, 6]);
+
+        // Sum over level-0 point rows == total source point count.
+        assert_eq!(level_count_sum(&feats, &min_levels, &tables[0], 0), 10);
+        // Canonical table empty; per-row counts default to 1; sum still 10.
+        assert!(tables[1].is_empty(), "canonical level has no clusters");
+        assert_eq!(level_count_sum(&feats, &min_levels, &tables[1], 1), 10);
+    }
+
+    #[test]
+    fn aggregation_ops_including_nulls() {
+        // One cluster of 4 points at level 0 (all within one coarse cell).
+        // Values: 10, 30, null, 20 → sum 60, max 30, min 10, mean 20.
+        let feats: Vec<AssignFeature> = (0..4).map(|i| point(i, i as f64 * 100.0, 0.0)).collect();
+        let gsds = [gsd(2), gsd(10)];
+        let cfg = AssignConfig::default();
+        let assignment = assign_levels(&feats, &gsds, &cfg, Crs::Epsg3857);
+        let min_levels: Vec<u8> = assignment.assignments.iter().map(|a| a.min_level).collect();
+
+        let vals = vec![vec![Some(10.0), Some(30.0), None, Some(20.0)]; 4];
+        let ops = [
+            AccumulateOp::Sum,
+            AccumulateOp::Max,
+            AccumulateOp::Min,
+            AccumulateOp::Mean,
+        ];
+        let tables =
+            build_cluster_tables(&feats, &min_levels, &gsds, &cfg, Crs::Epsg3857, &vals, &ops);
+
+        assert_eq!(tables[0].len(), 1, "one cluster at level 0");
+        let entry = tables[0].values().next().unwrap();
+        assert_eq!(entry.point_count, 4);
+        assert_eq!(
+            entry.aggregates,
+            vec![Some(60.0), Some(30.0), Some(10.0), Some(20.0)]
+        );
+    }
+
+    #[test]
+    fn all_null_values_yield_none_aggregate() {
+        let feats: Vec<AssignFeature> = (0..3).map(|i| point(i, i as f64 * 100.0, 0.0)).collect();
+        let gsds = [gsd(2), gsd(10)];
+        let cfg = AssignConfig::default();
+        let assignment = assign_levels(&feats, &gsds, &cfg, Crs::Epsg3857);
+        let min_levels: Vec<u8> = assignment.assignments.iter().map(|a| a.min_level).collect();
+        let vals = vec![vec![None, None, None]];
+        let tables = build_cluster_tables(
+            &feats,
+            &min_levels,
+            &gsds,
+            &cfg,
+            Crs::Epsg3857,
+            &vals,
+            &[AccumulateOp::Sum],
+        );
+        let entry = tables[0].values().next().unwrap();
+        assert_eq!(entry.point_count, 3);
+        assert_eq!(entry.aggregates, vec![None]);
+    }
+
+    /// Mean is exact per level (computed from source values, not a mean of
+    /// per-cluster means): two sub-clusters of unequal size merging at the
+    /// coarse level must yield the true source mean, not the mean-of-means.
+    #[test]
+    fn mean_is_exact_across_levels_not_mean_of_means() {
+        // Level 1 grid (gsd(6)·4 ≈ 2446 m cells): clump A = 3 points (values
+        // 0,0,0) in one cell, clump B = 1 point (value 8) in a nearby cell.
+        // Level 0 grid (gsd(2)·4 ≈ 39 km): both clumps in ONE cell.
+        // True mean = 8/4 = 2. Mean of level-1 cluster means = (0+8)/2 = 4.
+        let mut feats = vec![
+            point(0, 0.0, 0.0),
+            point(1, 100.0, 0.0),
+            point(2, 200.0, 0.0),
+            point(3, 5000.0, 0.0), // separate level-1 cell, same level-0 cell
+        ];
+        // Make feature 3 the level-0 winner-independent: give 0 high priority
+        // via sort key so the level-0 winner is deterministic (id 0).
+        feats[0].sort_key = Some(1.0);
+        let gsds = [gsd(2), gsd(6), gsd(12)];
+        let cfg = AssignConfig::default();
+        let assignment = assign_levels(&feats, &gsds, &cfg, Crs::Epsg3857);
+        let min_levels: Vec<u8> = assignment.assignments.iter().map(|a| a.min_level).collect();
+
+        let vals = vec![vec![Some(0.0), Some(0.0), Some(0.0), Some(8.0)]];
+        let tables = build_cluster_tables(
+            &feats,
+            &min_levels,
+            &gsds,
+            &cfg,
+            Crs::Epsg3857,
+            &vals,
+            &[AccumulateOp::Mean],
+        );
+
+        // Level 0: a single 4-point cluster with the exact source mean 2.0.
+        let e0 = tables[0].get(&0).expect("feature 0 wins level 0");
+        assert_eq!(e0.point_count, 4);
+        assert_eq!(e0.aggregates, vec![Some(2.0)]);
+
+        // Level 1: clump A collapses to one 3-point cluster (mean 0); the
+        // clump-B point is its own singleton (absent from the table).
+        let sum1 = level_count_sum(&feats, &min_levels, &tables[1], 1);
+        assert_eq!(sum1, 4, "level-1 counts partition the source set");
+        let e1 = tables[1]
+            .values()
+            .find(|e| e.point_count == 3)
+            .expect("3-point cluster at level 1");
+        assert_eq!(e1.aggregates, vec![Some(0.0)]);
+    }
+
+    /// Per-level absorption: a feature absorbed at level 0 is a winner at
+    /// level 1 with its own (smaller) cluster — counts reflect each level's
+    /// grid independently and always partition the source set.
+    #[test]
+    fn per_level_absorption_partitions_at_every_level() {
+        // 12 points in 3 clumps 5 km apart: one level-0 cell (39 km) holds
+        // all; level-1 cells (2.4 km) separate the clumps.
+        let mut feats = Vec::new();
+        for c in 0..3 {
+            for i in 0..4 {
+                feats.push(point(c * 4 + i, c as f64 * 5000.0 + i as f64 * 50.0, 0.0));
+            }
+        }
+        let gsds = [gsd(2), gsd(6), gsd(12)];
+        let cfg = AssignConfig::default();
+        let assignment = assign_levels(&feats, &gsds, &cfg, Crs::Epsg3857);
+        let min_levels: Vec<u8> = assignment.assignments.iter().map(|a| a.min_level).collect();
+
+        let tables =
+            build_cluster_tables(&feats, &min_levels, &gsds, &cfg, Crs::Epsg3857, &[], &[]);
+
+        // Level 0: one winner holding all 12.
+        let l0_winners: Vec<usize> = (0..feats.len()).filter(|&i| min_levels[i] == 0).collect();
+        assert_eq!(l0_winners.len(), 1);
+        assert_eq!(tables[0][&l0_winners[0]].point_count, 12);
+
+        // Level 1: three present rows (one per clump), each holding 4 — the
+        // level-0 winner's count SHRINKS to its own clump at the finer grid.
+        assert_eq!(level_count_sum(&feats, &min_levels, &tables[1], 1), 12);
+        let present1: Vec<usize> = (0..feats.len()).filter(|&i| min_levels[i] <= 1).collect();
+        assert_eq!(present1.len(), 3, "one winner per clump at level 1");
+        for &w in &present1 {
+            assert_eq!(
+                tables[1].get(&w).map_or(1, |e| e.point_count),
+                4,
+                "each level-1 winner holds its own clump"
+            );
+        }
+
+        // Canonical: all singletons.
+        assert!(tables[2].is_empty());
+        assert_eq!(level_count_sum(&feats, &min_levels, &tables[2], 2), 12);
+    }
+
+    /// Orphan cells (budget-deferred winners) attach to the nearest present
+    /// feature; the per-level sum invariant survives.
+    #[test]
+    fn orphan_cell_attaches_to_nearest_present_winner() {
+        // Three points in three separate level-0 cells. Simulate a density
+        // budget having deferred point 1's cell winner: min_levels says only
+        // points 0 and 2 are present at level 0.
+        let cell = 4.0 * gsd(2); // level-0 point cell size in meters (3857)
+        let feats = vec![
+            point(0, 0.5 * cell, 0.0),
+            point(1, 1.5 * cell, 0.0), // orphan cell (deferred winner)
+            point(2, 4.5 * cell, 0.0),
+        ];
+        let min_levels = vec![0u8, 1, 0];
+        let gsds = [gsd(2), gsd(10)];
+        let cfg = AssignConfig::default();
+
+        let tables =
+            build_cluster_tables(&feats, &min_levels, &gsds, &cfg, Crs::Epsg3857, &[], &[]);
+
+        // Point 1 attaches to point 0 (1 cell away) not point 2 (3 cells).
+        assert_eq!(tables[0].get(&0).map(|e| e.point_count), Some(2));
+        assert!(!tables[0].contains_key(&2), "far winner stays a singleton");
+        assert_eq!(level_count_sum(&feats, &min_levels, &tables[0], 0), 3);
+    }
+
+    /// Lines/polygons never participate: no table entries, and point counts
+    /// ignore them entirely.
+    #[test]
+    fn non_point_features_are_ignored() {
+        let mut feats = vec![
+            point(0, 0.0, 0.0),
+            point(1, 100.0, 0.0),
+            AssignFeature {
+                index: 2,
+                bbox: [0.0, 0.0, 50_000.0, 50_000.0],
+                kind: FeatureKind::Polygon,
+                sort_key: None,
+            },
+            AssignFeature {
+                index: 3,
+                bbox: [0.0, 0.0, 60_000.0, 60_000.0],
+                kind: FeatureKind::Line,
+                sort_key: None,
+            },
+        ];
+        feats[0].sort_key = Some(1.0);
+        let gsds = [gsd(2), gsd(10)];
+        let cfg = AssignConfig::default();
+        let assignment = assign_levels(&feats, &gsds, &cfg, Crs::Epsg3857);
+        let min_levels: Vec<u8> = assignment.assignments.iter().map(|a| a.min_level).collect();
+
+        let tables =
+            build_cluster_tables(&feats, &min_levels, &gsds, &cfg, Crs::Epsg3857, &[], &[]);
+        // Only the two points cluster (into one 2-point cluster on feature 0).
+        assert_eq!(tables[0].len(), 1);
+        assert_eq!(tables[0].get(&0).map(|e| e.point_count), Some(2));
+        assert!(!tables[0].contains_key(&2));
+        assert!(!tables[0].contains_key(&3));
+    }
+
+    /// Winner priority alignment: the clustering representative in a cell is
+    /// the same feature the cell-winner stage picked (sort-key order).
+    #[test]
+    fn representative_matches_cell_winner_priority() {
+        let mut feats: Vec<AssignFeature> =
+            (0..5).map(|i| point(i, i as f64 * 10.0, 0.0)).collect();
+        feats[3].sort_key = Some(99.0); // highest priority wins the cell
+        let gsds = [gsd(2), gsd(10)];
+        let cfg = AssignConfig {
+            sort_direction: SortDirection::Desc,
+            ..Default::default()
+        };
+        let assignment = assign_levels(&feats, &gsds, &cfg, Crs::Epsg3857);
+        let min_levels: Vec<u8> = assignment.assignments.iter().map(|a| a.min_level).collect();
+        assert_eq!(min_levels[3], 0, "sort-key holder wins the coarse cell");
+
+        let tables =
+            build_cluster_tables(&feats, &min_levels, &gsds, &cfg, Crs::Epsg3857, &[], &[]);
+        assert_eq!(tables[0].get(&3).map(|e| e.point_count), Some(5));
+    }
+
+    #[test]
+    fn empty_inputs_and_no_points_are_noops() {
+        let gsds = [gsd(2), gsd(6)];
+        let cfg = AssignConfig::default();
+        let t = build_cluster_tables(&[], &[], &gsds, &cfg, Crs::Epsg3857, &[], &[]);
+        assert!(t.iter().all(|m| m.is_empty()));
+
+        let poly = AssignFeature {
+            index: 0,
+            bbox: [0.0, 0.0, 50_000.0, 50_000.0],
+            kind: FeatureKind::Polygon,
+            sort_key: None,
+        };
+        let t = build_cluster_tables(&[poly], &[0], &gsds, &cfg, Crs::Epsg3857, &[], &[]);
+        assert!(t.iter().all(|m| m.is_empty()));
+    }
+
+    #[test]
+    fn ring_offsets_cover_ring_exactly() {
+        for r in 1..=3i64 {
+            let ring = ring_offsets(r);
+            assert_eq!(ring.len() as i64, 8 * r);
+            assert!(ring.iter().all(|&(x, y)| x.abs().max(y.abs()) == r));
+            let mut sorted = ring.clone();
+            sorted.sort_unstable();
+            sorted.dedup();
+            assert_eq!(sorted.len(), ring.len(), "no duplicate cells");
+        }
+    }
+}

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -52,9 +52,10 @@ use super::assign::{
     apply_density_budget, assign_levels, AssignConfig, AssignFeature, DensityBudgetConfig,
     FeatureKind, SUPERCELL_GSD_FACTOR,
 };
+use super::cluster::{build_cluster_tables, AccumulateSpec, ClusterEntry, POINT_COUNT_COLUMN};
 use super::level::{
-    gsd_with_base, Crs, DensityProvenance, Generalization, GeneralizationLevel, Mode,
-    RankingProvenance, GSD_TILE_BASE,
+    gsd_with_base, AccumulatedColumn, ClusteringProvenance, Crs, DensityProvenance, Generalization,
+    GeneralizationLevel, Mode, RankingProvenance, GSD_TILE_BASE,
 };
 use super::simplify::{simplify_for_level, Simplified, SimplifyOptions};
 use super::writer::{LevelSpec, OverviewWriter, OverviewWriterOptions, WriterError, LEVEL_COLUMN};
@@ -281,6 +282,18 @@ pub struct ConvertOptions {
     /// overhead at the cost of proportionally more peak memory; smaller
     /// batches bound memory tighter. No effect when `streaming` is `false`.
     pub read_batch_size: usize,
+    /// Enable point clustering (plan Q4; opt-in per spec §11 Q4). Duplicating
+    /// mode only. When enabled, each level's point cell-winners absorb the
+    /// other point features in their cell: the output gains a `point_count`
+    /// INT64 NOT NULL column (1 at the canonical level) and the winner keeps
+    /// its own geometry and attributes (see [`super::cluster`]). Lines and
+    /// polygons are unaffected. Default `false`.
+    pub cluster: bool,
+    /// Numeric per-cluster attribute aggregation (Q6): for each spec, the
+    /// winner's value of the column becomes the aggregate over itself + the
+    /// absorbed features at that level. Requires [`cluster`](Self::cluster).
+    /// Empty by default.
+    pub accumulate: Vec<AccumulateSpec>,
 }
 
 /// Default rows per read batch for the streaming pipeline (H3).
@@ -306,6 +319,8 @@ impl Default for ConvertOptions {
             full_column_stats: false,
             streaming: true,
             read_batch_size: DEFAULT_READ_BATCH_SIZE,
+            cluster: false,
+            accumulate: Vec::new(),
         }
     }
 }
@@ -404,6 +419,44 @@ pub enum ConvertError {
     /// The level plan is invalid (empty / non-monotonic / bad zoom range).
     #[error("invalid level specification: {0}")]
     InvalidLevels(String),
+    /// `--cluster` was requested in partitioning mode. A partitioning row is
+    /// read at MANY display zooms (prefix reads, §2.3) but exists at exactly
+    /// one level, so a single stored `point_count` cannot reflect "that
+    /// level's grid" for every zoom it is displayed at — and absorbed
+    /// features reappear as their own rows at finer levels while remaining
+    /// counted in coarser winners, double-counting every prefix sum.
+    #[error(
+        "--cluster requires duplicating mode: a partitioning-mode feature has one \
+         row read across many zoom prefixes, so a per-level point_count cannot be \
+         represented without double counting"
+    )]
+    ClusterPartitioningUnsupported,
+    /// `--accumulate-attribute` was supplied without `--cluster`.
+    #[error("--accumulate-attribute requires --cluster")]
+    AccumulateWithoutCluster,
+    /// An `--accumulate-attribute` column is not present in the input schema.
+    #[error("accumulate-attribute column {name:?} not found in input schema")]
+    AccumulateColumnMissing {
+        /// The requested column name.
+        name: String,
+    },
+    /// An `--accumulate-attribute` column is not numeric.
+    #[error(
+        "accumulate-attribute column {name:?} is {data_type} but must be numeric \
+         (int/uint/float)"
+    )]
+    AccumulateColumnNotNumeric {
+        /// The requested column name.
+        name: String,
+        /// The actual Arrow data type found.
+        data_type: String,
+    },
+    /// The input already contains a `point_count` column (clustering enabled).
+    #[error(
+        "input already contains a '{POINT_COUNT_COLUMN}' column; rename it before \
+         converting with --cluster"
+    )]
+    PointCountColumnPresent,
     /// The input has no features, or every feature was dropped from every level.
     #[error("no output rows produced (empty input or all features dropped)")]
     NoData,
@@ -418,6 +471,16 @@ pub fn convert_to_overviews(
     output_path: impl AsRef<Path>,
     options: &ConvertOptions,
 ) -> Result<ConvertReport, ConvertError> {
+    // Clustering option sanity (Q4), shared by both pipelines: partitioning
+    // mode cannot represent per-level counts (see the error's rationale), and
+    // aggregation is meaningless without clustering.
+    if options.cluster && matches!(options.mode, Mode::Partitioning) {
+        return Err(ConvertError::ClusterPartitioningUnsupported);
+    }
+    if !options.accumulate.is_empty() && !options.cluster {
+        return Err(ConvertError::AccumulateWithoutCluster);
+    }
+
     // Two-pass bounded-memory pipeline (H3, default). The in-memory path below
     // is kept as the reference implementation (`streaming: false`).
     if options.streaming {
@@ -460,6 +523,9 @@ pub fn convert_to_overviews(
 
     let geom_idx = find_geometry_column(&input_schema).ok_or(ConvertError::NoGeometryColumn)?;
     let geom_field = input_schema.field(geom_idx).clone();
+
+    // Clustering schema checks + accumulate column resolution (Q4).
+    let acc_cols = validate_cluster_schema(&input_schema, options)?;
 
     let reader = builder.build()?;
     let mut batches: Vec<RecordBatch> = Vec::new();
@@ -516,9 +582,30 @@ pub fn convert_to_overviews(
     let num_levels = level_gsds.len();
     let finest = num_levels.saturating_sub(1);
 
+    // --- Cluster tables (Q4): per level, winner → point_count + aggregates. --
+    let cluster_tables = if options.cluster {
+        let min_levels: Vec<u8> = assignment.assignments.iter().map(|a| a.min_level).collect();
+        let acc_values = extract_accumulate_values(&full, &acc_cols);
+        let ops: Vec<_> = options.accumulate.iter().map(|s| s.op).collect();
+        Some(build_cluster_tables(
+            &features,
+            &min_levels,
+            &level_gsds,
+            &options.assign,
+            crs,
+            &acc_values,
+            &ops,
+        ))
+    } else {
+        None
+    };
+
     // --- Build per-level generalized selections (coarse→fine). ---------------
     // Each emitted entry: (spec, feature indices, geometries, vertex_count).
     struct EmittedLevel {
+        /// Index in the resolved level plan (cluster-table key; may differ
+        /// from the emitted index when empty levels are omitted, §7.3).
+        orig: usize,
         gsd: f64,
         zoom: Option<u8>,
         indices: Vec<usize>,
@@ -566,6 +653,7 @@ pub fn convert_to_overviews(
             continue;
         }
         emitted.push(EmittedLevel {
+            orig: level,
             gsd: gsd_m,
             zoom,
             indices,
@@ -585,6 +673,12 @@ pub fn convert_to_overviews(
     // same type so RecordBatch assembly matches.
     let geom_out_field = mixed_geometry_field(&geom_name);
     let source_schema = build_source_schema(&input_schema, geom_idx, geom_out_field.clone());
+    // Writer schema: base + point_count when clustering (Q4).
+    let out_schema = if options.cluster {
+        append_point_count_field(&source_schema)
+    } else {
+        source_schema.clone()
+    };
 
     let writer_levels: Vec<LevelSpec> = emitted
         .iter()
@@ -602,7 +696,7 @@ pub fn convert_to_overviews(
         ranking_provenance,
     ));
 
-    let mut writer = OverviewWriter::create(output_path, &source_schema, writer_opts)?;
+    let mut writer = OverviewWriter::create(output_path, &out_schema, writer_opts)?;
 
     // Column indices of the non-geometry source columns (preserve original order).
     let non_geom_cols: Vec<usize> = (0..input_schema.fields().len())
@@ -611,7 +705,7 @@ pub fn convert_to_overviews(
 
     let mut level_reports = Vec::with_capacity(emitted.len());
     for (level_idx, e) in emitted.iter().enumerate() {
-        let batch = build_level_batch(
+        let mut batch = build_level_batch(
             &source_schema,
             &full,
             &non_geom_cols,
@@ -619,6 +713,11 @@ pub fn convert_to_overviews(
             &e.indices,
             &e.geoms,
         )?;
+        if let Some(tables) = &cluster_tables {
+            // Canonical level: singleton clusters, columns verbatim (§2.4).
+            let table = (e.orig != finest).then(|| &tables[e.orig]);
+            batch = apply_cluster_columns(batch, &out_schema, &e.indices, table, &acc_cols)?;
+        }
         writer.write_level(level_idx, Some(e.indices.len()), std::iter::once(batch))?;
         level_reports.push(LevelReport {
             level: level_idx,
@@ -819,6 +918,193 @@ pub(super) fn build_level_batch(
     )?)
 }
 
+// ============================================================================
+// Clustering helpers (Q4) — shared by the in-memory and streaming pipelines
+// ============================================================================
+
+/// Validate the clustering-related schema constraints and resolve the
+/// accumulate columns to schema indices (parallel to `options.accumulate`).
+///
+/// Checks (clustering enabled only):
+/// - the input does not already carry a `point_count` column
+///   (case-insensitive, mirroring the `level` column rule §4.1);
+/// - every accumulate column exists and is numeric.
+pub(super) fn validate_cluster_schema(
+    schema: &Schema,
+    options: &ConvertOptions,
+) -> Result<Vec<usize>, ConvertError> {
+    if !options.cluster {
+        return Ok(Vec::new());
+    }
+    if schema
+        .fields()
+        .iter()
+        .any(|f| f.name().eq_ignore_ascii_case(POINT_COUNT_COLUMN))
+    {
+        return Err(ConvertError::PointCountColumnPresent);
+    }
+    let mut indices = Vec::with_capacity(options.accumulate.len());
+    for spec in &options.accumulate {
+        let idx =
+            schema
+                .index_of(&spec.column)
+                .map_err(|_| ConvertError::AccumulateColumnMissing {
+                    name: spec.column.clone(),
+                })?;
+        let dt = schema.field(idx).data_type();
+        if !is_numeric_type(dt) {
+            return Err(ConvertError::AccumulateColumnNotNumeric {
+                name: spec.column.clone(),
+                data_type: format!("{dt:?}"),
+            });
+        }
+        indices.push(idx);
+    }
+    Ok(indices)
+}
+
+/// Whether an Arrow type is accepted by `--accumulate-attribute`.
+fn is_numeric_type(dt: &DataType) -> bool {
+    matches!(
+        dt,
+        DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64
+            | DataType::Float32
+            | DataType::Float64
+    )
+}
+
+/// The writer source schema with the trailing `point_count` INT64 NOT NULL
+/// column appended (clustering enabled).
+pub(super) fn append_point_count_field(schema: &Schema) -> Schema {
+    let mut fields: Vec<Arc<Field>> = schema.fields().iter().cloned().collect();
+    fields.push(Arc::new(Field::new(
+        POINT_COUNT_COLUMN,
+        DataType::Int64,
+        false,
+    )));
+    Schema::new(fields)
+}
+
+/// Per-feature accumulate values (one vector per spec, parallel to the rows),
+/// extracted from the resolved column indices of a batch-shaped table.
+pub(super) fn extract_accumulate_values(
+    batch: &RecordBatch,
+    acc_col_indices: &[usize],
+) -> Vec<Vec<Option<f64>>> {
+    acc_col_indices
+        .iter()
+        .map(|&idx| extract_sort_keys(batch.column(idx).as_ref()))
+        .collect()
+}
+
+/// Append the `point_count` column to a level batch and overwrite the
+/// accumulate columns for clustered rows (Q4).
+///
+/// - `batch`: the level batch built by [`build_level_batch`] (base schema).
+/// - `out_schema`: base schema + trailing `point_count` field.
+/// - `global_indices`: per batch row, the source-row index used as the
+///   cluster-table key.
+/// - `table`: the level's cluster table; `None` at the canonical level (all
+///   singletons — every column passes through verbatim, count = 1).
+/// - `acc_cols`: schema indices of the accumulate columns (parallel to the
+///   aggregates in each [`ClusterEntry`]).
+///
+/// Singleton rows (absent from the table) keep every source value; only
+/// non-singleton winners have `point_count > 1` and rewritten aggregates.
+/// Aggregates are computed in `f64`; written back in the column's original
+/// type (integer columns round to nearest — relevant for `mean`).
+pub(super) fn apply_cluster_columns(
+    batch: RecordBatch,
+    out_schema: &Schema,
+    global_indices: &[usize],
+    table: Option<&HashMap<usize, ClusterEntry>>,
+    acc_cols: &[usize],
+) -> Result<RecordBatch, ConvertError> {
+    use arrow_array::Int64Array;
+
+    debug_assert_eq!(batch.num_rows(), global_indices.len());
+    let mut columns: Vec<Arc<dyn Array>> = batch.columns().to_vec();
+
+    // Overwrite accumulate columns for clustered rows.
+    if let Some(table) = table {
+        for (s, &col_idx) in acc_cols.iter().enumerate() {
+            let overrides: Vec<Option<f64>> = global_indices
+                .iter()
+                .map(|g| table.get(g).and_then(|e| e.aggregates[s]))
+                .collect();
+            if overrides.iter().any(|o| o.is_some()) {
+                columns[col_idx] = overwrite_numeric_column(&columns[col_idx], &overrides)?;
+            }
+        }
+    }
+
+    // Append point_count (1 for singletons / non-points / canonical rows).
+    let counts: Vec<i64> = global_indices
+        .iter()
+        .map(|g| table.and_then(|t| t.get(g)).map_or(1, |e| e.point_count))
+        .collect();
+    columns.push(Arc::new(Int64Array::from(counts)));
+
+    Ok(RecordBatch::try_new(Arc::new(out_schema.clone()), columns)?)
+}
+
+/// Rebuild a numeric column with per-row override values (`None` keeps the
+/// original value, including its nullness). Aggregates arrive as `f64`;
+/// integer columns round to nearest.
+fn overwrite_numeric_column(
+    col: &Arc<dyn Array>,
+    overrides: &[Option<f64>],
+) -> Result<Arc<dyn Array>, ConvertError> {
+    use arrow_array::cast::AsArray;
+    use arrow_array::types::{
+        Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type,
+        UInt32Type, UInt64Type, UInt8Type,
+    };
+    use arrow_array::PrimitiveArray;
+
+    macro_rules! rebuild {
+        ($ty:ty, $cast:expr) => {{
+            let a = col.as_primitive::<$ty>();
+            let rebuilt: PrimitiveArray<$ty> = (0..a.len())
+                .map(|i| match overrides[i] {
+                    Some(v) => Some($cast(v)),
+                    None => {
+                        if a.is_null(i) {
+                            None
+                        } else {
+                            Some(a.value(i))
+                        }
+                    }
+                })
+                .collect();
+            Ok(Arc::new(rebuilt))
+        }};
+    }
+    match col.data_type() {
+        DataType::Int8 => rebuild!(Int8Type, |v: f64| v.round() as i8),
+        DataType::Int16 => rebuild!(Int16Type, |v: f64| v.round() as i16),
+        DataType::Int32 => rebuild!(Int32Type, |v: f64| v.round() as i32),
+        DataType::Int64 => rebuild!(Int64Type, |v: f64| v.round() as i64),
+        DataType::UInt8 => rebuild!(UInt8Type, |v: f64| v.round() as u8),
+        DataType::UInt16 => rebuild!(UInt16Type, |v: f64| v.round() as u16),
+        DataType::UInt32 => rebuild!(UInt32Type, |v: f64| v.round() as u32),
+        DataType::UInt64 => rebuild!(UInt64Type, |v: f64| v.round() as u64),
+        DataType::Float32 => rebuild!(Float32Type, |v: f64| v as f32),
+        DataType::Float64 => rebuild!(Float64Type, |v: f64| v),
+        other => Err(ConvertError::AccumulateColumnNotNumeric {
+            name: "<accumulate column>".to_string(),
+            data_type: format!("{other:?}"),
+        }),
+    }
+}
+
 /// Build informative generalization provenance (§3.5) from the emitted gsds.
 pub(super) fn build_generalization(
     gsds: &[f64],
@@ -857,6 +1143,24 @@ pub(super) fn build_generalization(
                 drop_rate: options.density.drop_rate,
                 gamma: options.density.gamma,
                 supercell_gsd_factor: SUPERCELL_GSD_FACTOR,
+            })
+        } else {
+            None
+        },
+        // Recorded only when clustering was applied; a non-clustered run emits
+        // a byte-identical footer to before this feature existed.
+        clustering: if options.cluster {
+            Some(ClusteringProvenance {
+                enabled: true,
+                point_count_column: POINT_COUNT_COLUMN.to_string(),
+                accumulated: options
+                    .accumulate
+                    .iter()
+                    .map(|s| AccumulatedColumn {
+                        column: s.column.clone(),
+                        op: s.op.as_str().to_string(),
+                    })
+                    .collect(),
             })
         } else {
             None
@@ -2225,6 +2529,393 @@ mod tests {
         let mr = OverviewReader::open(mem_out.path()).unwrap();
         let sr = OverviewReader::open(stream_out.path()).unwrap();
         assert_eq!(min_level_by_id(&mr), min_level_by_id(&sr));
+    }
+
+    // --- Q4 point clustering -------------------------------------------------
+
+    /// Read the `point_count` column for one level, in row order.
+    fn read_point_counts(reader: &OverviewReader, level: usize) -> Vec<i64> {
+        use arrow_array::cast::AsArray;
+        use arrow_array::types::Int64Type;
+        let rdr = reader.read_level(level, None).unwrap();
+        let mut out = Vec::new();
+        for batch in rdr {
+            let batch = batch.unwrap();
+            let idx = batch.schema().index_of("point_count").unwrap();
+            let col = batch.column(idx).as_primitive::<Int64Type>().clone();
+            assert_eq!(col.null_count(), 0, "point_count must be NOT NULL");
+            out.extend(col.values().iter().copied());
+        }
+        out
+    }
+
+    /// Read a Float64 column for one level, in row order (None = null).
+    fn read_f64_column(reader: &OverviewReader, level: usize, name: &str) -> Vec<Option<f64>> {
+        use arrow_array::cast::AsArray;
+        use arrow_array::types::Float64Type;
+        let rdr = reader.read_level(level, None).unwrap();
+        let mut out = Vec::new();
+        for batch in rdr {
+            let batch = batch.unwrap();
+            let idx = batch.schema().index_of(name).unwrap();
+            let col = batch.column(idx).as_primitive::<Float64Type>().clone();
+            for i in 0..col.len() {
+                out.push(if col.is_null(i) {
+                    None
+                } else {
+                    Some(col.value(i))
+                });
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn cluster_duplicating_end_to_end_counts_partition_every_level() {
+        // 600 grid points, clustering on: every level's point_count sums to
+        // the source count, canonical counts are all 1, file validates.
+        let geoms = grid_points(600);
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        write_input(tin.path(), &geoms, false, None);
+
+        let opts = ConvertOptions {
+            levels: LevelPlan::ZoomRange {
+                min_zoom: 0,
+                max_zoom: 8,
+            },
+            cluster: true,
+            ..Default::default()
+        };
+        let report = convert_to_overviews(tin.path(), tout.path(), &opts).unwrap();
+        let vr = validate_file(tout.path()).unwrap();
+        assert!(
+            vr.is_valid(),
+            "failures: {:?}",
+            vr.failures().collect::<Vec<_>>()
+        );
+
+        let reader = OverviewReader::open(tout.path()).unwrap();
+        let canonical = reader.num_levels() - 1;
+        for level in 0..reader.num_levels() {
+            let counts = read_point_counts(&reader, level);
+            assert!(counts.iter().all(|&c| c >= 1), "level {level} counts >= 1");
+            assert_eq!(
+                counts.iter().sum::<i64>(),
+                geoms.len() as i64,
+                "level {level}: sum(point_count) must equal source count"
+            );
+        }
+        // Canonical: every cluster is a singleton.
+        assert!(read_point_counts(&reader, canonical)
+            .iter()
+            .all(|&c| c == 1));
+        // Density budget bites mid-levels: some coarse level must actually
+        // cluster (a count > 1), or this test tests nothing.
+        let coarse = read_point_counts(&reader, 0);
+        assert!(coarse.iter().any(|&c| c > 1), "no clustering happened");
+        assert!(coarse.len() < geoms.len());
+        assert_eq!(report.levels.last().unwrap().feature_count, geoms.len());
+    }
+
+    #[test]
+    fn cluster_accumulate_sum_and_mean_consistent() {
+        // The `rank` column (Float64, values n..1) accumulated as sum: every
+        // level's Σ rank over rows must equal the source Σ (clusters
+        // partition the source set and sum is additive). Canonical stays
+        // verbatim.
+        let geoms = grid_points(400);
+        let n = geoms.len();
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        write_input(tin.path(), &geoms, false, None);
+        let source_sum: f64 = (1..=n).map(|v| v as f64).sum();
+
+        // sum
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        let opts = ConvertOptions {
+            levels: LevelPlan::ZoomRange {
+                min_zoom: 0,
+                max_zoom: 8,
+            },
+            cluster: true,
+            accumulate: vec![AccumulateSpec {
+                column: "rank".to_string(),
+                op: super::super::cluster::AccumulateOp::Sum,
+            }],
+            ..Default::default()
+        };
+        convert_to_overviews(tin.path(), tout.path(), &opts).unwrap();
+        let reader = OverviewReader::open(tout.path()).unwrap();
+        for level in 0..reader.num_levels() {
+            let ranks = read_f64_column(&reader, level, "rank");
+            let total: f64 = ranks.iter().flatten().sum();
+            assert!(
+                (total - source_sum).abs() < 1e-6,
+                "level {level}: rank sum {total} != source {source_sum}"
+            );
+        }
+        // Canonical: verbatim source values (id i has rank n - i).
+        let canonical = reader.num_levels() - 1;
+        let rows = read_level_rows(&reader, canonical);
+        for (id, _, rank, _) in rows {
+            assert_eq!(rank, (n as i64 - id) as f64, "canonical rank verbatim");
+        }
+
+        // mean: Σ (mean_i × point_count_i) must reproduce the source sum at
+        // every level (mean computed from source values, not mean-of-means).
+        let tout2 = tempfile::NamedTempFile::new().unwrap();
+        let opts_mean = ConvertOptions {
+            accumulate: vec![AccumulateSpec {
+                column: "rank".to_string(),
+                op: super::super::cluster::AccumulateOp::Mean,
+            }],
+            ..opts.clone()
+        };
+        convert_to_overviews(tin.path(), tout2.path(), &opts_mean).unwrap();
+        let reader2 = OverviewReader::open(tout2.path()).unwrap();
+        for level in 0..reader2.num_levels() {
+            let means = read_f64_column(&reader2, level, "rank");
+            let counts = read_point_counts(&reader2, level);
+            let total: f64 = means
+                .iter()
+                .zip(&counts)
+                .map(|(m, &c)| m.unwrap() * c as f64)
+                .sum();
+            assert!(
+                (total - source_sum).abs() < 1e-6,
+                "level {level}: Σ mean×count {total} != source {source_sum}"
+            );
+        }
+    }
+
+    #[test]
+    fn cluster_footer_provenance_recorded() {
+        let geoms = grid_points(100);
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        write_input(tin.path(), &geoms, false, None);
+
+        let opts = ConvertOptions {
+            cluster: true,
+            accumulate: vec![AccumulateSpec {
+                column: "rank".to_string(),
+                op: super::super::cluster::AccumulateOp::Mean,
+            }],
+            ..Default::default()
+        };
+        convert_to_overviews(tin.path(), tout.path(), &opts).unwrap();
+        let reader = OverviewReader::open(tout.path()).unwrap();
+        let c = reader
+            .meta()
+            .generalization
+            .as_ref()
+            .unwrap()
+            .clustering
+            .clone()
+            .expect("clustering provenance recorded");
+        assert!(c.enabled);
+        assert_eq!(c.point_count_column, "point_count");
+        assert_eq!(c.accumulated.len(), 1);
+        assert_eq!(c.accumulated[0].column, "rank");
+        assert_eq!(c.accumulated[0].op, "mean");
+
+        // Off by default: no clustering block, no point_count column.
+        let tout_off = tempfile::NamedTempFile::new().unwrap();
+        convert_to_overviews(tin.path(), tout_off.path(), &ConvertOptions::default()).unwrap();
+        let r_off = OverviewReader::open(tout_off.path()).unwrap();
+        assert!(r_off
+            .meta()
+            .generalization
+            .as_ref()
+            .unwrap()
+            .clustering
+            .is_none());
+    }
+
+    #[test]
+    fn cluster_option_errors() {
+        let geoms = grid_points(20);
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        write_input(tin.path(), &geoms, false, None);
+
+        // Partitioning + cluster is rejected.
+        let err = convert_to_overviews(
+            tin.path(),
+            tout.path(),
+            &ConvertOptions {
+                mode: Mode::Partitioning,
+                cluster: true,
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(err, ConvertError::ClusterPartitioningUnsupported));
+
+        // Accumulate without cluster is rejected.
+        let err = convert_to_overviews(
+            tin.path(),
+            tout.path(),
+            &ConvertOptions {
+                accumulate: vec![AccumulateSpec {
+                    column: "rank".to_string(),
+                    op: super::super::cluster::AccumulateOp::Sum,
+                }],
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(err, ConvertError::AccumulateWithoutCluster));
+
+        // Missing accumulate column is rejected (both pipelines).
+        for streaming in [true, false] {
+            let err = convert_to_overviews(
+                tin.path(),
+                tout.path(),
+                &ConvertOptions {
+                    cluster: true,
+                    streaming,
+                    accumulate: vec![AccumulateSpec {
+                        column: "nonexistent".to_string(),
+                        op: super::super::cluster::AccumulateOp::Sum,
+                    }],
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+            assert!(
+                matches!(err, ConvertError::AccumulateColumnMissing { .. }),
+                "streaming={streaming}: got {err:?}"
+            );
+        }
+
+        // Non-numeric accumulate column is rejected.
+        let err = convert_to_overviews(
+            tin.path(),
+            tout.path(),
+            &ConvertOptions {
+                cluster: true,
+                accumulate: vec![AccumulateSpec {
+                    column: "name".to_string(),
+                    op: super::super::cluster::AccumulateOp::Max,
+                }],
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            ConvertError::AccumulateColumnNotNumeric { .. }
+        ));
+    }
+
+    #[test]
+    fn cluster_rejects_existing_point_count_column() {
+        // An input already carrying a `point_count` column is rejected when
+        // clustering (case-insensitively), but accepted when clustering is off.
+        let geoms = grid_points(10);
+        let n = geoms.len();
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        {
+            let id = Int64Array::from((0..n as i64).collect::<Vec<_>>());
+            let pc = Int64Array::from(vec![7i64; n]);
+            let geom_arr = build_geometry_array(&geoms);
+            let geom_field = geom_arr.data_type().to_field("geometry", true);
+            let fields = vec![
+                Arc::new(Field::new("id", DataType::Int64, false)),
+                Arc::new(Field::new("Point_Count", DataType::Int64, false)),
+                Arc::new(geom_field),
+            ];
+            let columns: Vec<Arc<dyn Array>> =
+                vec![Arc::new(id), Arc::new(pc), geom_arr.to_array_ref()];
+            let schema = Arc::new(Schema::new(fields));
+            let batch = RecordBatch::try_new(schema.clone(), columns).unwrap();
+            let gpq_options = GeoParquetWriterOptionsBuilder::default()
+                .set_encoding(GeoParquetWriterEncoding::WKB)
+                .set_generate_covering(true)
+                .build();
+            let mut encoder = GeoParquetRecordBatchEncoder::try_new(&schema, &gpq_options).unwrap();
+            let target_schema = encoder.target_schema();
+            let file = std::fs::File::create(tin.path()).unwrap();
+            let mut writer = ArrowWriter::try_new(file, target_schema, None).unwrap();
+            writer
+                .write(&encoder.encode_record_batch(&batch).unwrap())
+                .unwrap();
+            writer.append_key_value_metadata(encoder.into_keyvalue().unwrap());
+            writer.close().unwrap();
+        }
+
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        let err = convert_to_overviews(
+            tin.path(),
+            tout.path(),
+            &ConvertOptions {
+                cluster: true,
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(err, ConvertError::PointCountColumnPresent));
+
+        // Without clustering the column is an ordinary property.
+        convert_to_overviews(tin.path(), tout.path(), &ConvertOptions::default()).unwrap();
+    }
+
+    #[test]
+    fn streaming_matches_in_memory_clustering() {
+        // Clustering + accumulation must be byte-equivalent between the
+        // streaming and in-memory pipelines, including with tiny read batches
+        // and the density budget's orphan-cell handling.
+        let geoms = grid_points(600);
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        write_input(tin.path(), &geoms, false, None);
+
+        let base = ConvertOptions {
+            levels: LevelPlan::ZoomRange {
+                min_zoom: 0,
+                max_zoom: 8,
+            },
+            read_batch_size: 7,
+            cluster: true,
+            accumulate: vec![
+                AccumulateSpec {
+                    column: "rank".to_string(),
+                    op: super::super::cluster::AccumulateOp::Sum,
+                },
+                AccumulateSpec {
+                    column: "rank".to_string(),
+                    op: super::super::cluster::AccumulateOp::Mean,
+                },
+            ],
+            ..Default::default()
+        };
+        // NOTE: two specs on one column — the LAST rewrite wins per column;
+        // exercised here purely for pipeline equivalence.
+        assert_streaming_equivalent(tin.path(), &base);
+
+        // Explicitly compare point_count per level too (read_level_rows in
+        // the shared helper does not include it).
+        let mem_out = tempfile::NamedTempFile::new().unwrap();
+        let stream_out = tempfile::NamedTempFile::new().unwrap();
+        convert_to_overviews(
+            tin.path(),
+            mem_out.path(),
+            &ConvertOptions {
+                streaming: false,
+                ..base.clone()
+            },
+        )
+        .unwrap();
+        convert_to_overviews(tin.path(), stream_out.path(), &base).unwrap();
+        let mr = OverviewReader::open(mem_out.path()).unwrap();
+        let sr = OverviewReader::open(stream_out.path()).unwrap();
+        for level in 0..mr.num_levels() {
+            assert_eq!(
+                read_point_counts(&mr, level),
+                read_point_counts(&sr, level),
+                "level {level} point_count differs"
+            );
+        }
     }
 
     #[test]

--- a/crates/core/src/overview/level.rs
+++ b/crates/core/src/overview/level.rs
@@ -142,6 +142,41 @@ pub struct Generalization {
     /// this field existed; readers MUST tolerate its absence.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub density_drop: Option<DensityProvenance>,
+    /// OPTIONAL point-clustering provenance (§3.5, additive; spec §12 draft).
+    ///
+    /// Records that clustering was enabled (Q4): the name of the cluster-size
+    /// column (`point_count`) and any accumulated attribute columns. Absent
+    /// when clustering was off (`--cluster` not passed) or on files written
+    /// before this field existed; readers MUST tolerate its absence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub clustering: Option<ClusteringProvenance>,
+}
+
+/// How point clustering was applied for a conversion (Q4, spec §12 draft).
+///
+/// Additive, OPTIONAL provenance embedded in [`Generalization`] (§3.5).
+/// When present with `enabled: true`, the file carries the named
+/// `point_count` column (INT64 NOT NULL) and the listed accumulated columns;
+/// the validator checks those structural facts.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ClusteringProvenance {
+    /// Whether clustering was applied. Always `true` when the block is
+    /// emitted; present for forward compatibility.
+    pub enabled: bool,
+    /// Name of the cluster-size column (this implementation: `point_count`).
+    pub point_count_column: String,
+    /// Columns whose values were aggregated across clustered points.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub accumulated: Vec<AccumulatedColumn>,
+}
+
+/// One accumulated attribute column in [`ClusteringProvenance`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AccumulatedColumn {
+    /// Source column name.
+    pub column: String,
+    /// Aggregation operator: `sum`, `max`, `min`, or `mean`.
+    pub op: String,
 }
 
 /// How the per-level density budget was applied for a conversion (Q2).
@@ -793,6 +828,7 @@ mod tests {
                 unknown_rank: Some(0.0),
             }),
             density_drop: None,
+            clustering: None,
         });
         let json = meta.to_json().unwrap();
         let parsed = OverviewsMeta::from_json(&json).unwrap();
@@ -819,6 +855,7 @@ mod tests {
                 gamma: 1.5,
                 supercell_gsd_factor: 128.0,
             }),
+            clustering: None,
         });
         let json = meta.to_json().unwrap();
         let parsed = OverviewsMeta::from_json(&json).unwrap();
@@ -839,6 +876,46 @@ mod tests {
         }"#;
         let m = OverviewsMeta::from_json(src).unwrap();
         assert!(m.generalization.unwrap().density_drop.is_none());
+    }
+
+    #[test]
+    fn clustering_provenance_roundtrip_and_absent_tolerated() {
+        // A clustering block survives JSON round-trip; absent key → None.
+        let mut meta = duplicating_example();
+        meta.generalization = Some(Generalization {
+            engine: "gpq-tiles test".to_string(),
+            gsd_base: None,
+            levels: vec![],
+            ranking: None,
+            density_drop: None,
+            clustering: Some(ClusteringProvenance {
+                enabled: true,
+                point_count_column: "point_count".to_string(),
+                accumulated: vec![AccumulatedColumn {
+                    column: "confidence".to_string(),
+                    op: "mean".to_string(),
+                }],
+            }),
+        });
+        let json = meta.to_json().unwrap();
+        let parsed = OverviewsMeta::from_json(&json).unwrap();
+        assert_eq!(meta, parsed);
+        let c = parsed.generalization.unwrap().clustering.unwrap();
+        assert!(c.enabled);
+        assert_eq!(c.point_count_column, "point_count");
+        assert_eq!(c.accumulated.len(), 1);
+        assert_eq!(c.accumulated[0].column, "confidence");
+        assert_eq!(c.accumulated[0].op, "mean");
+
+        // Absent key → None (additive-field tolerance); empty accumulated
+        // list is omitted from serialization.
+        let src = r#"{
+            "version": "0.1.0", "mode": "duplicating", "canonical_level": 0,
+            "levels": [ { "row_group_end": 0, "gsd": 611.50, "zoom": 6 } ],
+            "generalization": { "engine": "gpq-tiles 0.1.0", "levels": [] }
+        }"#;
+        let m = OverviewsMeta::from_json(src).unwrap();
+        assert!(m.generalization.unwrap().clustering.is_none());
     }
 
     #[test]

--- a/crates/core/src/overview/mod.rs
+++ b/crates/core/src/overview/mod.rs
@@ -10,6 +10,7 @@
 
 pub mod assign;
 pub mod check;
+pub mod cluster;
 pub mod convert;
 pub mod export;
 pub mod level;

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -62,12 +62,14 @@ use rayon::prelude::*;
 use crate::batch_processor::extract_geometries_from_array;
 
 use super::assign::{apply_density_budget, assign_levels, AssignFeature, FeatureKind};
+use super::cluster::{build_cluster_tables, ClusterEntry, ClusterTables};
 use super::convert::{
-    build_generalization, build_level_batch, build_source_schema, class_ranking_provenance,
-    count_vertices, detect_crs, extract_class_ranks, extract_sort_keys, feature_kind,
-    fill_level_bytes, find_geometry_column, geometry_bbox, mixed_geometry_field,
-    overture_road_ranking, ClassRanking, ConvertError, ConvertOptions, ConvertReport, LevelReport,
-    KNOWN_ROAD_CLASSES, ROAD_VOCAB_MIN_DISTINCT,
+    append_point_count_field, apply_cluster_columns, build_generalization, build_level_batch,
+    build_source_schema, class_ranking_provenance, count_vertices, detect_crs, extract_class_ranks,
+    extract_sort_keys, feature_kind, fill_level_bytes, find_geometry_column, geometry_bbox,
+    mixed_geometry_field, overture_road_ranking, validate_cluster_schema, ClassRanking,
+    ConvertError, ConvertOptions, ConvertReport, LevelReport, KNOWN_ROAD_CLASSES,
+    ROAD_VOCAB_MIN_DISTINCT,
 };
 use super::level::{Crs, Mode, RankingProvenance};
 use super::simplify::{
@@ -117,10 +119,13 @@ pub(super) fn convert_streaming(
     let geom_idx = find_geometry_column(&input_schema).ok_or(ConvertError::NoGeometryColumn)?;
     let geom_field = input_schema.field(geom_idx).clone();
 
+    // Clustering schema checks + accumulate column resolution (Q4).
+    let acc_cols = validate_cluster_schema(&input_schema, options)?;
+
     // --- Pass 1: stream → AssignFeatures + resolved ranking. -----------------
     let t_pass1 = Instant::now();
-    let (mut features, ranking_provenance) =
-        run_pass1(input_path, &input_schema, geom_idx, options)?;
+    let (mut features, ranking_provenance, acc_values) =
+        run_pass1(input_path, &input_schema, geom_idx, options, &acc_cols)?;
     let num_features = features.len();
     log::debug!(
         "[profile] pass1 stream+scan: {:.2}s",
@@ -154,6 +159,25 @@ pub(super) fn convert_streaming(
     // 1 byte per feature — the only O(N) state carried into pass 2.
     let min_levels: Vec<u8> = assignment.assignments.iter().map(|a| a.min_level).collect();
     drop(assignment);
+
+    // Cluster tables (Q4): built from the pass-1 features + final winner
+    // table, before the O(N) scratch is freed. Memory afterwards is
+    // O(non-singleton clusters), carried into pass 2 alongside `min_levels`.
+    let cluster_tables: Option<ClusterTables> = if options.cluster {
+        let ops: Vec<_> = options.accumulate.iter().map(|s| s.op).collect();
+        Some(build_cluster_tables(
+            &features,
+            &min_levels,
+            &level_gsds,
+            &options.assign,
+            crs,
+            &acc_values,
+            &ops,
+        ))
+    } else {
+        None
+    };
+    drop(acc_values);
     features.clear();
     features.shrink_to_fit(); // free the pass-1 O(N)·48B scratch before pass 2
 
@@ -197,6 +221,12 @@ pub(super) fn convert_streaming(
     let geom_name = geom_field.name().clone();
     let geom_out_field = mixed_geometry_field(&geom_name);
     let source_schema = build_source_schema(&input_schema, geom_idx, geom_out_field);
+    // Writer schema: base + point_count when clustering (Q4).
+    let out_schema = if options.cluster {
+        append_point_count_field(&source_schema)
+    } else {
+        source_schema.clone()
+    };
 
     let writer_levels: Vec<LevelSpec> = emitted
         .iter()
@@ -214,7 +244,7 @@ pub(super) fn convert_streaming(
         ranking_provenance,
     ));
 
-    let mut writer = OverviewWriter::create(output_path, &source_schema, writer_opts)?;
+    let mut writer = OverviewWriter::create(output_path, &out_schema, writer_opts)?;
 
     let non_geom_cols: Vec<usize> = (0..input_schema.fields().len())
         .filter(|&c| c != geom_idx)
@@ -229,6 +259,7 @@ pub(super) fn convert_streaming(
         let verbatim = matches!(options.mode, Mode::Partitioning) || e.orig as usize == finest;
         let ctx = LevelStreamCtx {
             source_schema: &source_schema,
+            out_schema: &out_schema,
             non_geom_cols: &non_geom_cols,
             geom_idx,
             min_levels: &min_levels,
@@ -238,6 +269,13 @@ pub(super) fn convert_streaming(
             gsd_m: e.gsd,
             crs,
             simplify: &options.simplify,
+            cluster_enabled: options.cluster,
+            // Canonical level: singleton clusters, columns verbatim (§2.4).
+            cluster_table: cluster_tables
+                .as_ref()
+                .filter(|_| e.orig as usize != finest)
+                .map(|t| &t[e.orig as usize]),
+            acc_cols: &acc_cols,
         };
         let (rows, vertices) = write_level_streaming(
             &mut writer,
@@ -420,19 +458,26 @@ fn scan_road_vocab(col: &dyn Array, found: &mut HashSet<&'static str>) {
     }
 }
 
-/// Pass 1: stream the input (geometry + ranking columns only) and produce the
-/// per-feature [`AssignFeature`]s (with resolved sort keys) plus the ranking
-/// provenance block (§3.5). Memory: `O(read batch)` transient +
-/// `O(N)` small per-feature records.
+/// Result of [`run_pass1`]: the per-feature [`AssignFeature`]s, the resolved
+/// ranking provenance, and the per-accumulate-spec source values.
+type Pass1Output = (Vec<AssignFeature>, RankingProvenance, Vec<Vec<Option<f64>>>);
+
+/// Pass 1: stream the input (geometry + ranking/accumulate columns only) and
+/// produce the per-feature [`AssignFeature`]s (with resolved sort keys), the
+/// ranking provenance block (§3.5), and — when clustering with aggregation —
+/// the per-spec source values (parallel to `acc_cols`). Memory: `O(read
+/// batch)` transient + `O(N)` small per-feature records.
 fn run_pass1(
     input_path: &Path,
     input_schema: &Schema,
     geom_idx: usize,
     options: &ConvertOptions,
-) -> Result<(Vec<AssignFeature>, RankingProvenance), ConvertError> {
+    acc_cols: &[usize],
+) -> Result<Pass1Output, ConvertError> {
     let mut plan = build_rank_plan(input_schema, options)?;
 
-    // Project only the columns pass 1 needs: geometry + ranking candidates.
+    // Project only the columns pass 1 needs: geometry + ranking candidates +
+    // accumulate columns (Q4).
     let mut cols: Vec<usize> = vec![geom_idx];
     match &plan {
         RankPlan::ExplicitSort { idx, .. } | RankPlan::ExplicitClass { idx, .. } => cols.push(*idx),
@@ -444,6 +489,7 @@ fn run_pass1(
         }
         RankPlan::SizeFallback => {}
     }
+    cols.extend(acc_cols.iter().copied());
     cols.sort_unstable();
     cols.dedup();
     // Original schema index → projected batch column index.
@@ -461,6 +507,7 @@ fn run_pass1(
     let mut point_count = 0usize;
     let mut explicit_keys: Vec<Option<f64>> = Vec::new();
     let mut confidence_keys: Vec<Option<f64>> = Vec::new();
+    let mut acc_values: Vec<Vec<Option<f64>>> = vec![Vec::new(); acc_cols.len()];
     let mut geoms_buf: Vec<Geometry<f64>> = Vec::new();
 
     for batch in reader {
@@ -509,6 +556,11 @@ fn run_pass1(
                 }
             }
             RankPlan::SizeFallback => {}
+        }
+
+        // Accumulate columns (Q4): per-spec source values, in row order.
+        for (s, &idx) in acc_cols.iter().enumerate() {
+            acc_values[s].extend(extract_sort_keys(batch.column(proj(idx)).as_ref()));
         }
     }
 
@@ -593,7 +645,7 @@ fn run_pass1(
         }
     }
 
-    Ok((features, provenance))
+    Ok((features, provenance, acc_values))
 }
 
 // ============================================================================
@@ -622,6 +674,9 @@ impl Pass2Timers {
 /// Immutable context for one level's pass-2 stream.
 struct LevelStreamCtx<'a> {
     source_schema: &'a Schema,
+    /// Output schema: `source_schema` + trailing `point_count` when
+    /// clustering, otherwise identical.
+    out_schema: &'a Schema,
     non_geom_cols: &'a [usize],
     geom_idx: usize,
     /// Winner table: per input row, its coarsest level.
@@ -634,6 +689,13 @@ struct LevelStreamCtx<'a> {
     gsd_m: f64,
     crs: Crs,
     simplify: &'a SimplifyOptions,
+    /// Clustering (Q4): append `point_count` + rewrite accumulate columns.
+    cluster_enabled: bool,
+    /// This level's cluster table; `None` at the canonical level (singletons)
+    /// or when clustering is off.
+    cluster_table: Option<&'a std::collections::HashMap<usize, ClusterEntry>>,
+    /// Schema indices of the accumulate columns.
+    acc_cols: &'a [usize],
 }
 
 /// Stream one level from the input file into the writer. Returns
@@ -796,7 +858,7 @@ fn process_level_batch(
     Pass2Timers::add(&timers.simplify, t_simplify);
 
     let t_build = Instant::now();
-    let out_batch = build_level_batch(
+    let mut out_batch = build_level_batch(
         ctx.source_schema,
         batch,
         ctx.non_geom_cols,
@@ -804,6 +866,17 @@ fn process_level_batch(
         &kept_idx,
         &kept_geoms,
     )?;
+    if ctx.cluster_enabled {
+        // Cluster-table keys are global row indices; kept_idx is batch-local.
+        let globals: Vec<usize> = kept_idx.iter().map(|&i| row_offset + i).collect();
+        out_batch = apply_cluster_columns(
+            out_batch,
+            ctx.out_schema,
+            &globals,
+            ctx.cluster_table,
+            ctx.acc_cols,
+        )?;
+    }
     Pass2Timers::add(&timers.build, t_build);
     Ok(Some((out_batch, verts)))
 }

--- a/docs/OVERVIEW_TUNING.md
+++ b/docs/OVERVIEW_TUNING.md
@@ -263,6 +263,69 @@ the block.
 
 ---
 
+## Clustering: `--cluster`, `--accumulate-attribute`
+
+By default a point that loses its thinning-grid cell simply does not appear at
+that level — the survivor says nothing about how many features it stands for.
+**`--cluster`** (opt-in, duplicating mode only) makes the survivor **absorb**
+its cell's losers instead:
+
+- Every output row gains a **`point_count`** INT64 NOT NULL column — the
+  number of source features the row represents at its level (the tippecanoe /
+  supercluster convention). At the canonical (finest) level every value is 1;
+  lines and polygons always carry 1 (clustering only applies to points).
+- The winner keeps its **own geometry and attribute values** — clusters are
+  anchored on a real feature, not moved to a centroid (a deliberate divergence
+  from supercluster's re-centering: deterministic, and the anchor stays a real
+  place).
+- Absorption is **per level**: a point absorbed at z4 may itself be a winner
+  at z6 with its own (smaller) cluster. At each level,
+  `sum(point_count) == total source point count` — the clusters partition the
+  dataset at every level's grid.
+
+Use it for graduated-dot rendering of dense point data (POIs, addresses): the
+client scales the symbol by `point_count` instead of drawing a misleadingly
+sparse constant-size dot field.
+
+**`--accumulate-attribute COL:OP`** (repeatable; requires `--cluster`)
+aggregates a numeric column across each cluster: the winner's value of `COL`
+becomes the `OP` over itself + everything it absorbed at that level. Ops:
+`sum`, `max`, `min`, `mean`. Examples:
+
+```bash
+gpq-tiles overview places.parquet places_overview.parquet \
+  --min-zoom 0 --max-zoom 14 \
+  --cluster \
+  --accumulate-attribute population:sum \
+  --accumulate-attribute confidence:mean
+```
+
+Notes:
+
+- Aggregates are computed **per level from source values** (never from
+  already-aggregated coarser values), so `mean` is exact at every level.
+- Null values don't contribute; a cluster whose members are all null keeps
+  the winner's null. Non-accumulated columns keep the winner's own values.
+- Aggregation is computed in `f64` and written back in the column's original
+  type; a `mean` over an integer column rounds to the nearest integer
+  (prefer float columns for `mean`).
+- The column must exist and be numeric — the conversion fails early otherwise.
+- Interaction with the density budget: a budget-deferred cell winner leaves
+  its cell without a representative; those features attach to the **nearest
+  surviving point** at that level, so counts still sum correctly.
+- **Partitioning mode is rejected.** A partitioning row is read at many zooms
+  (prefix reads) but exists at exactly one level, so a single stored
+  `point_count` cannot reflect every zoom's grid — and absorbed features
+  reappear as their own rows at finer levels while remaining counted in
+  coarser winners, double-counting every prefix sum.
+
+Clustering is recorded in the footer `geo:overviews` →
+`generalization.clustering` provenance (`enabled`, `point_count_column`,
+`accumulated: [{column, op}]`); `gpq-tiles validate` checks that the column
+exists as INT64 NOT NULL and that canonical-level values are all 1.
+
+---
+
 ## File layout knobs: `--row-group-size`, `--full-column-stats`
 
 These do not change *which* features or vertices survive — geometry and
@@ -374,6 +437,8 @@ stay laptop-sized.
 | Whole map uniformly too sparse or too dense | move `--gsd-base` (up = denser, down = sparser) instead of tuning each family |
 | Mid zooms have far more features than tippecanoe / duplicating files too large | RAISE `--drop-rate` (density budget); or `--no-density-drop` to turn it off |
 | Density cut is stripping sparse rural areas to keep cities | RAISE `--drop-gamma` (sparse-area protection) |
+| Dense point data renders as a misleadingly sparse dot field at coarse zooms | `--cluster` and style the symbol size by `point_count` |
+| Need per-cluster totals/averages of a numeric column | `--accumulate-attribute col:sum` / `col:mean` (with `--cluster`) |
 | Every remote query fetches a huge footer before any data | default already suppresses string/geometry stats; do NOT pass `--full-column-stats` |
 | Need server-side row-group skipping on a property predicate | pass `--full-column-stats` (bigger footer, gains column pruning) |
 | Tiny viewports over high-latency storage fetch too much | LOWER `--row-group-size` for tighter bbox pruning |

--- a/docs/OVERVIEW_TUNING.md
+++ b/docs/OVERVIEW_TUNING.md
@@ -85,7 +85,7 @@ cell_size = thinning_factor * gsd(level)          (in the CRS's units)
 
 | Knob | Default | Units | Direction |
 |------|---------|-------|-----------|
-| `--point-thinning` | `4.0` | × GSD (cell size) | **bigger = sparser** |
+| `--point-thinning` | `4.0` (`16.0` with `--cluster`) | × GSD (cell size) | **bigger = sparser** |
 | `--line-thinning` | `1.0` | × GSD (cell size) | **bigger = sparser** |
 | `--polygon-thinning` | `1.0` | × GSD (cell size) | **bigger = sparser** |
 
@@ -286,6 +286,15 @@ its cell's losers instead:
 Use it for graduated-dot rendering of dense point data (POIs, addresses): the
 client scales the symbol by `point_count` instead of drawing a misleadingly
 sparse constant-size dot field.
+
+**Clustering changes the `--point-thinning` default from 4.0 to 16.0.** With
+thin-only output a coarse grid *discards* data, so the default stays dense;
+with clustering the losers are summarized into `point_count`, so a sparser
+grid is pure win and gives the familiar graduated-cluster look (supercluster's
+default radius is ~40 px; 16 × GSD ≈ one dot per ~16 display pixels). Chosen
+from the NYC pt={4,16,48} sweep — each 4× step in the factor shifts the whole
+density ladder two zooms. Pass `--point-thinning` explicitly to override in
+either mode.
 
 **`--accumulate-attribute COL:OP`** (repeatable; requires `--cluster`)
 aggregates a numeric column across each cluster: the winner's value of `COL`


### PR DESCRIPTION
## Summary

Q4 from the quality ladder (`context/OVERVIEWS_PLAN.md` §V5): with `--cluster`, point overview levels **summarize instead of sample**. At each level the cell winner absorbs the other points in its cell and carries `point_count` (INT64 NOT NULL, tippecanoe/supercluster convention); `--accumulate-attribute COL:OP` (repeatable; sum/max/min/mean) aggregates numeric columns over absorbed features. All other attributes are winner-takes. Winners keep their own geometry (documented divergence from supercluster's centroid re-centering — deterministic and simpler).

## Semantics guarantees

- **Conservation law**: sum(point_count) at every level equals the source feature count — validator-checked and integration-tested.
- **Canonical fidelity**: canonical rows pass through verbatim (point_count=1, no f64 round-trip of source values); spec §2.4 value-identity preserved bit-for-bit.
- **Mean is computed per level from source values** (never mean-of-means — unit test demonstrates the difference).
- **Orphan cells** (Q2 density budget defers a cell's winner to a finer level): features attach to the nearest present point via expanding Chebyshev-ring search, keeping the sum invariant intact.
- **Partitioning mode rejected** with a clear error (CLI + core + validator): one stored count cannot be correct for all prefix-read zooms without double-counting. Rationale in spec §12.5.
- Footer provenance: `generalization.clustering {enabled, point_count_column, accumulated[]}`; non-clustered runs emit byte-identical footers to before.

## Real data (points-nyc-medium, 458,135 points)

`--cluster --accumulate-attribute confidence:mean`, z0–14, **4.6 s**: 15 levels, sum(point_count) = 458,135 at every level (DuckDB-verified); Σ(confidence × point_count) reproduces the source Σconfidence to ~1e-10 at every level. Export: 54 MB PMTiles, 838 tiles, 0 oversized, tiles carry `point_count` + aggregated `confidence`.

## Streaming-native

Cluster tables build in pass 1 (memory O(non-singleton clusters)); pass 2 attaches columns per batch. Streaming ↔ in-memory equivalence tested including point_count columns under tiny batches + density budgets. Works both pipelines; validator gains 3 clustering checks (12 total).

## Docs

Spec: `context/OVERVIEWS_SPEC.md` §12 "Point clustering extension (v0.2.0-draft)" + changelog. Tuning: new "Clustering" section in `docs/OVERVIEW_TUNING.md`.

## Tests

25 new tests across cluster.rs / convert / check / level / CLI. Overview suite: 148 passed, 0 failed; fmt + clippy `-D warnings` clean per commit.

## Found during verification (NOT fixed here)

A **pre-existing** `export-pmtiles` bug: coarse-zoom tiles (z0–z3) place features at wrong latitudes (NYC at ~65°N at z0; correct by ~z4) — pattern suggests linear-vs-mercator Y mixing in the tile encoder. Reproduced on non-clustered overviews; the overview .parquet itself is correct. Fix tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)