### PR TITLE
perf(core): stream tile partitions to PMTiles writer — export RSS 2.4 GB → 0.89 GB (H3b)

### DIFF
--- a/benchmarks/overview/H3_NOTES.md
+++ b/benchmarks/overview/H3_NOTES.md
@@ -90,3 +90,94 @@ Documented in `docs/OVERVIEW_TUNING.md` § "Memory / streaming knobs".
 - H3(b) (export: flush finished tiles instead of holding a zoom map)
   is **not** part of this change; export still holds one zoom in
   memory.
+
+# H3(b) — Bounded-memory export + serial-merge removal
+
+Date: 2026-07-03. Branch: `fix/export-memory-flush` (on top of the
+H3(c) levers, base b8a1635).
+
+Restructures `crates/core/src/overview/export.rs` from per-zoom
+whole-band materialization (level `Vec<Feature>` + staged per-feature
+clip results + a **serial** `BTreeMap` grouping merge + all encoded
+tiles held until written) to a partitioned streaming pipeline:
+
+1. **Scan pass** per level: stream the band once (geometry decode
+   only) → per-tile member counts, band row count, overall bounds.
+   O(#tiles) state.
+2. **Partition**: split the zoom's tiles into contiguous ascending
+   `(x, y)` ranges of ~`DEFAULT_PARTITION_TARGET` = 32,768
+   (feature × tile) members.
+3. **Partition pass**: partitions run in parallel waves of
+   `PARTITION_WAVE` = 6 (order-preserving collect, serial in-order
+   write). Each partition re-reads a row-group-pruned subset of the
+   band (conservative bbox pruning via the covering stats; skipped for
+   EPSG:3857 inputs), clips features in parallel per 8k-row batch
+   (`OverviewReader::read_level_with_batch_size`, new), groups by a
+   **parallel `(tile key, band order)` sort** — the serial per-zoom
+   `BTreeMap` merge is gone — and MVT-encodes tiles in parallel.
+   Finished partitions stream straight to the PMTiles writer.
+
+Parallel: per-batch clip, member grouping sort, per-tile MVT encode,
+and up to 6 concurrent partitions. Serial: band scan, per-batch
+decode/property extraction (within each partition), and the in-order
+gzip/write loop (unchanged).
+
+## Byte-identity
+
+Tiles are still added zoom-ascending and `(x, y)`-ascending within a
+zoom (the packed tile key sorts exactly like the old `BTreeMap<(x, y)>`
+iteration), and within-tile members keep band order, so tile bytes,
+dedup offsets, directory, and metadata are unchanged. Verified three
+ways:
+
+- `overview::export::tests::export_archive_matches_pre_refactor_reference`:
+  whole-archive xxh3 pinned from the pre-refactor implementation
+  (captured at b8a1635 before the rewrite) on a mixed-geometry
+  2-level fixture — green after the rewrite.
+- `overview::export::tests::partitioned_export_is_partition_invariant`:
+  `partition_target = 1` (max partitions, max band re-reads) vs the
+  default produce byte-identical archives and identical reports.
+- Moldova: `cmp` of the full 123 MB archive, pre- vs post-refactor
+  build — **byte-identical**; reports identical modulo
+  `duration_secs`. 17,372 tiles, 1,807,912 tile features, 0 oversized
+  in both.
+
+## Moldova before / after
+
+Input `corpus/data/bench/h3/moldova.dup.stream.parquet` (632k
+polygons, duplicating z0–14), command:
+
+```bash
+/usr/bin/time -v target/release/gpq-tiles \
+  export-pmtiles \
+  corpus/data/bench/h3/moldova.dup.stream.parquet \
+  out.pmtiles --layer-name fields
+```
+
+Caveat: the machine was heavily loaded by unrelated jobs (load avg
+13–30 of 16 cores) throughout these runs, so absolute walls are
+inflated vs the idle-machine H3(c) figures (58.8 s / 2.38 GB).
+Before/after pairs were therefore run back-to-back under the same
+load; best-of-pairs shown:
+
+| build | wall (paired, loaded) | CPU | Max RSS |
+|---|---:|---:|---:|
+| pre-refactor (b8a1635 + anchor test) | 75.5 s | 717 % | **2.41 GB** |
+| **partitioned streaming** | **73.9 s** | 688 % | **0.89 GB** |
+
+- **Peak RSS 2.4 GB → 0.89 GB (−63 %), under the 1 GB target.** The
+  bound is now O(wave × partition): ~6 × (32k members + one 8k-row
+  batch transient), independent of the zoom band size.
+- Wall: parity with the pre-refactor build under identical load
+  (73.9 vs 75.5 s; run-to-run noise under this contention was ±25 %,
+  e.g. ref itself ranged 75.5–103.5 s). The serial `BTreeMap` merge is
+  eliminated (per-partition sort+encode is 0.2–0.6 s at z14), but the
+  per-partition band re-reads add ~3.5× row-read redundancy at z14
+  (row groups pruned per partition; Hilbert row groups vs `(x, y)`
+  stripe partitions overlap imperfectly), and wave scheduling absorbs
+  most of the freed serial time. The 8.4× Amdahl ceiling (~32 s) was
+  not demonstrable under this load; on the paired evidence the
+  restructure is wall-neutral and memory is the win.
+- Debug-level `[profile]` instrumentation now also logs per-partition
+  `rows_read / members / collect / sort+encode` (kept, like the H3(c)
+  instrumentation, behind `RUST_LOG=gpq_tiles_core::overview=debug`).

--- a/crates/core/src/overview/export.rs
+++ b/crates/core/src/overview/export.rs
@@ -3,24 +3,34 @@
 //! This is the **replacement** for the shelved tile-generation pipeline, not a
 //! revival of it. An overview file already contains per-level thinned,
 //! simplified, ranked, Hilbert-ordered features; exporting to PMTiles is
-//! therefore mechanical and single-pass:
+//! therefore mechanical, two streaming passes per level (H3(b)):
 //!
 //! 1. For each overview **level**, resolve its Web Mercator **zoom** (§5.2).
-//! 2. Stream the level band via [`OverviewReader::read_level`] with `bbox=None`.
-//!    The reader already implements the mode semantics — `duplicating` reads
-//!    exactly the level's own row-group band, `partitioning` reads the prefix
-//!    `0..=level` (features accumulate) — so this module treats both modes
-//!    identically: "read level `k`, emit tiles at level `k`'s zoom".
-//! 3. Assign every feature to the tile(s) it intersects at that zoom
-//!    ([`tiles_for_bbox`]), clip each to the tile bounds **plus a pixel buffer**
+//! 2. **Scan pass**: stream the level band via [`OverviewReader::read_level`]
+//!    with `bbox=None`, decoding geometries only, to size every tile at that
+//!    zoom (per-tile member counts), count the band's rows, and expand the
+//!    overall bounds. The reader already implements the mode semantics —
+//!    `duplicating` reads exactly the level's own row-group band,
+//!    `partitioning` reads the prefix `0..=level` (features accumulate) — so
+//!    this module treats both modes identically: "read level `k`, emit tiles
+//!    at level `k`'s zoom".
+//! 3. **Partition pass**: split the zoom's tiles into contiguous ascending
+//!    `(x, y)` ranges of roughly [`DEFAULT_PARTITION_TARGET`] members each.
+//!    For each partition, in tile order: re-read the band (row groups pruned
+//!    to the partition's bbox), assign every feature to the tile(s) it
+//!    intersects at that zoom ([`tiles_for_bbox`]) restricted to the
+//!    partition's range, clip each to the tile bounds **plus a pixel buffer**
 //!    (reusing the shelved [`clip_geometry`] entry point), MVT-encode
-//!    (reusing [`crate::mvt`]), and write via [`StreamingPmtilesWriter`].
+//!    (reusing [`crate::mvt`]), and immediately stream the finished
+//!    partition's tiles to [`StreamingPmtilesWriter`]. Tiles are written in
+//!    ascending `(x, y)` order per zoom — the historical order — so the
+//!    archive's tile-data layout, deduplication, and directory are unchanged.
 //!
 //! ## What this deliberately does NOT do (per `context/CARRYOVER.md`)
 //!
 //! - **No global cross-zoom external sort / per-tile fan-out.** Tiling is done
-//!   one zoom at a time into an in-memory `BTreeMap<tile, Vec<feature>>` that is
-//!   built, drained into the writer, and dropped before the next zoom.
+//!   one zoom at a time, one tile partition at a time; each partition is
+//!   built, drained into the writer, and dropped before the next.
 //! - **No per-tile budget retry loop / adaptive re-encode.** Generalization is
 //!   precomputed in the overview file. The only safety valve is a single,
 //!   optional, non-iterative drop pass for pathologically dense tiles
@@ -28,12 +38,14 @@
 //!
 //! ## Memory ceiling
 //!
-//! For each zoom the peak working set is `O(F_level + C)` where `F_level` is the
-//! feature count of that level's band and `C` is the number of
-//! (feature × intersecting-tile) clipped copies at that zoom. For the finest
-//! (canonical) level in duplicating mode this equals the whole dataset plus its
-//! tile-boundary duplication — the documented v1 ceiling. There is **no**
-//! global (all-zoom) accumulation.
+//! Peak working set is `O(one wave of partitions + writer state)` (waves are
+//! [`PARTITION_WAVE`] partitions processed concurrently): each in-flight
+//! partition holds its (feature × intersecting-tile) clipped members plus its
+//! encoded tiles, bounded by the partition target — **not** the zoom band's
+//! feature count.
+//! The scan pass keeps only per-tile member counts (`O(#tiles)`), and the
+//! PMTiles writer streams tile bytes to a temp file, keeping only directory
+//! entries. There is **no** per-zoom or global accumulation.
 //!
 //! ## Tile-boundary duplication (expected MVT semantics)
 //!
@@ -185,7 +197,9 @@ pub enum ExportError {
 
 /// One source feature: its (possibly reprojected-to-4326) geometry and the MVT
 /// properties carried over from the overview file (level column + covering
-/// struct excluded).
+/// struct excluded). Test-support only: production streams members directly
+/// instead of materializing features (see [`collect_batch_members`]).
+#[cfg(test)]
 struct Feature {
     geom: Geometry<f64>,
     props: Vec<(String, PropertyValue)>,
@@ -216,6 +230,28 @@ pub fn zoom_for_level(meta: &OverviewsMeta, level_idx: usize) -> u8 {
     z.clamp(0.0, 255.0) as u8
 }
 
+/// Members-per-partition target for the partitioned streaming export (H3(b)).
+///
+/// Each zoom's tiles are split into contiguous `(x, y)` ranges whose summed
+/// (feature × tile) member counts reach at least this value; partitions are
+/// processed one at a time and streamed to the writer, so this bounds the
+/// per-partition working set (clipped geometries + encoded tiles) instead of
+/// holding the whole zoom in memory.
+const DEFAULT_PARTITION_TARGET: usize = 32_768;
+
+/// Number of partitions processed concurrently per wave. Each partition
+/// re-reads (a row-group-pruned subset of) the level band; the wave overlaps
+/// those serial read/decode passes with parallel clip/encode work while
+/// keeping peak memory at O(`PARTITION_WAVE` partitions). Waves complete in
+/// order, so the writer still receives tiles in ascending `(x, y)` order.
+const PARTITION_WAVE: usize = 6;
+
+/// Arrow batch size for the partition read passes (the parquet reader default
+/// of 1024 rows makes the per-batch parallel clip sections too small to load-
+/// balance across cores; 16k rows amortizes decode and barrier overhead while
+/// keeping per-batch memory modest).
+const EXPORT_BATCH_SIZE: usize = 8_192;
+
 /// Export an overview GeoParquet file to a PMTiles archive.
 ///
 /// See the module documentation for the full pipeline and the design
@@ -224,6 +260,18 @@ pub fn export_pmtiles(
     input_path: impl AsRef<Path>,
     output_path: impl AsRef<Path>,
     options: &ExportOptions,
+) -> Result<ExportReport, ExportError> {
+    export_pmtiles_with_partition_target(input_path, output_path, options, DEFAULT_PARTITION_TARGET)
+}
+
+/// Implementation of [`export_pmtiles`] with an explicit partition-size target,
+/// exposed separately so tests can force many tiny partitions and verify the
+/// archive is byte-identical regardless of partitioning.
+fn export_pmtiles_with_partition_target(
+    input_path: impl AsRef<Path>,
+    output_path: impl AsRef<Path>,
+    options: &ExportOptions,
+    partition_target: usize,
 ) -> Result<ExportReport, ExportError> {
     let start = Instant::now();
     let input_path = input_path.as_ref();
@@ -251,50 +299,74 @@ pub fn export_pmtiles(
     for level_idx in 0..num_levels {
         let zoom = zoom_for_level(&meta, level_idx);
 
-        // Read the whole level band into memory (v1). The reader already applies
-        // duplicating (single band) vs partitioning (prefix) semantics.
-        let t_read = Instant::now();
-        let features = read_level_features(&reader, level_idx, crs)?;
-        let read_secs = t_read.elapsed().as_secs_f64();
-        let level_feature_count = features.len();
-
-        // Expand the overall geographic bounds from feature bboxes.
-        for f in &features {
-            if let Some(rect) = f.geom.bounding_rect() {
-                let b = TileBounds::new(rect.min().x, rect.min().y, rect.max().x, rect.max().y);
-                match &mut overall_bounds {
-                    Some(acc) => acc.expand(&b),
-                    None => overall_bounds = Some(b),
-                }
+        // Pass 1 (scan): stream the level band once, decoding geometries only,
+        // to size every tile (member counts), expand the overall geographic
+        // bounds, and count the band's rows. O(#tiles) memory. The reader
+        // already applies duplicating (single band) vs partitioning (prefix)
+        // semantics.
+        let t_scan = Instant::now();
+        let scan = scan_level(&reader, level_idx, crs, zoom)?;
+        let scan_secs = t_scan.elapsed().as_secs_f64();
+        if let Some(b) = &scan.bounds {
+            match &mut overall_bounds {
+                Some(acc) => acc.expand(b),
+                None => overall_bounds = Some(*b),
             }
         }
 
-        let t_encode = Instant::now();
-        let tiles = encode_level_tiles(&features, zoom, options);
-        let encode_secs = t_encode.elapsed().as_secs_f64();
+        // Split the zoom's tiles into contiguous ascending (x, y) ranges of
+        // roughly `partition_target` members each.
+        let partitions = plan_partitions(&scan.tile_counts, zoom, partition_target);
 
-        let t_write = Instant::now();
+        // Pass 2: process partitions in ascending tile order, streaming each
+        // finished partition's encoded tiles straight to the writer. To hide
+        // the per-partition band re-read/decode behind clip work, partitions
+        // are processed in small parallel waves (order-preserving collect,
+        // then a serial in-order write), so peak memory is O(one wave of
+        // partitions + writer state), not O(zoom band).
+        let t_tiles = Instant::now();
+        let ctx = LevelCtx {
+            reader: &reader,
+            level_idx,
+            crs,
+            zoom,
+            opts: options,
+        };
+        let mut tile_count = 0usize;
         let mut tile_feature_count = 0usize;
         let mut oversized = 0usize;
-        for t in &tiles {
-            tile_feature_count += t.feature_count;
-            if t.oversized {
-                oversized += 1;
+        let mut write_secs = 0f64;
+        for wave in partitions.chunks(PARTITION_WAVE) {
+            let results: Vec<Vec<EncodedTile>> = wave
+                .par_iter()
+                .map(|part| process_partition(&ctx, part))
+                .collect::<Result<_, _>>()?;
+            let t_write = Instant::now();
+            for tiles in &results {
+                for t in tiles {
+                    tile_feature_count += t.feature_count;
+                    if t.oversized {
+                        oversized += 1;
+                    }
+                    writer.add_tile_with_count(zoom, t.x, t.y, &t.data, t.feature_count)?;
+                }
+                tile_count += tiles.len();
             }
-            writer.add_tile_with_count(zoom, t.x, t.y, &t.data, t.feature_count)?;
+            write_secs += t_write.elapsed().as_secs_f64();
         }
         log::debug!(
-            "[profile] z{zoom} (level {level_idx}, {level_feature_count} feats, {} tiles): \
-             read={read_secs:.2}s clip+encode={encode_secs:.2}s write(gzip)={:.2}s",
-            tiles.len(),
-            t_write.elapsed().as_secs_f64(),
+            "[profile] z{zoom} (level {level_idx}, {} feats, {tile_count} tiles, {} partitions): \
+             scan={scan_secs:.2}s clip+encode={:.2}s write(gzip)={write_secs:.2}s",
+            scan.feature_count,
+            partitions.len(),
+            t_tiles.elapsed().as_secs_f64() - write_secs,
         );
 
         zooms.push(ZoomReport {
             zoom,
             level: level_idx,
-            level_feature_count,
-            tile_count: tiles.len(),
+            level_feature_count: scan.feature_count,
+            tile_count,
             tile_feature_count,
             oversized_tiles: oversized,
         });
@@ -327,79 +399,337 @@ pub fn export_pmtiles(
 }
 
 // ============================================================================
-// Tiling + encoding
+// Partitioned tiling + encoding (H3(b))
 // ============================================================================
 
-/// One tile's members: list of `(clipped geometry, property index into the
-/// level's `features`)`.
-type TileMembers = Vec<(Geometry<f64>, usize)>;
+/// Pack a tile `(x, y)` into a single ordered key. Ordering by this key equals
+/// ordering by the `(x, y)` tuple — the historical per-zoom write order (the
+/// old per-zoom `BTreeMap<(u32, u32), _>` iteration order). Preserving it
+/// keeps the archive's tile-data layout, deduplication, and directory
+/// byte-identical.
+#[inline]
+fn tile_key(x: u32, y: u32) -> u64 {
+    ((x as u64) << 32) | y as u64
+}
 
-/// Per-tile working map: tile `(x, y)` -> members.
-type GroupedTileGeoms = BTreeMap<(u32, u32), TileMembers>;
+/// One tile member: a feature's clipped geometry destined for the tile with
+/// key `key`, the feature's band-order sequence number (stable within-tile
+/// ordering), and the feature's MVT properties (shared across the feature's
+/// tile copies).
+struct Member {
+    key: u64,
+    seq: u64,
+    geom: Geometry<f64>,
+    props: Arc<Vec<(String, PropertyValue)>>,
+}
 
-/// Per-feature clip results: list of `(tile (x, y), clipped geometry)`.
-type FeatureTileGeoms = Vec<((u32, u32), Geometry<f64>)>;
+/// Result of the per-level scan pass.
+struct LevelScan {
+    /// Rows in the level band.
+    feature_count: usize,
+    /// Union of feature bboxes (`None` when no feature has one).
+    bounds: Option<TileBounds>,
+    /// Member count per tile key, ascending `(x, y)`.
+    tile_counts: BTreeMap<u64, usize>,
+}
 
-/// Group a level's features into tiles at `zoom`, clip each to its tile bounds
-/// plus the pixel buffer, and MVT-encode. Applies the optional oversized valve.
-///
-/// Returns the encoded tiles in Hilbert-ish `(x, y)` `BTreeMap` order (the
-/// PMTiles writer re-sorts by tile id regardless, so exact order is not
-/// load-bearing — the `BTreeMap` is used for deterministic, locality-friendly
-/// grouping and a bounded per-zoom working set).
-fn encode_level_tiles(features: &[Feature], zoom: u8, opts: &ExportOptions) -> Vec<EncodedTile> {
-    // Clip in parallel per feature (H3(c) lever 2: clipping is 94% of export
-    // wall and independent per feature). `par_iter().map().collect()`
-    // preserves feature order, so the sequential merge below pushes members
-    // into each tile's vector in exactly the serial order — grouping, and
-    // therefore the encoded tile bytes, are unchanged.
-    let t_clip = Instant::now();
-    let per_feature: Vec<FeatureTileGeoms> = features
-        .par_iter()
-        .map(|feat| {
-            let Some(rect) = feat.geom.bounding_rect() else {
-                return Vec::new();
+/// A contiguous range of tile keys, processed (and written) as one unit.
+struct Partition {
+    key_lo: u64,
+    key_hi: u64,
+    /// Union of the partition's tile bounds plus a one-tile margin, used to
+    /// prune row groups on the partition's read pass. Pruning is conservative:
+    /// a feature assigned to a tile in this partition has a bbox intersecting
+    /// that tile's bounds, hence intersecting this rectangle.
+    bbox: TileBounds,
+    /// Summed member count (for balancing).
+    members: usize,
+}
+
+/// Shared per-level context for partition processing.
+struct LevelCtx<'a> {
+    reader: &'a OverviewReader,
+    level_idx: usize,
+    crs: Crs,
+    zoom: u8,
+    opts: &'a ExportOptions,
+}
+
+/// Pass 1: stream the level band once and record, per tile, how many
+/// (feature × tile) members it will receive, plus the band's row count and
+/// the union of feature bboxes. Geometries are decoded for their bbox and
+/// dropped immediately; properties are not extracted.
+fn scan_level(
+    reader: &OverviewReader,
+    level_idx: usize,
+    crs: Crs,
+    zoom: u8,
+) -> Result<LevelScan, ExportError> {
+    let batch_reader = reader.read_level_with_batch_size(level_idx, None, EXPORT_BATCH_SIZE)?;
+    let mut scan = LevelScan {
+        feature_count: 0,
+        bounds: None,
+        tile_counts: BTreeMap::new(),
+    };
+    for batch in batch_reader {
+        let batch = batch?;
+        let schema = batch.schema();
+        let geom_idx = geometry_index(&schema).ok_or(ExportError::NoGeometryColumn)?;
+        let geom_field = schema.field(geom_idx).clone();
+        let garr: Arc<dyn GeoArrowArray> =
+            from_arrow_array(batch.column(geom_idx).as_ref(), &geom_field)
+                .map_err(|e| crate::Error::GeoParquetRead(format!("geometry decode: {e}")))?;
+        let mut geoms: Vec<Geometry<f64>> = Vec::with_capacity(batch.num_rows());
+        extract_geometries_from_array(garr.as_ref(), &mut geoms)?;
+        scan.feature_count += geoms.len();
+        for geom in &geoms {
+            let Some(rect) = geom.bounding_rect() else {
+                continue;
             };
-            let bbox = TileBounds::new(rect.min().x, rect.min().y, rect.max().x, rect.max().y);
-            let mut out = Vec::new();
-            for tc in tiles_for_bbox(&bbox, zoom) {
-                let tb = tc.bounds();
-                let buffer_deg = tb.width() * opts.tile_buffer as f64 / opts.extent as f64;
-                // Fast path (H3(c) lever 4): a feature whose bbox lies entirely
-                // within the buffered tile bounds is unaffected by clipping —
-                // skip the BooleanOps intersection and emit the geometry as-is.
-                // At z14 ~80% of features are interior to a single tile.
-                if bbox_within_buffered(&bbox, &tb, buffer_deg) {
-                    out.push(((tc.x, tc.y), feat.geom.clone()));
-                } else if let Some(clipped) = clip_geometry(&feat.geom, &tb, buffer_deg) {
-                    out.push(((tc.x, tc.y), clipped));
-                }
+            let mut bbox = TileBounds::new(rect.min().x, rect.min().y, rect.max().x, rect.max().y);
+            if matches!(crs, Crs::Epsg3857) {
+                // Web Mercator -> lon/lat is monotone per axis, so reprojecting
+                // the two corners reprojects the bbox — bit-identical to taking
+                // the bbox of the reprojected geometry.
+                let (lng_min, lat_min) = webmerc_to_lnglat(bbox.lng_min, bbox.lat_min);
+                let (lng_max, lat_max) = webmerc_to_lnglat(bbox.lng_max, bbox.lat_max);
+                bbox = TileBounds::new(lng_min, lat_min, lng_max, lat_max);
             }
-            out
-        })
-        .collect();
+            match &mut scan.bounds {
+                Some(acc) => acc.expand(&bbox),
+                None => scan.bounds = Some(bbox),
+            }
+            for tc in tiles_for_bbox(&bbox, zoom) {
+                *scan.tile_counts.entry(tile_key(tc.x, tc.y)).or_insert(0) += 1;
+            }
+        }
+    }
+    Ok(scan)
+}
 
-    // tile (x,y) -> list of (clipped geometry, property index into `features`).
-    let mut grouped: GroupedTileGeoms = BTreeMap::new();
-    for (fi, items) in per_feature.into_iter().enumerate() {
+/// Split a zoom's tiles (ascending key order) into contiguous partitions of at
+/// least `partition_target` members each (the last partition may be smaller).
+fn plan_partitions(
+    tile_counts: &BTreeMap<u64, usize>,
+    zoom: u8,
+    partition_target: usize,
+) -> Vec<Partition> {
+    let target = partition_target.max(1);
+    let mut out: Vec<Partition> = Vec::new();
+    let mut cur: Option<Partition> = None;
+    for (&key, &count) in tile_counts {
+        let tb = TileCoord::new((key >> 32) as u32, key as u32, zoom).bounds();
+        match cur.as_mut() {
+            Some(p) => {
+                p.key_hi = key;
+                p.bbox.expand(&tb);
+                p.members += count;
+            }
+            None => {
+                cur = Some(Partition {
+                    key_lo: key,
+                    key_hi: key,
+                    bbox: tb,
+                    members: count,
+                });
+            }
+        }
+        if cur.as_ref().is_some_and(|p| p.members >= target) {
+            out.push(cur.take().unwrap());
+        }
+    }
+    out.extend(cur);
+    // One-tile margin on the pruning bbox: generously covers any rounding in
+    // row-group bbox statistics; over-inclusion only reads an extra row group.
+    let margin = 360.0 / 2f64.powi(zoom as i32);
+    for p in &mut out {
+        p.bbox = TileBounds::new(
+            p.bbox.lng_min - margin,
+            p.bbox.lat_min - margin,
+            p.bbox.lng_max + margin,
+            p.bbox.lat_max + margin,
+        );
+    }
+    out
+}
+
+/// Pass 2, one partition: re-read the band (row groups pruned to the
+/// partition bbox), clip every feature into its tiles within the partition's
+/// key range, group by tile via a parallel sort, and MVT-encode each tile in
+/// parallel. Returns encoded tiles in ascending `(x, y)` order.
+fn process_partition(
+    ctx: &LevelCtx<'_>,
+    part: &Partition,
+) -> Result<Vec<EncodedTile>, ExportError> {
+    // Row-group pruning is only valid when the file's coordinates (and thus
+    // its row-group bbox statistics) are lon/lat. For 3857 files the stats
+    // are in meters; skip pruning (correct, just unpruned).
+    let bbox = match ctx.crs {
+        Crs::Epsg4326 => Some([
+            part.bbox.lng_min,
+            part.bbox.lat_min,
+            part.bbox.lng_max,
+            part.bbox.lat_max,
+        ]),
+        Crs::Epsg3857 => None,
+    };
+    let batch_reader =
+        ctx.reader
+            .read_level_with_batch_size(ctx.level_idx, bbox, EXPORT_BATCH_SIZE)?;
+
+    let t_collect = Instant::now();
+    let mut members: Vec<Member> = Vec::new();
+    let mut seq = 0u64;
+    for batch in batch_reader {
+        let batch = batch?;
+        collect_batch_members(ctx, part, &batch, &mut seq, &mut members)?;
+    }
+    let collect_secs = t_collect.elapsed().as_secs_f64();
+    let t_encode = Instant::now();
+    let n_members = members.len();
+    let tiles = encode_members(members, ctx.zoom, ctx.opts);
+    log::debug!(
+        "[profile]     z{} partition [{:x}..{:x}]: rows_read={seq} members={n_members} \
+         tiles={} collect={collect_secs:.2}s sort+encode={:.2}s",
+        ctx.zoom,
+        part.key_lo,
+        part.key_hi,
+        tiles.len(),
+        t_encode.elapsed().as_secs_f64(),
+    );
+    Ok(tiles)
+}
+
+/// Decode one record batch and append this partition's members: clip every
+/// feature (in parallel) into its intersecting tiles restricted to the
+/// partition's key range, then attach shared per-feature properties in band
+/// order. `seq` is the running band-order counter (advanced for every row,
+/// member-producing or not, so within-tile ordering matches the old
+/// whole-band feature indexing).
+fn collect_batch_members(
+    ctx: &LevelCtx<'_>,
+    part: &Partition,
+    batch: &RecordBatch,
+    seq: &mut u64,
+    members: &mut Vec<Member>,
+) -> Result<(), ExportError> {
+    let schema = batch.schema();
+    let geom_idx = geometry_index(&schema).ok_or(ExportError::NoGeometryColumn)?;
+    let geom_field = schema.field(geom_idx).clone();
+    let garr: Arc<dyn GeoArrowArray> =
+        from_arrow_array(batch.column(geom_idx).as_ref(), &geom_field)
+            .map_err(|e| crate::Error::GeoParquetRead(format!("geometry decode: {e}")))?;
+    let mut geoms: Vec<Geometry<f64>> = Vec::with_capacity(batch.num_rows());
+    extract_geometries_from_array(garr.as_ref(), &mut geoms)?;
+    if matches!(ctx.crs, Crs::Epsg3857) {
+        geoms = geoms.par_iter().map(reproject_3857_to_4326).collect();
+    }
+
+    // Parallel per-feature clip (H3(c) lever 2), restricted to this partition.
+    let row_members: Vec<Vec<(u64, Geometry<f64>)>> = geoms
+        .par_iter()
+        .map(|g| feature_tile_members(g, ctx.zoom, ctx.opts, part.key_lo, part.key_hi))
+        .collect();
+    drop(geoms);
+
+    if row_members.iter().all(|v| v.is_empty()) {
+        *seq += row_members.len() as u64;
+        return Ok(());
+    }
+
+    // Extract property columns once per batch; materialize per-feature props
+    // only for rows that produced members.
+    let prop_cols = property_columns(&schema, geom_idx);
+    let mut extracted: Vec<(String, Vec<Option<PropertyValue>>)> =
+        Vec::with_capacity(prop_cols.len());
+    for &(idx, ref name) in &prop_cols {
+        extracted.push((name.clone(), extract_property_column(batch.column(idx))));
+    }
+    for (row, items) in row_members.into_iter().enumerate() {
+        if items.is_empty() {
+            *seq += 1;
+            continue;
+        }
+        let mut props = Vec::with_capacity(extracted.len());
+        for (name, col) in &extracted {
+            if let Some(v) = &col[row] {
+                props.push((name.clone(), v.clone()));
+            }
+        }
+        let props = Arc::new(props);
         for (key, geom) in items {
-            grouped.entry(key).or_default().push((geom, fi));
+            members.push(Member {
+                key,
+                seq: *seq,
+                geom,
+                props: Arc::clone(&props),
+            });
+        }
+        *seq += 1;
+    }
+    Ok(())
+}
+
+/// Clip (or fast-path pass through) one feature into every tile it intersects
+/// at `zoom` whose key falls within `[key_lo, key_hi]`.
+fn feature_tile_members(
+    geom: &Geometry<f64>,
+    zoom: u8,
+    opts: &ExportOptions,
+    key_lo: u64,
+    key_hi: u64,
+) -> Vec<(u64, Geometry<f64>)> {
+    let Some(rect) = geom.bounding_rect() else {
+        return Vec::new();
+    };
+    let bbox = TileBounds::new(rect.min().x, rect.min().y, rect.max().x, rect.max().y);
+    let mut out = Vec::new();
+    for tc in tiles_for_bbox(&bbox, zoom) {
+        let key = tile_key(tc.x, tc.y);
+        if key < key_lo || key > key_hi {
+            continue;
+        }
+        let tb = tc.bounds();
+        let buffer_deg = tb.width() * opts.tile_buffer as f64 / opts.extent as f64;
+        // Fast path (H3(c) lever 4): a feature whose bbox lies entirely
+        // within the buffered tile bounds is unaffected by clipping —
+        // skip the BooleanOps intersection and emit the geometry as-is.
+        // At z14 ~80% of features are interior to a single tile.
+        if bbox_within_buffered(&bbox, &tb, buffer_deg) {
+            out.push((key, geom.clone()));
+        } else if let Some(clipped) = clip_geometry(geom, &tb, buffer_deg) {
+            out.push((key, clipped));
+        }
+    }
+    out
+}
+
+/// Group members by tile and MVT-encode. A **parallel sort** on
+/// `(tile key, band order)` replaces the old serial per-zoom `BTreeMap`
+/// merge — `(key, seq)` pairs are unique (one member per feature per tile),
+/// so the unstable sort is deterministic, and within a tile members stay in
+/// band (file) order, exactly as before. Encoded tiles come back in ascending
+/// `(x, y)` order; empty tiles are dropped.
+fn encode_members(mut members: Vec<Member>, zoom: u8, opts: &ExportOptions) -> Vec<EncodedTile> {
+    members.par_sort_unstable_by_key(|m| (m.key, m.seq));
+
+    // Group boundaries (manual scan: `slice::chunk_by` needs Rust 1.77, MSRV
+    // is 1.75).
+    let mut groups: Vec<&[Member]> = Vec::new();
+    let mut start = 0usize;
+    for i in 1..=members.len() {
+        if i == members.len() || members[i].key != members[start].key {
+            groups.push(&members[start..i]);
+            start = i;
         }
     }
 
-    let clip_secs = t_clip.elapsed().as_secs_f64();
-
-    // Encode tiles in parallel; the indexed collect preserves the BTreeMap's
-    // (x, y) order, and the caller's serial write loop consumes `out` in that
-    // order, so PMTiles tile ordering and bytes are unchanged.
-    let t_mvt = Instant::now();
-    let entries: Vec<((u32, u32), TileMembers)> = grouped.into_iter().collect();
-    let out: Vec<EncodedTile> = entries
+    groups
         .into_par_iter()
-        .filter_map(|((x, y), members)| {
-            let tc = TileCoord::new(x, y, zoom);
-            let tb = tc.bounds();
-            let (data, count, oversized) = encode_tile(&members, features, &tb, opts);
+        .filter_map(|g| {
+            let (x, y) = ((g[0].key >> 32) as u32, g[0].key as u32);
+            let tb = TileCoord::new(x, y, zoom).bounds();
+            let (data, count, oversized) = encode_tile(g, &tb, opts);
             if count == 0 {
                 return None;
             }
@@ -411,12 +741,7 @@ fn encode_level_tiles(features: &[Feature], zoom: u8, opts: &ExportOptions) -> V
                 oversized,
             })
         })
-        .collect();
-    log::debug!(
-        "[profile]   z{zoom} clip+group={clip_secs:.2}s mvt-encode={:.2}s",
-        t_mvt.elapsed().as_secs_f64(),
-    );
-    out
+        .collect()
 }
 
 /// `true` when `bbox` lies entirely within `tb` expanded by `buffer` on every
@@ -433,33 +758,29 @@ fn bbox_within_buffered(bbox: &TileBounds, tb: &TileBounds, buffer: f64) -> bool
 /// Encode a single tile's members to MVT bytes, applying the oversized valve.
 /// Returns `(bytes, features_encoded, oversized)`.
 fn encode_tile(
-    members: &[(Geometry<f64>, usize)],
-    features: &[Feature],
+    members: &[Member],
     tb: &TileBounds,
     opts: &ExportOptions,
 ) -> (Vec<u8>, usize, bool) {
-    let data = build_mvt(members, features, tb, opts);
+    let data = build_mvt(members.iter(), tb, opts);
 
     match opts.tile_size_limit {
         Some(limit) if data.len() > limit && members.len() > 1 => {
             // Single, non-iterative drop pass: rank members by geometry size
             // (coordinate count) descending — the biggest features carry the
             // tile's visual signal — and keep a proportional prefix.
-            let mut ranked: Vec<&(Geometry<f64>, usize)> = members.iter().collect();
-            ranked.sort_by_key(|m| std::cmp::Reverse(m.0.coords_count()));
+            let mut ranked: Vec<&Member> = members.iter().collect();
+            ranked.sort_by_key(|m| std::cmp::Reverse(m.geom.coords_count()));
             let keep_frac = limit as f64 / data.len() as f64;
             let keep = ((members.len() as f64 * keep_frac).floor() as usize).max(1);
-            let kept: Vec<(Geometry<f64>, usize)> =
-                ranked.into_iter().take(keep).cloned().collect();
-            let data = build_mvt(&kept, features, tb, opts);
-            let count = kept.len();
+            let data = build_mvt(ranked.iter().take(keep).copied(), tb, opts);
             log::warn!(
                 "oversized tile ({} bytes > {limit} limit): dropped {} of {} features (one pass)",
                 data.len(),
-                members.len() - count,
+                members.len() - keep,
                 members.len()
             );
-            (data, count, true)
+            (data, keep, true)
         }
         _ => {
             let count = members.len();
@@ -468,16 +789,15 @@ fn encode_tile(
     }
 }
 
-/// Build the MVT bytes for a set of tile members.
-fn build_mvt(
-    members: &[(Geometry<f64>, usize)],
-    features: &[Feature],
+/// Build the MVT bytes for a sequence of tile members.
+fn build_mvt<'a>(
+    members: impl IntoIterator<Item = &'a Member>,
     tb: &TileBounds,
     opts: &ExportOptions,
 ) -> Vec<u8> {
     let mut layer = LayerBuilder::new(opts.layer_name.clone()).with_extent(opts.extent);
-    for (i, (geom, fi)) in members.iter().enumerate() {
-        layer.add_feature(Some(i as u64), geom, &features[*fi].props, tb);
+    for (i, m) in members.into_iter().enumerate() {
+        layer.add_feature(Some(i as u64), &m.geom, &m.props, tb);
     }
     let mut tb_builder = TileBuilder::new();
     tb_builder.add_layer(layer.build());
@@ -488,7 +808,29 @@ fn build_mvt(
 // Reading + property extraction
 // ============================================================================
 
-/// Read every feature (geometry + carried properties) of a level band.
+/// Test-support: the pre-partitioning in-memory reference path — build every
+/// member for a fully materialized feature slice at `zoom` (unbounded key
+/// range) and encode via the production member machinery.
+#[cfg(test)]
+fn encode_level_tiles(features: &[Feature], zoom: u8, opts: &ExportOptions) -> Vec<EncodedTile> {
+    let mut members = Vec::new();
+    for (fi, f) in features.iter().enumerate() {
+        let props = Arc::new(f.props.clone());
+        for (key, geom) in feature_tile_members(&f.geom, zoom, opts, 0, u64::MAX) {
+            members.push(Member {
+                key,
+                seq: fi as u64,
+                geom,
+                props: Arc::clone(&props),
+            });
+        }
+    }
+    encode_members(members, zoom, opts)
+}
+
+/// Test-support: read every feature (geometry + carried properties) of a level
+/// band into memory.
+#[cfg(test)]
 fn read_level_features(
     reader: &OverviewReader,
     level_idx: usize,
@@ -503,8 +845,10 @@ fn read_level_features(
     Ok(out)
 }
 
-/// Decode one record batch into [`Feature`]s, excluding the `level` column and
-/// any struct/list column (the bbox covering) from properties.
+/// Test-support: decode one record batch into [`Feature`]s, excluding the
+/// `level` column and any struct/list column (the bbox covering) from
+/// properties.
+#[cfg(test)]
 fn decode_batch(batch: &RecordBatch, crs: Crs, out: &mut Vec<Feature>) -> Result<(), ExportError> {
     let schema = batch.schema();
     let geom_idx = geometry_index(&schema).ok_or(ExportError::NoGeometryColumn)?;
@@ -702,14 +1046,21 @@ fn detect_crs(path: &Path) -> Result<Crs, ExportError> {
     })
 }
 
+/// Reproject one EPSG:3857 point (meters) to EPSG:4326 (lon/lat degrees).
+#[inline]
+fn webmerc_to_lnglat(x: f64, y: f64) -> (f64, f64) {
+    let lng = x / WEBMERC_HALF_M * 180.0;
+    let lat = (2.0 * (y / WEBMERC_HALF_M * std::f64::consts::PI).exp().atan()
+        - std::f64::consts::FRAC_PI_2)
+        .to_degrees();
+    (lng, lat)
+}
+
 /// Reproject a geometry from EPSG:3857 (meters) to EPSG:4326 (lon/lat degrees)
 /// so the geographic tile grid math applies.
 fn reproject_3857_to_4326(g: &Geometry<f64>) -> Geometry<f64> {
     g.map_coords(|c| {
-        let lng = c.x / WEBMERC_HALF_M * 180.0;
-        let lat = (2.0 * (c.y / WEBMERC_HALF_M * std::f64::consts::PI).exp().atan()
-            - std::f64::consts::FRAC_PI_2)
-            .to_degrees();
+        let (lng, lat) = webmerc_to_lnglat(c.x, c.y);
         geo::coord! { x: lng, y: lat }
     })
 }
@@ -872,6 +1223,39 @@ mod tests {
             "58d90ae6c69d16f6",
             "archive bytes diverged from the pre-refactor reference"
         );
+    }
+
+    /// The archive must be byte-identical regardless of partitioning:
+    /// `target=1` forces (roughly) one partition per tile — the maximum
+    /// partition count and maximal per-partition band re-reads — and must
+    /// produce exactly the bytes of the default (large-target) export. With
+    /// `export_archive_matches_pre_refactor_reference` this pins the
+    /// multi-partition path to the pre-refactor output.
+    #[test]
+    fn partitioned_export_is_partition_invariant() {
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        equivalence_fixture(tin.path());
+        let opts = ExportOptions {
+            layer_name: "ref".to_string(),
+            ..Default::default()
+        };
+        let t_many = tempfile::NamedTempFile::new().unwrap();
+        let t_one = tempfile::NamedTempFile::new().unwrap();
+        let r_many =
+            export_pmtiles_with_partition_target(tin.path(), t_many.path(), &opts, 1).unwrap();
+        let r_one = export_pmtiles(tin.path(), t_one.path(), &opts).unwrap();
+
+        let b_many = std::fs::read(t_many.path()).unwrap();
+        let b_one = std::fs::read(t_one.path()).unwrap();
+        assert_eq!(
+            b_many, b_one,
+            "partitioned archive bytes diverge from single-partition archive"
+        );
+        // Reports must agree on everything except wall-clock duration.
+        assert_eq!(r_many.zooms, r_one.zooms);
+        assert_eq!(r_many.total_tiles, r_one.total_tiles);
+        assert_eq!(r_many.total_tile_features, r_one.total_tile_features);
+        assert_eq!(r_many.oversized_tiles, r_one.oversized_tiles);
     }
 
     #[test]
@@ -1078,7 +1462,13 @@ mod tests {
         assert_eq!(tiles[0].feature_count, 1);
 
         let tc = TileCoord::new(tiles[0].x, tiles[0].y, 4);
-        let expected = build_mvt(&[(poly.clone(), 0)], &feats, &tc.bounds(), &opts);
+        let member = Member {
+            key: tile_key(tiles[0].x, tiles[0].y),
+            seq: 0,
+            geom: poly.clone(),
+            props: Arc::new(vec![]),
+        };
+        let expected = build_mvt([&member], &tc.bounds(), &opts);
         assert_eq!(
             tiles[0].data, expected,
             "contained feature must bypass the clip (geometry emitted as-is)"

--- a/crates/core/src/overview/export.rs
+++ b/crates/core/src/overview/export.rs
@@ -813,6 +813,67 @@ mod tests {
 
     // --- tests ---------------------------------------------------------------
 
+    /// Rich 2-level fixture used by the byte-equivalence tests: points, a
+    /// seam-crossing line, a concave polygon and a many-vertex line, with
+    /// id/name properties, at zooms 2 and 4.
+    fn equivalence_fixture(path: &Path) {
+        let pa = Geometry::Point(Point::new(-120.0, 40.0));
+        let pb = Geometry::Point(Point::new(120.0, -40.0));
+        let wide = Geometry::LineString(LineString::from(vec![
+            (-100.0, 10.0),
+            (-80.0, 12.0),
+            (-60.0, 8.0),
+            (-40.0, 11.0),
+        ]));
+        let concave = Geometry::Polygon(geo::Polygon::new(
+            LineString::from(vec![
+                (-100.0, 25.0),
+                (-98.0, 25.0),
+                (-98.0, 27.0),
+                (-99.0, 25.5),
+                (-100.0, 27.0),
+                (-100.0, 25.0),
+            ]),
+            vec![],
+        ));
+        let mut coords = Vec::new();
+        for k in 0..200 {
+            coords.push((30.0 + k as f64 * 0.3, -20.0 + (k as f64 * 0.1).sin()));
+        }
+        let wiggly = Geometry::LineString(LineString::from(coords));
+        write_fixture(
+            path,
+            &[
+                (vec![0, 1], vec![pa.clone(), pb.clone()]),
+                (vec![0, 1, 2, 3, 4], vec![pa, pb, wide, concave, wiggly]),
+            ],
+        );
+    }
+
+    /// Byte-level anchor for the H3(b) export restructure: the whole archive
+    /// (header + directory + metadata + tile data) must hash to the value
+    /// produced by the pre-refactor per-zoom BTreeMap implementation. The
+    /// reference hash was captured from that implementation (commit b8a1635)
+    /// on this exact fixture before the partitioned-streaming rewrite.
+    #[test]
+    fn export_archive_matches_pre_refactor_reference() {
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        equivalence_fixture(tin.path());
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        let opts = ExportOptions {
+            layer_name: "ref".to_string(),
+            ..Default::default()
+        };
+        let report = export_pmtiles(tin.path(), tout.path(), &opts).unwrap();
+        assert_eq!(report.total_tiles, 12);
+        let bytes = std::fs::read(tout.path()).unwrap();
+        assert_eq!(
+            format!("{:016x}", crate::dedup::TileHasher::hash(&bytes)),
+            "58d90ae6c69d16f6",
+            "archive bytes diverged from the pre-refactor reference"
+        );
+    }
+
     #[test]
     fn zoom_mapping_uses_explicit_zoom() {
         let meta = OverviewsMeta {

--- a/crates/core/src/overview/reader.rs
+++ b/crates/core/src/overview/reader.rs
@@ -236,6 +236,24 @@ impl OverviewReader {
             .build()?;
         Ok(reader)
     }
+
+    /// [`Self::read_level`] with an explicit Arrow batch size (the builder
+    /// default is 1024 rows). Larger batches amortize per-batch overhead for
+    /// consumers that do parallel per-row work on each batch (PMTiles export).
+    pub fn read_level_with_batch_size(
+        &self,
+        level_idx: usize,
+        bbox: Option<[f64; 4]>,
+        batch_size: usize,
+    ) -> Result<ParquetRecordBatchReader, ReaderError> {
+        let selected = self.selected_row_groups(level_idx, bbox)?;
+        let file = File::open(&self.path)?;
+        let reader = ParquetRecordBatchReaderBuilder::try_new(file)?
+            .with_row_groups(selected)
+            .with_batch_size(batch_size)
+            .build()?;
+        Ok(reader)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

H3(b) from the hardening roadmap: `export-pmtiles` no longer materializes a whole zoom level's feature groupings before writing. Each zoom is split into contiguous tile-key partitions that run in parallel waves and **stream finished partitions straight to the writer** — memory is now O(wave × partition), independent of dataset size. The serial per-zoom BTreeMap merge (the bottleneck that capped the H3c export speedup at 4.9× of its 8.4× ceiling) is replaced with a parallel grouping sort.

## Moldova (632k polygons, paired pre/post runs on the same loaded machine)

| build | wall | Max RSS |
|---|---:|---:|
| pre-refactor | 75.5 s | 2.41 GB |
| **partitioned streaming** | 73.9 s | **0.89 GB** |

**−63% peak memory, under the 1 GB target, wall time at parity.** (Absolute walls inflated by machine load 13–30 during the benchmark session; the H3c idle baseline was 58.8 s. The freed merge time is currently absorbed by ~3.5× row-read redundancy from per-partition pruned re-reads — noted in H3_NOTES.md as the next lever if export speed matters later.) 17,372 tiles, 1,807,912 tile features, 0 oversized — matches baseline exactly.

## Equivalence — byte-identical

1. Pinned whole-archive xxh3 test captured from the pre-refactor code **before** refactoring; green after.
2. Partition-invariance test: max-partitions vs default → byte-identical archives.
3. Full Moldova archive `cmp` pre vs post: **byte-identical** (reports identical modulo duration).

## Design

Per level: one scan pass (geometry-only decode → per-tile counts/bounds, O(#tiles) state), then partitions of ~32k (feature × tile) members in ascending tile-key order (preserves exact legacy write order), each re-reading a row-group-pruned band subset, clipping in parallel 8k-row batches, grouping via parallel sort, par-encoding tiles, streaming to the serial in-order writer. Properties ride as per-feature `Arc`s. Report JSON, per-zoom logging, `--tile-size-limit`, and tile-buffer semantics preserved.

All 150 `overview::` tests pass; fmt + clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)