### PR TITLE
feat(core): line network coalescing, on by default (Q3)

### DIFF
--- a/context/OVERVIEWS_SPEC.md
+++ b/context/OVERVIEWS_SPEC.md
@@ -879,13 +879,13 @@ segments into single "stroke" LineStrings:
 - **Chaining**: endpoints are matched exactly first, then chain ends
   within a snap tolerance of `snap_tolerance_gsd_factor × gsd` (two
   endpoints closer than one ground sample are indistinguishable at the
-  level). Nodes of **degree 2** always continue a chain. At junctions
-  (three or more compatible endpoints), an implementation MAY continue
-  the pair(s) of lines that best continue each other within a bounded
-  angular deviation from straight (stroke building; gpq-tiles:
-  `--coalesce-junction-angle`, default 30°, `0` = strict degree-2
-  chaining); all other incident lines terminate there, preserving
-  network topology.
+  level). Nodes of **degree 2** always continue a chain; junctions
+  (three or more compatible endpoints) terminate chains by default,
+  preserving network topology. An implementation MAY optionally
+  continue the pair(s) of lines that best continue each other within a
+  bounded angular deviation from straight (stroke building; gpq-tiles:
+  `--coalesce-junction-angle`, default `0` = off per maintainer render
+  review 2026-07-03).
 - **Attributes**: the merged row carries the attribute values of its
   highest-priority member (the same priority order the cell-winner
   stage uses), plus the member count (§13.2).
@@ -963,9 +963,11 @@ no `coalescing` provenance) rather than fail; it SHOULD reject an
 
 - **v0.2.0-draft (2026-07-03, later still)**: §13 revised per
   maintainer review — junction continuation (angle-bounded stroke
-  building at degree >= 3 nodes) added to the chaining model; the
-  gpq-tiles engine default flipped to ON (opt-out); §13.5 reworded
-  for default-on tools (inert in partitioning, reject only explicit
+  building at degree >= 3 nodes) added to the chaining model as an
+  OPTIONAL mechanism (gpq-tiles default OFF: the Portland sweep found
+  strict degree-2 chaining renders better); the gpq-tiles engine
+  coalescing default flipped to ON (opt-out); §13.5 reworded for
+  default-on tools (inert in partitioning, reject only explicit
   requests).
 - **v0.2.0-draft (2026-07-03, later)**: added §13 line coalescing
   extension (`coalesced_count` column, degree-2 endpoint chaining

--- a/context/OVERVIEWS_SPEC.md
+++ b/context/OVERVIEWS_SPEC.md
@@ -863,8 +863,10 @@ introduces new normative requirements for files that opt in.
 
 Coalescing applies to **line features only** (LineString rows; points
 and polygons are unaffected, and MultiLineString rows pass through
-unmerged) and to **`duplicating` mode only** (§13.5). It is **opt-in,
-default off**.
+unmerged) and to **`duplicating` mode only** (§13.5). It is an OPTIONAL
+extension of this spec; whether a producer enables it by default is an
+implementation choice (gpq-tiles: **on by default** since 2026-07-03
+per maintainer render review, opt-out via `--no-coalesce-lines`).
 
 At each non-canonical level, BEFORE the visibility gate and cell-winner
 thinning run, the generalization engine chains touching compatible line
@@ -877,9 +879,13 @@ segments into single "stroke" LineStrings:
 - **Chaining**: endpoints are matched exactly first, then chain ends
   within a snap tolerance of `snap_tolerance_gsd_factor × gsd` (two
   endpoints closer than one ground sample are indistinguishable at the
-  level). Chains extend only through nodes of **degree 2**: junctions
-  where three or more compatible endpoints meet terminate every chain,
-  preserving network topology.
+  level). Nodes of **degree 2** always continue a chain. At junctions
+  (three or more compatible endpoints), an implementation MAY continue
+  the pair(s) of lines that best continue each other within a bounded
+  angular deviation from straight (stroke building; gpq-tiles:
+  `--coalesce-junction-angle`, default 30°, `0` = strict degree-2
+  chaining); all other incident lines terminate there, preserving
+  network topology.
 - **Attributes**: the merged row carries the attribute values of its
   highest-priority member (the same priority order the cell-winner
   stage uses), plus the member count (§13.2).
@@ -937,20 +943,30 @@ values are exactly `1`.
 
 ### 13.5 Partitioning mode is excluded (normative)
 
-`--coalesce-lines` MUST be rejected for `partitioning`-mode files.
-Rationale: partitioning requires every source feature to appear
-**exactly once with its geometry verbatim** (§2.3). A merged chain is a
-new geometry replacing several source rows — it cannot satisfy
-geometry-verbatim, and removing the merged members from the finer bands
-they belong to would break the prefix-read contract (a prefix would no
-longer be a complete coarse rendering plus refinements). No sound
-construction was found; producers who need coalescing use `duplicating`
-mode.
+Coalescing MUST NOT be applied to `partitioning`-mode files. Rationale:
+partitioning requires every source feature to appear **exactly once
+with its geometry verbatim** (§2.3). A merged chain is a new geometry
+replacing several source rows — it cannot satisfy geometry-verbatim,
+and removing the merged members from the finer bands they belong to
+would break the prefix-read contract (a prefix would no longer be a
+complete coarse rendering plus refinements). No sound construction was
+found; producers who need coalescing use `duplicating` mode.
+
+A tool whose coalescing option is enabled **by default** MUST treat a
+partitioning conversion as non-coalesced (no `coalesced_count` column,
+no `coalescing` provenance) rather than fail; it SHOULD reject an
+*explicit* request to coalesce a partitioning conversion.
 
 ---
 
 ## 14. Changelog
 
+- **v0.2.0-draft (2026-07-03, later still)**: §13 revised per
+  maintainer review — junction continuation (angle-bounded stroke
+  building at degree >= 3 nodes) added to the chaining model; the
+  gpq-tiles engine default flipped to ON (opt-out); §13.5 reworded
+  for default-on tools (inert in partitioning, reject only explicit
+  requests).
 - **v0.2.0-draft (2026-07-03, later)**: added §13 line coalescing
   extension (`coalesced_count` column, degree-2 endpoint chaining
   model, `generalization.coalescing` metadata,

--- a/context/OVERVIEWS_SPEC.md
+++ b/context/OVERVIEWS_SPEC.md
@@ -850,8 +850,111 @@ mode.
 
 ---
 
-## 13. Changelog
+## 13. Line coalescing extension (v0.2.0-draft)
 
+Status: draft addition targeted at spec v0.2.0; implemented by gpq-tiles
+behind the opt-in `--coalesce-lines` flag (2026-07-03). Additive: files
+written with coalescing remain valid v0.1.0 overview files (an extra
+optional column + an optional provenance block that v0.1 readers MUST
+ignore per §3.8); the section is versioned v0.2.0-draft because it
+introduces new normative requirements for files that opt in.
+
+### 13.1 Model
+
+Coalescing applies to **line features only** (LineString rows; points
+and polygons are unaffected, and MultiLineString rows pass through
+unmerged) and to **`duplicating` mode only** (§13.5). It is **opt-in,
+default off**.
+
+At each non-canonical level, BEFORE the visibility gate and cell-winner
+thinning run, the generalization engine chains touching compatible line
+segments into single "stroke" LineStrings:
+
+- **Compatibility**: segments chain only within the same class value of
+  the active class-ranking column (when one is active); with no class
+  ranking, all lines are compatible. Null class values are compatible
+  with each other only.
+- **Chaining**: endpoints are matched exactly first, then chain ends
+  within a snap tolerance of `snap_tolerance_gsd_factor × gsd` (two
+  endpoints closer than one ground sample are indistinguishable at the
+  level). Chains extend only through nodes of **degree 2**: junctions
+  where three or more compatible endpoints meet terminate every chain,
+  preserving network topology.
+- **Attributes**: the merged row carries the attribute values of its
+  highest-priority member (the same priority order the cell-winner
+  stage uses), plus the member count (§13.2).
+- The visibility gate and thinning then evaluate the **merged chains**,
+  so a chain of individually sub-visibility fragments survives as one
+  visible artery. This ordering is the point of the extension.
+
+The **canonical level is never coalesced** (§2.4 value fidelity: the
+canonical band remains verbatim source rows plus the constant
+`coalesced_count = 1`).
+
+Feature identity across levels is already NOT guaranteed (§2.2), so a
+merged chain at a coarse level needs no correspondence machinery.
+
+### 13.2 `coalesced_count` column (normative when coalescing)
+
+A coalesced file MUST contain a physical column:
+
+- **Name**: `coalesced_count` (recorded in metadata, §13.4).
+- **Type**: Parquet `INT32`. **Nullability**: NOT NULL.
+- **Domain**: `>= 1`. Non-line rows and unmerged line rows carry `1`.
+- At the **canonical level** every value MUST be `1`.
+
+Writers MUST reject source data whose schema already contains a column
+named `coalesced_count` under case-insensitive comparison (same
+rationale as the `level` column rule, §4.1).
+
+### 13.3 Snap tolerance
+
+The snap tolerance is expressed in GSD multiples so it scales with each
+level's resolution. `1.0` (one ground sample) is the natural default;
+`0` restricts chaining to exact endpoint matches. Implementations MAY
+realize the snap by grid quantization of endpoints (deterministic,
+O(n)); the effective join distance then lies between 0 and √2 × the
+tolerance.
+
+### 13.4 Metadata
+
+Coalescing is recorded in the `generalization` provenance block (§3.5):
+
+```
+Generalization += {
+  "coalescing": {                          // OPTIONAL
+    "enabled":                   true,
+    "snap_tolerance_gsd_factor": number,
+    "coalesced_count_column":    "coalesced_count"
+  }
+}
+```
+
+When `coalescing.enabled` is true a validator MUST enforce §13.2
+structurally: the named column exists as INT32 NOT NULL, all values are
+`>= 1` (checkable via row-group statistics), and the canonical band's
+values are exactly `1`.
+
+### 13.5 Partitioning mode is excluded (normative)
+
+`--coalesce-lines` MUST be rejected for `partitioning`-mode files.
+Rationale: partitioning requires every source feature to appear
+**exactly once with its geometry verbatim** (§2.3). A merged chain is a
+new geometry replacing several source rows — it cannot satisfy
+geometry-verbatim, and removing the merged members from the finer bands
+they belong to would break the prefix-read contract (a prefix would no
+longer be a complete coarse rendering plus refinements). No sound
+construction was found; producers who need coalescing use `duplicating`
+mode.
+
+---
+
+## 14. Changelog
+
+- **v0.2.0-draft (2026-07-03, later)**: added §13 line coalescing
+  extension (`coalesced_count` column, degree-2 endpoint chaining
+  model, `generalization.coalescing` metadata,
+  duplicating-mode-only rule).
 - **v0.2.0-draft (2026-07-03)**: added §12 point clustering extension
   (`point_count` column, numeric attribute accumulation,
   `generalization.clustering` metadata, duplicating-mode-only rule);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -222,6 +222,44 @@ struct OverviewArgs {
     #[arg(long = "accumulate-attribute", value_name = "COL:OP")]
     accumulate_attribute: Vec<String>,
 
+    /// Enable line network coalescing (duplicating mode only; opt-in).
+    ///
+    /// At each non-canonical level, touching same-class line segments are
+    /// chained into single "stroke" LineStrings BEFORE the visibility gate
+    /// and thinning run, so a chain of individually sub-visibility fragments
+    /// survives as one long, connected artery — road/river networks read as
+    /// continuous lines at coarse zooms instead of scattered dashes. Chains
+    /// never merge across class values (when a class ranking is active) or
+    /// through junctions where 3+ segments meet. The merged feature keeps
+    /// the attributes of its highest-priority member, and the output gains
+    /// a `coalesced_count` INT32 NOT NULL column (source segments merged
+    /// per row; 1 for unmerged rows and everywhere at the canonical level).
+    /// Points and polygons are unaffected. See docs/OVERVIEW_TUNING.md.
+    #[arg(long)]
+    coalesce_lines: bool,
+
+    /// Endpoint snap tolerance for --coalesce-lines, in GSD multiples
+    /// (default 1.0).
+    ///
+    /// Exactly-touching endpoints always chain; this knob additionally joins
+    /// chain ends within factor * gsd of each other (two endpoints closer
+    /// than one ground sample are indistinguishable at that level). BIGGER =
+    /// bridges larger digitization gaps (risk: rungs of nearby parallel
+    /// lines fusing); 0 = exact endpoint matching only.
+    #[arg(long, value_name = "F", default_value = "1.0")]
+    coalesce_snap: f64,
+
+    /// Per-level candidate-line ceiling for --coalesce-lines (memory guard).
+    ///
+    /// Chaining holds the level's candidate line geometries in memory at
+    /// once (every line is a candidate at every non-canonical level, since
+    /// sub-visibility fragments must be reclaimable). Datasets with more
+    /// lines than this skip coalescing with a warning instead of breaking
+    /// the streaming pipeline's memory bound; near-canonical levels that
+    /// large need coalescing least (segments are individually visible).
+    #[arg(long, value_name = "ROWS", default_value = "2000000")]
+    coalesce_max_level_rows: usize,
+
     /// Emit the optional COGP compatibility footer key (partitioning mode).
     #[arg(long)]
     cogp_compat: bool,
@@ -1114,6 +1152,15 @@ fn run_overview(args: OverviewArgs) -> Result<()> {
         .map(|s| parse_accumulate(s))
         .collect::<Result<Vec<_>>>()?;
 
+    // Coalescing flags (Q3; also enforced in core).
+    if args.coalesce_lines && mode == Mode::Partitioning {
+        anyhow::bail!(
+            "--coalesce-lines requires --mode duplicating: partitioning places \
+             each feature exactly once with geometry verbatim, which a merged \
+             chain cannot satisfy"
+        );
+    }
+
     let options = ConvertOptions {
         mode,
         levels,
@@ -1138,6 +1185,9 @@ fn run_overview(args: OverviewArgs) -> Result<()> {
         read_batch_size: args.read_batch_size,
         cluster: args.cluster,
         accumulate,
+        coalesce_lines: args.coalesce_lines,
+        coalesce_snap: args.coalesce_snap,
+        coalesce_max_level_rows: args.coalesce_max_level_rows,
     };
 
     let report = convert_to_overviews(&args.input, &args.output, &options)

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -222,23 +222,46 @@ struct OverviewArgs {
     #[arg(long = "accumulate-attribute", value_name = "COL:OP")]
     accumulate_attribute: Vec<String>,
 
-    /// Enable line network coalescing (duplicating mode only; opt-in).
+    /// Disable line network coalescing (ON by default; duplicating mode).
     ///
-    /// At each non-canonical level, touching same-class line segments are
-    /// chained into single "stroke" LineStrings BEFORE the visibility gate
-    /// and thinning run, so a chain of individually sub-visibility fragments
-    /// survives as one long, connected artery — road/river networks read as
-    /// continuous lines at coarse zooms instead of scattered dashes. Chains
-    /// never merge across class values (when a class ranking is active) or
-    /// through junctions where 3+ segments meet. The merged feature keeps
-    /// the attributes of its highest-priority member, and the output gains
-    /// a `coalesced_count` INT32 NOT NULL column (source segments merged
-    /// per row; 1 for unmerged rows and everywhere at the canonical level).
-    /// Points and polygons are unaffected. See docs/OVERVIEW_TUNING.md.
+    /// By default, at each non-canonical level touching same-class line
+    /// segments are chained into single "stroke" LineStrings BEFORE the
+    /// visibility gate and thinning run, so a chain of individually
+    /// sub-visibility fragments survives as one long, connected artery —
+    /// road/river networks read as continuous lines at coarse zooms instead
+    /// of scattered dashes. Chains never merge across class values (when a
+    /// class ranking is active); junctions continue only within
+    /// --coalesce-junction-angle of straight. The merged feature keeps the
+    /// attributes of its highest-priority member, and the output gains a
+    /// `coalesced_count` INT32 NOT NULL column (source segments merged per
+    /// row; 1 for unmerged rows and everywhere at the canonical level).
+    /// Points and polygons are unaffected. In partitioning mode coalescing
+    /// is inert (a merged chain cannot satisfy the feature-once/verbatim
+    /// contract). See docs/OVERVIEW_TUNING.md.
     #[arg(long)]
+    no_coalesce_lines: bool,
+
+    /// Deprecated no-op: coalescing is now the default. Kept so existing
+    /// invocations keep working; rejected with partitioning mode (where the
+    /// default silently disables instead).
+    #[arg(long, hide = true, conflicts_with = "no_coalesce_lines")]
     coalesce_lines: bool,
 
-    /// Endpoint snap tolerance for --coalesce-lines, in GSD multiples
+    /// Junction continuation angle for line coalescing, in degrees
+    /// (default 30).
+    ///
+    /// At a junction (3+ same-class segment endpoints meeting), the pair of
+    /// lines that best continue each other merge when their deviation from
+    /// a straight continuation is at most this angle — best pair first, so
+    /// a 4-way crossing continues BOTH through-streets. BIGGER = chains
+    /// bend further through junctions (longer, fewer strokes; risk of
+    /// merging through genuine turns); 0 = never merge through junctions
+    /// (strict degree-2 chaining). See the Portland junction-angle sweep in
+    /// corpus/data/bench/q3/.
+    #[arg(long, value_name = "DEG", default_value = "30.0")]
+    coalesce_junction_angle: f64,
+
+    /// Endpoint snap tolerance for line coalescing, in GSD multiples
     /// (default 1.0).
     ///
     /// Exactly-touching endpoints always chain; this knob additionally joins
@@ -249,7 +272,7 @@ struct OverviewArgs {
     #[arg(long, value_name = "F", default_value = "1.0")]
     coalesce_snap: f64,
 
-    /// Per-level candidate-line ceiling for --coalesce-lines (memory guard).
+    /// Per-level candidate-line ceiling for line coalescing (memory guard).
     ///
     /// Chaining holds the level's candidate line geometries in memory at
     /// once (every line is a candidate at every non-canonical level, since
@@ -1152,7 +1175,10 @@ fn run_overview(args: OverviewArgs) -> Result<()> {
         .map(|s| parse_accumulate(s))
         .collect::<Result<Vec<_>>>()?;
 
-    // Coalescing flags (Q3; also enforced in core).
+    // Coalescing flags (Q3). Coalescing is ON by default (opt out with
+    // --no-coalesce-lines); with partitioning mode the default is silently
+    // inert (core logs it), but an EXPLICIT --coalesce-lines request is an
+    // error the user should hear about.
     if args.coalesce_lines && mode == Mode::Partitioning {
         anyhow::bail!(
             "--coalesce-lines requires --mode duplicating: partitioning places \
@@ -1160,6 +1186,7 @@ fn run_overview(args: OverviewArgs) -> Result<()> {
              chain cannot satisfy"
         );
     }
+    let coalesce_lines = !args.no_coalesce_lines;
 
     let options = ConvertOptions {
         mode,
@@ -1185,9 +1212,10 @@ fn run_overview(args: OverviewArgs) -> Result<()> {
         read_batch_size: args.read_batch_size,
         cluster: args.cluster,
         accumulate,
-        coalesce_lines: args.coalesce_lines,
+        coalesce_lines,
         coalesce_snap: args.coalesce_snap,
         coalesce_max_level_rows: args.coalesce_max_level_rows,
+        coalesce_junction_angle: args.coalesce_junction_angle,
     };
 
     let report = convert_to_overviews(&args.input, &args.output, &options)

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -248,17 +248,18 @@ struct OverviewArgs {
     coalesce_lines: bool,
 
     /// Junction continuation angle for line coalescing, in degrees
-    /// (default 30).
+    /// (default 0 = OFF: junctions terminate chains, preserving network
+    /// topology — chosen from the Portland junction-angle sweep in
+    /// corpus/data/bench/q3/, where strict degree-2 chaining rendered
+    /// better).
     ///
-    /// At a junction (3+ same-class segment endpoints meeting), the pair of
-    /// lines that best continue each other merge when their deviation from
-    /// a straight continuation is at most this angle — best pair first, so
-    /// a 4-way crossing continues BOTH through-streets. BIGGER = chains
-    /// bend further through junctions (longer, fewer strokes; risk of
-    /// merging through genuine turns); 0 = never merge through junctions
-    /// (strict degree-2 chaining). See the Portland junction-angle sweep in
-    /// corpus/data/bench/q3/.
-    #[arg(long, value_name = "DEG", default_value = "30.0")]
+    /// When > 0: at a junction (3+ same-class segment endpoints meeting),
+    /// the pair of lines that best continue each other merge when their
+    /// deviation from a straight continuation is at most this angle — best
+    /// pair first, so a 4-way crossing continues BOTH through-streets.
+    /// BIGGER = chains bend further through junctions (longer, fewer
+    /// strokes; risk of merging through genuine turns).
+    #[arg(long, value_name = "DEG", default_value = "0.0")]
     coalesce_junction_angle: f64,
 
     /// Endpoint snap tolerance for line coalescing, in GSD multiples

--- a/crates/core/src/overview/assign.rs
+++ b/crates/core/src/overview/assign.rs
@@ -651,7 +651,9 @@ fn priority_order(prio: &[Priority], a: usize, b: usize) -> Ordering {
 /// super-cells, fair-allocate the budget across them ([`water_fill`]) and keep
 /// each cell's top-priority members. Deterministic (cells iterated in sorted
 /// key order; ties broken by [`Priority`]'s index tiebreak).
-fn select_budget_survivors(
+/// `pub(super)` so the coalescing stage (`super::coalesce`) can apply the
+/// same per-level budget + spatial fairness to merged chains.
+pub(super) fn select_budget_survivors(
     cands: &[usize],
     available: usize,
     features: &[AssignFeature],

--- a/crates/core/src/overview/check.rs
+++ b/crates/core/src/overview/check.rs
@@ -270,6 +270,16 @@ pub fn validate_metadata(metadata: &ParquetMetaData) -> ValidationReport {
         check_clustering(metadata, meta.as_ref().unwrap(), cl, &mut report);
     }
 
+    // --- coalescing metadata (Q3): coalesced_count column + canonical values.
+    if let Some(co) = meta
+        .as_ref()
+        .and_then(|m| m.generalization.as_ref())
+        .and_then(|g| g.coalescing.as_ref())
+        .filter(|c| c.enabled)
+    {
+        check_coalescing(metadata, meta.as_ref().unwrap(), co, &mut report);
+    }
+
     // --- covering column per-RG min/max stats present (§4.4). ----------------
     match &covering {
         None => { /* already failed geoparquet_covering_declared */ }
@@ -451,6 +461,111 @@ fn check_clustering(
         );
     } else {
         report.fail("cluster_point_count_values", problems.join("; "));
+    }
+}
+
+/// Coalescing conformance (Q3, spec §13 draft): when the footer's
+/// `generalization.coalescing` block is present and enabled,
+/// - the mode must be `duplicating` (merged chains cannot satisfy
+///   partitioning's feature-once / geometry-verbatim contract);
+/// - the named merged-count column must exist as INT32 NOT NULL;
+/// - every row group's coalesced_count stats must have `min >= 1`, and the
+///   canonical level band's must be exactly `min == max == 1` (the
+///   canonical level is never coalesced, §2.4).
+fn check_coalescing(
+    metadata: &ParquetMetaData,
+    meta: &OverviewsMeta,
+    coalescing: &crate::overview::level::CoalescingProvenance,
+    report: &mut ValidationReport,
+) {
+    // Mode: duplicating only.
+    match meta.mode {
+        Some(Mode::Duplicating) => report.pass(
+            "coalesce_mode",
+            "coalescing metadata on a duplicating-mode file",
+        ),
+        other => {
+            report.fail(
+                "coalesce_mode",
+                format!(
+                    "coalescing metadata requires duplicating mode, found {other:?} \
+                     (a merged chain replaces several source rows, which \
+                     partitioning's feature-once contract cannot represent)"
+                ),
+            );
+            return;
+        }
+    }
+
+    // Column exists, INT32, NOT NULL.
+    let name = coalescing.coalesced_count_column.as_str();
+    let descr = metadata.file_metadata().schema_descr();
+    let col_idx = (0..descr.num_columns()).find(|&i| descr.column(i).path().string() == name);
+    let col_idx = match col_idx {
+        None => {
+            report.fail(
+                "coalesce_count_column",
+                format!("coalescing metadata names column {name:?} but it is absent"),
+            );
+            return;
+        }
+        Some(idx) => {
+            let col = descr.column(idx);
+            let phys_ok = col.physical_type() == PhysicalType::INT32;
+            let required = col.max_def_level() == 0;
+            if phys_ok && required {
+                report.pass(
+                    "coalesce_count_column",
+                    format!("{name:?} is INT32 NOT NULL"),
+                );
+                idx
+            } else {
+                report.fail(
+                    "coalesce_count_column",
+                    format!(
+                        "{name:?} must be INT32 NOT NULL (physical={:?}, max_def_level={})",
+                        col.physical_type(),
+                        col.max_def_level()
+                    ),
+                );
+                return;
+            }
+        }
+    };
+
+    // Values: min >= 1 everywhere; canonical band exactly 1 (via RG stats).
+    let canonical = meta.canonical_level;
+    let mut problems: Vec<String> = Vec::new();
+    for rg in 0..metadata.num_row_groups() {
+        let is_canonical = level_for_rg(meta, rg).map(|k| k as i64) == canonical;
+        let chunk = metadata.row_group(rg).column(col_idx);
+        match chunk.statistics() {
+            Some(Statistics::Int32(s)) => match (s.min_opt(), s.max_opt()) {
+                (Some(&min), Some(&max)) => {
+                    if min < 1 {
+                        problems.push(format!("RG {rg}: coalesced_count min={min} < 1"));
+                    }
+                    if is_canonical && (min != 1 || max != 1) {
+                        problems.push(format!(
+                            "RG {rg} (canonical): coalesced_count min={min} max={max}, expected 1"
+                        ));
+                    }
+                }
+                _ => problems.push(format!("RG {rg}: coalesced_count has no min/max stats")),
+            },
+            Some(other) => problems.push(format!(
+                "RG {rg}: coalesced_count stats not Int32 ({other:?})"
+            )),
+            None => problems.push(format!("RG {rg}: coalesced_count column has no statistics")),
+        }
+    }
+    if problems.is_empty() {
+        report.pass(
+            "coalesce_count_values",
+            "coalesced_count >= 1 everywhere; canonical level all 1",
+        );
+    } else {
+        report.fail("coalesce_count_values", problems.join("; "));
     }
 }
 
@@ -798,6 +913,7 @@ mod tests {
                     op: "sum".to_string(),
                 }],
             }),
+            coalescing: None,
         });
 
         let mut writer = OverviewWriter::create(path, &schema, opts).unwrap();
@@ -891,6 +1007,147 @@ mod tests {
             report.check_passed("cluster_point_count_values"),
             Some(false)
         );
+    }
+
+    // --- Q3 coalescing checks -------------------------------------------------
+
+    /// Write a duplicating fixture whose footer carries coalescing
+    /// provenance. `coalesced_counts` supplies per-level `coalesced_count`
+    /// values (parallel to `level_ids`); `None` omits the column entirely.
+    fn write_coalesce_fixture(
+        path: &std::path::Path,
+        level_ids: &[Vec<i64>],
+        coalesced_counts: Option<&[Vec<i32>]>,
+    ) {
+        use crate::overview::level::{CoalescingProvenance, Generalization};
+        use arrow_array::Int32Array as I32;
+
+        let mut fields = vec![
+            Arc::new(Field::new("id", DataType::Int64, false)),
+            Arc::new(Field::new("name", DataType::Utf8, false)),
+            Arc::new(geometry_field()),
+        ];
+        if coalesced_counts.is_some() {
+            fields.push(Arc::new(Field::new(
+                "coalesced_count",
+                DataType::Int32,
+                false,
+            )));
+        }
+        let schema = Arc::new(Schema::new(fields));
+
+        let specs: Vec<LevelSpec> = (0..level_ids.len())
+            .map(|k| {
+                let z = (2 + 2 * k) as u8;
+                LevelSpec::new(gsd(z), Some(z))
+            })
+            .collect();
+        let mut opts = OverviewWriterOptions::new(Mode::Duplicating, specs);
+        opts.generalization = Some(Generalization {
+            engine: "gpq-tiles test".to_string(),
+            gsd_base: None,
+            levels: vec![],
+            ranking: None,
+            density_drop: None,
+            clustering: None,
+            coalescing: Some(CoalescingProvenance {
+                enabled: true,
+                snap_tolerance_gsd_factor: 1.0,
+                coalesced_count_column: "coalesced_count".to_string(),
+            }),
+        });
+
+        let mut writer = OverviewWriter::create(path, &schema, opts).unwrap();
+        for (k, ids) in level_ids.iter().enumerate() {
+            let id_array = Int64Array::from(ids.to_vec());
+            let name_array =
+                StringArray::from(ids.iter().map(|id| format!("f{id}")).collect::<Vec<_>>());
+            let geom_array = build_geometry_array(ids);
+            let mut columns: Vec<Arc<dyn arrow_array::Array>> = vec![
+                Arc::new(id_array),
+                Arc::new(name_array),
+                Arc::new(geom_array.to_array_ref()),
+            ];
+            if let Some(counts) = coalesced_counts {
+                columns.push(Arc::new(I32::from(counts[k].clone())));
+            }
+            let batch = RecordBatch::try_new(schema.clone(), columns).unwrap();
+            writer
+                .write_level(k, Some(ids.len()), std::iter::once(batch))
+                .unwrap();
+        }
+        writer.finish().unwrap();
+    }
+
+    #[test]
+    fn coalescing_good_file_passes() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        write_coalesce_fixture(
+            tmp.path(),
+            &[vec![0], vec![0, 1, 2]],
+            Some(&[vec![3], vec![1, 1, 1]]),
+        );
+        let report = validate_file(tmp.path()).unwrap();
+        assert!(
+            report.is_valid(),
+            "unexpected failures: {:?}",
+            report.failures().collect::<Vec<_>>()
+        );
+        assert_eq!(report.check_passed("coalesce_mode"), Some(true));
+        assert_eq!(report.check_passed("coalesce_count_column"), Some(true));
+        assert_eq!(report.check_passed("coalesce_count_values"), Some(true));
+    }
+
+    #[test]
+    fn coalescing_metadata_without_column_fails() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        write_coalesce_fixture(tmp.path(), &[vec![0], vec![0, 1, 2]], None);
+        let report = validate_file(tmp.path()).unwrap();
+        assert!(!report.is_valid());
+        assert_eq!(report.check_passed("coalesce_count_column"), Some(false));
+    }
+
+    #[test]
+    fn coalescing_canonical_count_not_one_fails() {
+        // Canonical level carries a coalesced_count of 2 → conformance fail.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        write_coalesce_fixture(
+            tmp.path(),
+            &[vec![0], vec![0, 1, 2]],
+            Some(&[vec![3], vec![1, 2, 1]]),
+        );
+        let report = validate_file(tmp.path()).unwrap();
+        assert!(!report.is_valid());
+        assert_eq!(report.check_passed("coalesce_count_values"), Some(false));
+    }
+
+    #[test]
+    fn coalescing_zero_count_fails() {
+        // A coalesced_count of 0 anywhere violates the >= 1 invariant.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        write_coalesce_fixture(
+            tmp.path(),
+            &[vec![0], vec![0, 1, 2]],
+            Some(&[vec![0], vec![1, 1, 1]]),
+        );
+        let report = validate_file(tmp.path()).unwrap();
+        assert!(!report.is_valid());
+        assert_eq!(report.check_passed("coalesce_count_values"), Some(false));
+    }
+
+    #[test]
+    fn no_coalescing_metadata_skips_checks() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        write_fixture(
+            tmp.path(),
+            Mode::Duplicating,
+            &[vec![0, 2], vec![0, 1, 2, 3]],
+            false,
+        );
+        let report = validate_file(tmp.path()).unwrap();
+        assert!(report.is_valid());
+        assert_eq!(report.check_passed("coalesce_mode"), None);
+        assert_eq!(report.check_passed("coalesce_count_column"), None);
     }
 
     #[test]

--- a/crates/core/src/overview/coalesce.rs
+++ b/crates/core/src/overview/coalesce.rs
@@ -24,12 +24,12 @@
 //!    coordinates), then a **snap** pass that joins the resulting chains'
 //!    free endpoints quantized to `snap_gsd_factor × GSD` grid cells
 //!    (closing sub-resolution digitization gaps). Both phases join nodes
-//!    of **degree 2** unconditionally; at junctions (degree >= 3) the
-//!    incident pairs that continue each other within
-//!    [`CoalesceParams::junction_angle_deg`] of straight merge best-pair
-//!    first (stroke building — arterials chain THROUGH same-class
-//!    crossings; a sharp turn stays a chain boundary; `0` restores strict
-//!    degree-2-only chaining).
+//!    of **degree 2** unconditionally — junctions (degree >= 3) terminate
+//!    chains by default, preserving network topology. Optionally
+//!    ([`CoalesceParams::junction_angle_deg`] > 0, default OFF per
+//!    maintainer render review), the incident pairs at a junction that
+//!    continue each other within that deviation of straight merge
+//!    best-pair first (stroke building).
 //! 3. The merged feature takes the attributes of its **highest-priority
 //!    member** (the same [`Priority`] order the cell-winner stage uses),
 //!    and records the number of merged source segments
@@ -82,15 +82,15 @@ pub const COALESCED_COUNT_COLUMN: &str = "coalesced_count";
 /// one ground sample distance are indistinguishable at the level.
 pub const DEFAULT_SNAP_GSD_FACTOR: f64 = 1.0;
 
-/// Default junction continuation threshold, in degrees: at a junction
-/// (node degree >= 3), the pair of incident lines that best continue each
-/// other merge when their deviation from a straight continuation is at
-/// most this angle. `30°` keeps arterials chaining through the frequent
-/// same-class crossings that otherwise break every stroke, while a sharp
-/// turn onto a side street stays a chain boundary. Provisional default
-/// pending the maintainer's Portland junction-angle sweep
-/// (`corpus/data/bench/q3/portland-roads-junction{00,30,60}.pmtiles`).
-pub const DEFAULT_JUNCTION_ANGLE_DEG: f64 = 30.0;
+/// Default junction continuation threshold, in degrees. **`0` = OFF**
+/// (strict degree-2 chaining): the maintainer's Portland junction-angle
+/// sweep (`corpus/data/bench/q3/portland-roads-junction{00,30}.pmtiles`,
+/// reviewed 2026-07-03) found strict degree-2 chaining renders better —
+/// junction continuation over-merges. The knob remains available
+/// (`--coalesce-junction-angle DEG`): at a junction (node degree >= 3)
+/// the pair of incident lines that best continue each other merge when
+/// their deviation from a straight continuation is at most the angle.
+pub const DEFAULT_JUNCTION_ANGLE_DEG: f64 = 0.0;
 
 /// Default per-level candidate-row ceiling above which coalescing is
 /// skipped (bounded-memory guard; see `docs/OVERVIEW_TUNING.md`). Chaining

--- a/crates/core/src/overview/coalesce.rs
+++ b/crates/core/src/overview/coalesce.rs
@@ -1,0 +1,745 @@
+//! Line network coalescing for overview levels (plan Q3).
+//!
+//! At coarse levels, line networks (roads, rivers) degrade into scattered
+//! dashes: segments whose bbox diagonal is below the visibility gate
+//! (`line_visibility × GSD`, see [`super::assign`]) are dropped, and
+//! cell-winner thinning keeps disconnected fragments of what remains. This
+//! stage glues touching same-class segments into single "stroke"
+//! LineStrings **before** the visibility gate and thinning run, so a chain
+//! of individually sub-visibility segments survives as one long, visible
+//! artery. That ordering — chain first, gate/thin the *chains* — is the
+//! entire payoff.
+//!
+//! # Model (duplicating mode, non-canonical levels only)
+//!
+//! Per overview level:
+//!
+//! 1. **Group** line features by a compatibility key: the class value of
+//!    the active class-ranking column (Q1 explicit `--class-rank` or the
+//!    auto-detected Overture `class`/`road_class`), else all lines are
+//!    compatible. Chaining never crosses groups.
+//! 2. **Chain** segments within a group whose endpoints coincide, in two
+//!    phases: **exact** coordinate matching first (GSD-independent — the
+//!    dominant case, since OSM/Overture segments share exact node
+//!    coordinates), then a **snap** pass that joins the resulting chains'
+//!    free endpoints quantized to `snap_gsd_factor × GSD` grid cells
+//!    (closing sub-resolution digitization gaps). Both phases join only
+//!    through nodes of **degree 2** — junctions where three or more
+//!    endpoints meet terminate every chain, preserving network topology.
+//! 3. The merged feature takes the attributes of its **highest-priority
+//!    member** (the same [`Priority`] order the cell-winner stage uses),
+//!    and records the number of merged source segments
+//!    (`coalesced_count`, 1 for unmerged).
+//! 4. The **visibility gate** and **cell-winner thinning** then run on the
+//!    merged chains (gate on the chain's bbox diagonal; one chain per
+//!    `line_thinning × GSD` grid cell, best [`Priority`] wins).
+//!
+//! The canonical level is NEVER coalesced (spec §2.4 value fidelity), and
+//! partitioning mode rejects coalescing outright (merged geometries violate
+//! §2.3's feature-once / geometry-verbatim contract; see
+//! `ConvertError::CoalescePartitioningUnsupported`).
+//!
+//! # DIVERGENCE FROM TIPPECANOE
+//!
+//! Tippecanoe's `--coalesce` merges *consecutive* same-attribute features
+//! into multi-geometries without topological chaining (tile.cpp, coalesce
+//! path); its shared-node machinery protects junction vertices during
+//! simplification rather than building strokes. Our endpoint chaining
+//! through degree-2 nodes matches planetiler's `mergeLineStrings`
+//! behavior (the standard cartographic stroke-building operation), while
+//! keeping tippecanoe's *philosophy*: never merge across attribute
+//! (class) boundaries, never merge through junctions, deterministic
+//! output. We also merge with a snap tolerance of one GSD — two endpoints
+//! closer than one ground sample are indistinguishable at the level — where
+//! planetiler uses exact matches after tile-grid quantization (an
+//! equivalent idea in tile space).
+//!
+//! # Determinism
+//!
+//! Segments are processed in input order; joins are a pure function of the
+//! endpoint grid; walk starts are chosen by smallest feature index; ties in
+//! gating/thinning fall back to the strict [`Priority`] total order. No
+//! result depends on hash-map iteration order.
+
+use std::collections::HashMap;
+
+use geo::{BoundingRect, Geometry, LineString};
+
+use super::assign::{AssignConfig, AssignFeature, FeatureKind, Priority};
+use super::level::Crs;
+
+/// Name of the merged-segment-count column written when coalescing is
+/// enabled (INT32, 1 for unmerged rows; always 1 at the canonical level).
+pub const COALESCED_COUNT_COLUMN: &str = "coalesced_count";
+
+/// Default endpoint snap tolerance, in GSD multiples: two endpoints within
+/// one ground sample distance are indistinguishable at the level.
+pub const DEFAULT_SNAP_GSD_FACTOR: f64 = 1.0;
+
+/// Default per-level candidate-row ceiling above which coalescing is
+/// skipped (bounded-memory guard; see `docs/OVERVIEW_TUNING.md`). Chaining
+/// needs the level's line geometries in memory at once; levels larger than
+/// this are near-canonical, where segments are individually visible and
+/// coalescing matters least.
+pub const DEFAULT_COALESCE_MAX_LEVEL_ROWS: usize = 2_000_000;
+
+/// One candidate line feature for a level's coalescing pass.
+#[derive(Debug, Clone)]
+pub struct CoalesceInput<'a> {
+    /// Caller-owned feature identifier (typically the source row index).
+    pub index: usize,
+    /// The feature's geometry. Only single `LineString`s participate in
+    /// chaining; `MultiLineString`/`Line` features pass through as
+    /// unmerged singletons (still gated and thinned as chains of one).
+    pub geom: &'a Geometry<f64>,
+    /// Cell-winner sort key (Q1 ranking), for priority inheritance.
+    pub sort_key: Option<f64>,
+    /// Compatibility group id (interned class value). Chaining never
+    /// crosses groups.
+    pub group: u32,
+}
+
+/// One surviving coalesced chain at a level.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CoalescedLine {
+    /// Index of the highest-priority member — the source row that donates
+    /// the merged feature's attributes.
+    pub rep: usize,
+    /// Number of source segments merged into this chain (>= 1).
+    pub count: i32,
+    /// The merged geometry (a single `LineString` for merged chains; the
+    /// original geometry for singletons).
+    pub geom: Geometry<f64>,
+}
+
+/// End discriminant of a chainable segment: 0 = first vertex, 1 = last.
+type End = u8;
+
+/// Quantized endpoint node key, namespaced by compatibility group.
+type NodeKey = (u32, i64, i64);
+
+/// Coalesce one level's candidate lines: chain within compatibility groups
+/// through degree-2 endpoint nodes, then apply the visibility gate and
+/// cell-winner thinning to the merged chains. Returns the surviving chains
+/// ordered by ascending `rep` index.
+///
+/// - `gsd_m`: the level's GSD in meters (governs snap tolerance, gate, and
+///   thinning grid). Non-positive GSD returns every input as an ungated
+///   singleton (degenerate; callers pass canonical levels elsewhere).
+/// - `config`: the assignment configuration; `line_visibility`,
+///   `line_thinning`, and `sort_direction` are used.
+/// - `snap_gsd_factor`: endpoint snap tolerance in GSD multiples. `<= 0`
+///   means exact coordinate matching only.
+pub fn coalesce_level_lines(
+    lines: &[CoalesceInput<'_>],
+    gsd_m: f64,
+    crs: Crs,
+    config: &AssignConfig,
+    snap_gsd_factor: f64,
+) -> Vec<CoalescedLine> {
+    if lines.is_empty() {
+        return Vec::new();
+    }
+    let gsd_units = crs.meters_to_units(gsd_m);
+    let snap_tol = if gsd_units > 0.0 {
+        snap_gsd_factor * gsd_units
+    } else {
+        0.0
+    };
+
+    // --- 1+2. Build chains (grouped, degree-2 endpoint joins). --------------
+    let chains = build_chains(lines, snap_tol);
+
+    // --- Priorities + sort keys of the members (the cell-winner order, Q1). --
+    let mut prio: HashMap<usize, Priority> = HashMap::with_capacity(lines.len());
+    let mut sort_keys: HashMap<usize, Option<f64>> = HashMap::with_capacity(lines.len());
+    for l in lines {
+        let feat = AssignFeature {
+            index: l.index,
+            bbox: geom_bbox(l.geom),
+            kind: FeatureKind::Line,
+            sort_key: l.sort_key,
+        };
+        prio.insert(l.index, Priority::new(&feat, config.sort_direction));
+        sort_keys.insert(l.index, l.sort_key);
+    }
+
+    // --- 3. Merge geometry + inherit the best member's attributes. ----------
+    let mut merged: Vec<CoalescedLine> = Vec::with_capacity(chains.len());
+    for chain in chains {
+        let rep = chain
+            .members
+            .iter()
+            .copied()
+            .reduce(|best, m| {
+                if prio[&m].beats(&prio[&best]) {
+                    m
+                } else {
+                    best
+                }
+            })
+            .expect("chain has at least one member");
+        merged.push(CoalescedLine {
+            rep,
+            count: chain.members.len() as i32,
+            geom: chain.geom,
+        });
+    }
+
+    // --- 4a. Visibility gate on the CHAIN's bbox diagonal. -------------------
+    let gate = config.line_visibility * gsd_units;
+    let gate_sq = gate * gate;
+    let mut gated: Vec<(CoalescedLine, AssignFeature)> = Vec::with_capacity(merged.len());
+    for line in merged {
+        let bbox = geom_bbox(&line.geom);
+        let (dx, dy) = (bbox[2] - bbox[0], bbox[3] - bbox[1]);
+        if gate > 0.0 && dx * dx + dy * dy < gate_sq {
+            continue; // whole chain still below visibility at this level
+        }
+        // The chain competes in thinning with its rep member's sort key but
+        // its OWN bbox: a long merged artery out-ranks the short fragments a
+        // non-coalesced run would have fielded in the same cell.
+        let feat = AssignFeature {
+            index: line.rep,
+            bbox,
+            kind: FeatureKind::Line,
+            sort_key: sort_keys[&line.rep],
+        };
+        gated.push((line, feat));
+    }
+
+    // --- 4b. Cell-winner thinning among the surviving chains. ----------------
+    let cell_size = gsd_units * config.line_thinning;
+    let survivors: Vec<CoalescedLine> = if cell_size > 0.0 && !cell_size.is_nan() {
+        let chain_prio: Vec<Priority> = gated
+            .iter()
+            .map(|(_, f)| Priority::new(f, config.sort_direction))
+            .collect();
+        // cell -> position of the best chain so far in `gated`.
+        let mut grid: HashMap<(i64, i64), usize> = HashMap::new();
+        for (pos, (_, feat)) in gated.iter().enumerate() {
+            let (cx, cy) = feat.center();
+            let key = (
+                (cx / cell_size).floor() as i64,
+                (cy / cell_size).floor() as i64,
+            );
+            grid.entry(key)
+                .and_modify(|best| {
+                    if chain_prio[pos].beats(&chain_prio[*best]) {
+                        *best = pos;
+                    }
+                })
+                .or_insert(pos);
+        }
+        let mut keep: Vec<usize> = grid.into_values().collect();
+        keep.sort_unstable();
+        let mut out = Vec::with_capacity(keep.len());
+        let mut gated = gated;
+        // Drain winners in ascending position order (stable, deterministic).
+        for (offset, pos) in keep.into_iter().enumerate() {
+            out.push(gated.remove(pos - offset).0);
+        }
+        out
+    } else {
+        gated.into_iter().map(|(l, _)| l).collect()
+    };
+
+    let mut survivors = survivors;
+    survivors.sort_by_key(|c| c.rep);
+    survivors
+}
+
+/// `[xmin, ymin, xmax, ymax]` of a geometry (`[0;4]` when undefined).
+fn geom_bbox(g: &Geometry<f64>) -> [f64; 4] {
+    match g.bounding_rect() {
+        Some(r) => [r.min().x, r.min().y, r.max().x, r.max().y],
+        None => [0.0, 0.0, 0.0, 0.0],
+    }
+}
+
+/// An assembled chain before priority/gating: its ordered members and the
+/// merged geometry.
+struct RawChain {
+    members: Vec<usize>,
+    geom: Geometry<f64>,
+}
+
+/// A joinable polyline piece during chaining: one or more already-merged
+/// source segments with an owned, oriented coordinate run.
+struct Piece {
+    /// Source feature indices ([`CoalesceInput::index`]) merged so far.
+    members: Vec<usize>,
+    coords: Vec<geo::Coord<f64>>,
+    group: u32,
+}
+
+/// Exact node key: coordinate bit pattern (phase 1).
+#[inline]
+fn exact_key(group: u32, c: geo::Coord<f64>) -> NodeKey {
+    (group, c.x.to_bits() as i64, c.y.to_bits() as i64)
+}
+
+/// Snapped node key: endpoints quantized to `tol`-sized grid cells (phase 2).
+#[inline]
+fn snap_key(group: u32, c: geo::Coord<f64>, tol: f64) -> NodeKey {
+    (
+        group,
+        (c.x / tol).floor() as i64,
+        (c.y / tol).floor() as i64,
+    )
+}
+
+/// Build the chains for one level in **two phases**:
+///
+/// 1. **Exact matching**: chain segments whose endpoints are bit-identical
+///    (the dominant case — OSM/Overture networks share exact node
+///    coordinates). This is GSD-independent, so chains form even when
+///    segments are far shorter than the snap tolerance (the coarse-zoom
+///    norm, where a one-phase snapped graph would collapse a short
+///    segment's own two endpoints into a single node and never join it).
+/// 2. **Snap pass**: re-run the same degree-2 join over the *resulting
+///    chains'* free endpoints, quantized to `snap_tol` grid cells —
+///    closing small digitization gaps at the level's resolution. Skipped
+///    when `snap_tol <= 0` (exact matching only).
+fn build_chains(lines: &[CoalesceInput<'_>], snap_tol: f64) -> Vec<RawChain> {
+    // Chainable = plain LineString with >= 2 coordinates. Everything else
+    // (MultiLineString, Line, degenerate) is an unmerged singleton.
+    let mut pieces: Vec<Piece> = Vec::new();
+    let mut singles: Vec<usize> = Vec::new(); // positions in `lines`
+    for (pos, l) in lines.iter().enumerate() {
+        match l.geom {
+            Geometry::LineString(ls) if ls.0.len() >= 2 => pieces.push(Piece {
+                members: vec![l.index],
+                coords: ls.0.clone(),
+                group: l.group,
+            }),
+            _ => singles.push(pos),
+        }
+    }
+
+    // Phase 1: exact endpoint matching; phase 2: snapped matching.
+    let pieces = join_pieces(pieces, exact_key);
+    let pieces = if snap_tol > 0.0 {
+        join_pieces(pieces, |g, c| snap_key(g, c, snap_tol))
+    } else {
+        pieces
+    };
+
+    let mut chains: Vec<RawChain> = pieces
+        .into_iter()
+        .map(|p| RawChain {
+            geom: Geometry::LineString(LineString::new(p.coords)),
+            members: p.members,
+        })
+        .collect();
+
+    // Non-chainable singletons pass through unmerged (original geometry).
+    for pos in singles {
+        chains.push(RawChain {
+            members: vec![lines[pos].index],
+            geom: lines[pos].geom.clone(),
+        });
+    }
+    chains
+}
+
+/// One round of degree-2 endpoint joining over `pieces`, with node keys
+/// produced by `key(group, endpoint)`. Nodes with exactly two incident
+/// endpoints from two DISTINCT pieces join; junctions (degree >= 3) and
+/// self-loops never do. Deterministic: components are walked in ascending
+/// piece index, starting from a free end (or the lowest-index piece of a
+/// cycle).
+fn join_pieces(pieces: Vec<Piece>, key: impl Fn(u32, geo::Coord<f64>) -> NodeKey) -> Vec<Piece> {
+    // Endpoint node map: node -> incident (piece idx, end).
+    let mut nodes: HashMap<NodeKey, Vec<(usize, End)>> = HashMap::new();
+    for (pi, p) in pieces.iter().enumerate() {
+        let first = p.coords[0];
+        let last = p.coords[p.coords.len() - 1];
+        nodes.entry(key(p.group, first)).or_default().push((pi, 0));
+        nodes.entry(key(p.group, last)).or_default().push((pi, 1));
+    }
+
+    // Joins: per piece, the (other piece, other end) connected at each end.
+    let mut joins: Vec<[Option<(usize, End)>; 2]> = vec![[None, None]; pieces.len()];
+    for incidents in nodes.values() {
+        if incidents.len() == 2 && incidents[0].0 != incidents[1].0 {
+            let (a, a_end) = incidents[0];
+            let (b, b_end) = incidents[1];
+            joins[a][a_end as usize] = Some((b, b_end));
+            joins[b][b_end as usize] = Some((a, a_end));
+        }
+    }
+
+    // Walk components deterministically (ascending piece index).
+    let mut visited = vec![false; pieces.len()];
+    let mut order: Vec<Vec<(usize, End)>> = Vec::new();
+    for start in 0..pieces.len() {
+        if visited[start] {
+            continue;
+        }
+        // Find the walk head: follow joins backwards from `start`'s first
+        // end until a free end, or detect a cycle (back at `start`).
+        let (mut cur, mut cur_end) = (start, 0u8);
+        loop {
+            match joins[cur][cur_end as usize] {
+                None => break, // (cur, cur_end) is a free end: the head
+                Some((prev, prev_end)) => {
+                    if prev == start {
+                        // Came back around: pure cycle. Walk from `start`;
+                        // the forward walk's `visited` check closes it.
+                        cur = start;
+                        cur_end = 0;
+                        break;
+                    }
+                    cur = prev;
+                    cur_end = 1 - prev_end;
+                }
+            }
+        }
+
+        // Forward walk from the head, entering each piece at `entry` and
+        // exiting at the opposite end.
+        let (head, head_entry) = (cur, cur_end);
+        let mut walk: Vec<(usize, End)> = vec![(head, head_entry)];
+        visited[head] = true;
+        let (mut cur, mut entry) = (head, head_entry);
+        loop {
+            let exit = 1 - entry;
+            match joins[cur][exit as usize] {
+                Some((next, next_end)) if !visited[next] => {
+                    walk.push((next, next_end));
+                    visited[next] = true;
+                    cur = next;
+                    entry = next_end;
+                }
+                _ => break, // free end, junction, or cycle closed
+            }
+        }
+        order.push(walk);
+    }
+
+    // Assemble merged pieces. Consume the inputs by index (each appears in
+    // exactly one walk), reversing where the walk entered at the far end.
+    let mut slots: Vec<Option<Piece>> = pieces.into_iter().map(Some).collect();
+    let mut out: Vec<Piece> = Vec::with_capacity(order.len());
+    for walk in order {
+        if walk.len() == 1 {
+            let (pi, _) = walk[0];
+            out.push(slots[pi].take().expect("piece consumed once"));
+            continue;
+        }
+        let mut members: Vec<usize> = Vec::new();
+        let mut coords: Vec<geo::Coord<f64>> = Vec::new();
+        let mut group = 0u32;
+        for &(pi, seg_entry) in &walk {
+            let mut p = slots[pi].take().expect("piece consumed once");
+            members.append(&mut p.members);
+            group = p.group;
+            if seg_entry == 1 {
+                p.coords.reverse();
+            }
+            for c in p.coords {
+                if coords.last() == Some(&c) {
+                    continue; // exact shared node: no duplicate vertex
+                }
+                coords.push(c);
+            }
+        }
+        out.push(Piece {
+            members,
+            coords,
+            group,
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use geo::{Coord, MultiLineString};
+
+    fn ls(coords: &[(f64, f64)]) -> Geometry<f64> {
+        Geometry::LineString(LineString::from(coords.to_vec()))
+    }
+
+    fn input<'a>(index: usize, geom: &'a Geometry<f64>) -> CoalesceInput<'a> {
+        CoalesceInput {
+            index,
+            geom,
+            sort_key: None,
+            group: 0,
+        }
+    }
+
+    /// Small GSD so gates/thinning never interfere unless a test wants them.
+    const TINY_GSD: f64 = 1e-6;
+
+    fn cfg() -> AssignConfig {
+        AssignConfig::default()
+    }
+
+    fn run<'a>(lines: &[CoalesceInput<'a>], gsd_m: f64) -> Vec<CoalescedLine> {
+        coalesce_level_lines(lines, gsd_m, Crs::Epsg3857, &cfg(), DEFAULT_SNAP_GSD_FACTOR)
+    }
+
+    fn coords_of(g: &Geometry<f64>) -> Vec<(f64, f64)> {
+        match g {
+            Geometry::LineString(ls) => ls.0.iter().map(|c| (c.x, c.y)).collect(),
+            other => panic!("expected LineString, got {other:?}"),
+        }
+    }
+
+    // --- chaining ------------------------------------------------------------
+
+    #[test]
+    fn two_touching_segments_merge() {
+        let a = ls(&[(0.0, 0.0), (100.0, 0.0)]);
+        let b = ls(&[(100.0, 0.0), (200.0, 0.0)]);
+        let lines = [input(0, &a), input(1, &b)];
+        let out = run(&lines, TINY_GSD);
+        assert_eq!(out.len(), 1, "touching segments must merge: {out:?}");
+        assert_eq!(out[0].count, 2);
+        assert_eq!(
+            coords_of(&out[0].geom),
+            vec![(0.0, 0.0), (100.0, 0.0), (200.0, 0.0)],
+            "shared node vertex deduplicated"
+        );
+    }
+
+    #[test]
+    fn three_collinear_segments_merge_into_one() {
+        let a = ls(&[(0.0, 0.0), (100.0, 0.0)]);
+        let b = ls(&[(100.0, 0.0), (200.0, 0.0)]);
+        let c = ls(&[(200.0, 0.0), (300.0, 0.0)]);
+        let lines = [input(0, &a), input(1, &b), input(2, &c)];
+        let out = run(&lines, TINY_GSD);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].count, 3);
+        assert_eq!(coords_of(&out[0].geom).len(), 4);
+    }
+
+    #[test]
+    fn reversed_orientation_still_merges() {
+        // b runs INTO the shared node: (200,0) -> (100,0). The walk must
+        // reverse it so the merged line is continuous.
+        let a = ls(&[(0.0, 0.0), (100.0, 0.0)]);
+        let b = ls(&[(200.0, 0.0), (100.0, 0.0)]);
+        let lines = [input(0, &a), input(1, &b)];
+        let out = run(&lines, TINY_GSD);
+        assert_eq!(out.len(), 1);
+        let c = coords_of(&out[0].geom);
+        assert_eq!(c.len(), 3, "no duplicate shared vertex: {c:?}");
+        assert!(
+            c == vec![(0.0, 0.0), (100.0, 0.0), (200.0, 0.0)]
+                || c == vec![(200.0, 0.0), (100.0, 0.0), (0.0, 0.0)]
+        );
+    }
+
+    #[test]
+    fn t_junction_degree_three_does_not_merge_through() {
+        // Three segments meeting at (100, 0): degree-3 node, no chaining.
+        let a = ls(&[(0.0, 0.0), (100.0, 0.0)]);
+        let b = ls(&[(100.0, 0.0), (200.0, 0.0)]);
+        let c = ls(&[(100.0, 0.0), (100.0, 100.0)]);
+        let lines = [input(0, &a), input(1, &b), input(2, &c)];
+        let out = run(&lines, TINY_GSD);
+        assert_eq!(out.len(), 3, "junction must terminate chains: {out:?}");
+        assert!(out.iter().all(|l| l.count == 1));
+    }
+
+    #[test]
+    fn snap_tolerance_joins_near_endpoints() {
+        // gsd = 1 m, snap 1.0 => endpoints quantized to 1 m cells. Endpoints
+        // 0.3 m apart in the same cell join; endpoints 2 m apart do not.
+        let a = ls(&[(0.0, 0.0), (100.2, 0.2)]);
+        let b = ls(&[(100.4, 0.4), (200.0, 0.0)]); // same 1 m cell as a's end
+        let c = ls(&[(202.0, 0.0), (300.0, 0.0)]); // 2 m gap: separate cell
+        let lines = [input(0, &a), input(1, &b), input(2, &c)];
+        let out = run(&lines, 1.0);
+        assert_eq!(out.len(), 2, "near endpoints join, far do not: {out:?}");
+        let merged = out.iter().find(|l| l.count == 2).expect("merged chain");
+        // Snapped (non-identical) join keeps both endpoint vertices.
+        assert_eq!(coords_of(&merged.geom).len(), 4);
+    }
+
+    #[test]
+    fn exact_matching_when_snap_zero() {
+        let a = ls(&[(0.0, 0.0), (100.0, 0.0)]);
+        let b = ls(&[(100.0, 0.0), (200.0, 0.0)]); // exact match
+        let c = ls(&[(200.0000001, 0.0), (300.0, 0.0)]); // near, not exact
+        let lines = [input(0, &a), input(1, &b), input(2, &c)];
+        let out = coalesce_level_lines(&lines, 1.0, Crs::Epsg3857, &cfg(), 0.0);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out.iter().map(|l| l.count).max(), Some(2));
+    }
+
+    #[test]
+    fn class_mismatch_does_not_merge() {
+        let a = ls(&[(0.0, 0.0), (100.0, 0.0)]);
+        let b = ls(&[(100.0, 0.0), (200.0, 0.0)]);
+        let mut ia = input(0, &a);
+        let mut ib = input(1, &b);
+        ia.group = 1;
+        ib.group = 2;
+        let out = run(&[ia, ib], TINY_GSD);
+        assert_eq!(out.len(), 2, "different classes never chain");
+    }
+
+    #[test]
+    fn junction_degree_counted_within_group_only() {
+        // A minor road (group 9) also touches the shared node; within the
+        // motorway group the node is still degree 2, so the motorway chains
+        // straight through the cross-class junction.
+        let a = ls(&[(0.0, 0.0), (100.0, 0.0)]);
+        let b = ls(&[(100.0, 0.0), (200.0, 0.0)]);
+        let minor = ls(&[(100.0, 0.0), (100.0, 50.0)]);
+        let mut ia = input(0, &a);
+        let mut ib = input(1, &b);
+        let mut im = input(2, &minor);
+        ia.group = 1;
+        ib.group = 1;
+        im.group = 9;
+        let out = run(&[ia, ib, im], TINY_GSD);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out.iter().map(|l| l.count).max(), Some(2));
+    }
+
+    #[test]
+    fn priority_attribute_inheritance() {
+        // The member holding a sort key out-ranks the keyless one (Q1 null
+        // loses); the merged feature must take ITS index as rep.
+        let a = ls(&[(0.0, 0.0), (100.0, 0.0)]);
+        let b = ls(&[(100.0, 0.0), (150.0, 0.0)]); // shorter, but has key
+        let ia = input(7, &a);
+        let mut ib = input(3, &b);
+        ib.sort_key = Some(5.0);
+        let out = run(&[ia, ib], TINY_GSD);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].rep, 3, "sort-key holder donates attributes");
+        assert_eq!(out[0].count, 2);
+    }
+
+    #[test]
+    fn cycle_merges_into_closed_chain() {
+        // Four segments forming a square ring, all degree-2 nodes.
+        let a = ls(&[(0.0, 0.0), (100.0, 0.0)]);
+        let b = ls(&[(100.0, 0.0), (100.0, 100.0)]);
+        let c = ls(&[(100.0, 100.0), (0.0, 100.0)]);
+        let d = ls(&[(0.0, 100.0), (0.0, 0.0)]);
+        let lines = [input(0, &a), input(1, &b), input(2, &c), input(3, &d)];
+        let out = run(&lines, TINY_GSD);
+        assert_eq!(out.len(), 1, "ring merges into one chain: {out:?}");
+        assert_eq!(out[0].count, 4);
+        let coords = coords_of(&out[0].geom);
+        assert_eq!(coords.first(), coords.last(), "cycle closes");
+    }
+
+    #[test]
+    fn self_loop_is_not_merged_with_itself() {
+        // A closed ring segment (start == end) has both ends at one node:
+        // degree 2 from the SAME segment — never joined.
+        let ring = ls(&[(0.0, 0.0), (100.0, 0.0), (100.0, 100.0), (0.0, 0.0)]);
+        let lines = [input(0, &ring)];
+        let out = run(&lines, TINY_GSD);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].count, 1);
+        assert_eq!(out[0].geom, ring);
+    }
+
+    #[test]
+    fn multilinestring_passes_through_as_singleton() {
+        let mls = Geometry::MultiLineString(MultiLineString::new(vec![
+            LineString::from(vec![(0.0, 0.0), (100.0, 0.0)]),
+            LineString::from(vec![(300.0, 0.0), (400.0, 0.0)]),
+        ]));
+        let b = ls(&[(100.0, 0.0), (200.0, 0.0)]); // touches mls part 1's end
+        let lines = [input(0, &mls), input(1, &b)];
+        let out = run(&lines, TINY_GSD);
+        assert_eq!(out.len(), 2, "multilines never chain");
+        assert!(out.iter().all(|l| l.count == 1));
+    }
+
+    // --- gate + thinning on chains (THE payoff ordering) ----------------------
+
+    #[test]
+    fn sub_visibility_fragments_survive_as_one_chain() {
+        // gsd = 10 m, line_visibility = 2 => gate = 20 m. Five collinear 8 m
+        // segments each fail the gate alone (8 < 20) but their 40 m chain
+        // passes. An isolated 8 m segment far away is dropped.
+        let segs: Vec<Geometry<f64>> = (0..5)
+            .map(|i| ls(&[(i as f64 * 8.0, 0.0), ((i + 1) as f64 * 8.0, 0.0)]))
+            .collect();
+        let lone = ls(&[(10_000.0, 0.0), (10_008.0, 0.0)]);
+        let mut lines: Vec<CoalesceInput> =
+            segs.iter().enumerate().map(|(i, g)| input(i, g)).collect();
+        lines.push(input(5, &lone));
+        let out = run(&lines, 10.0);
+        assert_eq!(out.len(), 1, "chain survives, lone fragment drops: {out:?}");
+        assert_eq!(out[0].count, 5);
+        let coords = coords_of(&out[0].geom);
+        assert_eq!(coords.first(), Some(&(0.0, 0.0)));
+        assert_eq!(coords.last(), Some(&(40.0, 0.0)));
+    }
+
+    #[test]
+    fn thinning_keeps_one_chain_per_cell() {
+        // gsd = 1000 m, line_thinning = 1 => 1000 m cells. Two disjoint
+        // parallel chains whose centers share a cell: one winner.
+        let a = ls(&[(0.0, 0.0), (900.0, 0.0)]);
+        let b = ls(&[(0.0, 10.0), (900.0, 10.0)]);
+        let lines = [input(0, &a), input(1, &b)];
+        // Both pass the 2000 m gate? diag = 900 < 2000 -> both would drop.
+        // Use a lenient gate for this test.
+        let cfg = AssignConfig {
+            line_visibility: 0.5, // gate 500 m < 900 m diag
+            ..AssignConfig::default()
+        };
+        let out = coalesce_level_lines(&lines, 1000.0, Crs::Epsg3857, &cfg, 1.0);
+        assert_eq!(out.len(), 1, "one chain per thinning cell: {out:?}");
+    }
+
+    #[test]
+    fn longer_chain_wins_thinning_cell() {
+        // Same cell, no sort keys: the longer (bigger diagonal) chain wins.
+        let long = ls(&[(0.0, 0.0), (900.0, 0.0)]);
+        let short = ls(&[(0.0, 10.0), (400.0, 10.0)]);
+        let lines = [input(0, &long), input(1, &short)];
+        let cfg = AssignConfig {
+            line_visibility: 0.1,
+            ..AssignConfig::default()
+        };
+        let out = coalesce_level_lines(&lines, 1000.0, Crs::Epsg3857, &cfg, 1.0);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].rep, 0, "longer chain out-ranks in its cell");
+    }
+
+    // --- determinism / misc ----------------------------------------------------
+
+    #[test]
+    fn output_is_input_order_independent() {
+        let a = ls(&[(0.0, 0.0), (100.0, 0.0)]);
+        let b = ls(&[(100.0, 0.0), (200.0, 0.0)]);
+        let c = ls(&[(500.0, 0.0), (600.0, 0.0)]);
+        let l1 = [input(0, &a), input(1, &b), input(2, &c)];
+        let l2 = [input(2, &c), input(1, &b), input(0, &a)];
+        let mut o1 = run(&l1, TINY_GSD);
+        let mut o2 = run(&l2, TINY_GSD);
+        o1.sort_by_key(|l| l.rep);
+        o2.sort_by_key(|l| l.rep);
+        assert_eq!(o1, o2, "results independent of input order");
+    }
+
+    #[test]
+    fn empty_input_is_noop() {
+        assert!(run(&[], 10.0).is_empty());
+    }
+
+    #[test]
+    fn degenerate_single_point_line_is_gated_out() {
+        let dot = Geometry::LineString(LineString::new(vec![Coord { x: 1.0, y: 1.0 }]));
+        let lines = [input(0, &dot)];
+        let out = run(&lines, 10.0);
+        assert!(out.is_empty(), "zero-diagonal chain fails the gate");
+    }
+}

--- a/crates/core/src/overview/coalesce.rs
+++ b/crates/core/src/overview/coalesce.rs
@@ -23,9 +23,13 @@
 //!    dominant case, since OSM/Overture segments share exact node
 //!    coordinates), then a **snap** pass that joins the resulting chains'
 //!    free endpoints quantized to `snap_gsd_factor × GSD` grid cells
-//!    (closing sub-resolution digitization gaps). Both phases join only
-//!    through nodes of **degree 2** — junctions where three or more
-//!    endpoints meet terminate every chain, preserving network topology.
+//!    (closing sub-resolution digitization gaps). Both phases join nodes
+//!    of **degree 2** unconditionally; at junctions (degree >= 3) the
+//!    incident pairs that continue each other within
+//!    [`CoalesceParams::junction_angle_deg`] of straight merge best-pair
+//!    first (stroke building — arterials chain THROUGH same-class
+//!    crossings; a sharp turn stays a chain boundary; `0` restores strict
+//!    degree-2-only chaining).
 //! 3. The merged feature takes the attributes of its **highest-priority
 //!    member** (the same [`Priority`] order the cell-winner stage uses),
 //!    and records the number of merged source segments
@@ -35,9 +39,10 @@
 //!    `line_thinning × GSD` grid cell, best [`Priority`] wins).
 //!
 //! The canonical level is NEVER coalesced (spec §2.4 value fidelity), and
-//! partitioning mode rejects coalescing outright (merged geometries violate
-//! §2.3's feature-once / geometry-verbatim contract; see
-//! `ConvertError::CoalescePartitioningUnsupported`).
+//! coalescing is INERT in partitioning mode (merged geometries violate
+//! §2.3's feature-once / geometry-verbatim contract; spec §13.5).
+//! Coalescing is ON by default in the conversion options (maintainer
+//! render review 2026-07-03: defaults should look right), with an opt-out.
 //!
 //! # DIVERGENCE FROM TIPPECANOE
 //!
@@ -45,11 +50,12 @@
 //! into multi-geometries without topological chaining (tile.cpp, coalesce
 //! path); its shared-node machinery protects junction vertices during
 //! simplification rather than building strokes. Our endpoint chaining
-//! through degree-2 nodes matches planetiler's `mergeLineStrings`
-//! behavior (the standard cartographic stroke-building operation), while
-//! keeping tippecanoe's *philosophy*: never merge across attribute
-//! (class) boundaries, never merge through junctions, deterministic
-//! output. We also merge with a snap tolerance of one GSD — two endpoints
+//! through degree-2 nodes (plus angle-limited junction continuation)
+//! matches planetiler's `mergeLineStrings` behavior (the standard
+//! cartographic stroke-building operation), while keeping tippecanoe's
+//! *philosophy*: never merge across attribute (class) boundaries,
+//! deterministic output. We also merge with a snap tolerance of one GSD —
+//! two endpoints
 //! closer than one ground sample are indistinguishable at the level — where
 //! planetiler uses exact matches after tile-grid quantization (an
 //! equivalent idea in tile space).
@@ -75,6 +81,16 @@ pub const COALESCED_COUNT_COLUMN: &str = "coalesced_count";
 /// Default endpoint snap tolerance, in GSD multiples: two endpoints within
 /// one ground sample distance are indistinguishable at the level.
 pub const DEFAULT_SNAP_GSD_FACTOR: f64 = 1.0;
+
+/// Default junction continuation threshold, in degrees: at a junction
+/// (node degree >= 3), the pair of incident lines that best continue each
+/// other merge when their deviation from a straight continuation is at
+/// most this angle. `30°` keeps arterials chaining through the frequent
+/// same-class crossings that otherwise break every stroke, while a sharp
+/// turn onto a side street stays a chain boundary. Provisional default
+/// pending the maintainer's Portland junction-angle sweep
+/// (`corpus/data/bench/q3/portland-roads-junction{00,30,60}.pmtiles`).
+pub const DEFAULT_JUNCTION_ANGLE_DEG: f64 = 30.0;
 
 /// Default per-level candidate-row ceiling above which coalescing is
 /// skipped (bounded-memory guard; see `docs/OVERVIEW_TUNING.md`). Chaining
@@ -118,37 +134,68 @@ type End = u8;
 /// Quantized endpoint node key, namespaced by compatibility group.
 type NodeKey = (u32, i64, i64);
 
+/// Per-level chaining parameters for [`coalesce_level_lines`].
+#[derive(Debug, Clone, Copy)]
+pub struct CoalesceParams {
+    /// Endpoint snap tolerance in GSD multiples. `<= 0` means exact
+    /// coordinate matching only.
+    pub snap_gsd_factor: f64,
+    /// Junction continuation threshold in degrees
+    /// ([`DEFAULT_JUNCTION_ANGLE_DEG`]): at nodes of degree >= 3, incident
+    /// pairs that continue each other within this deviation from straight
+    /// are joined (best pair first, repeatedly — a 4-way crossing continues
+    /// both through-streets). `<= 0` restores strict degree-2-only chaining.
+    pub junction_angle_deg: f64,
+    /// OPTIONAL per-level `(max_chains, gamma)` density budget (Q2 applied
+    /// to CHAINS): when more chains than `max_chains` survive the gate +
+    /// thinning, the lowest-priority ones are dropped with the same
+    /// super-cell spatial fairness the point/polygon budget uses. Without
+    /// this, coalescing would bypass the Q2 budget entirely and re-inflate
+    /// the mid-zoom counts the budget was calibrated to cap.
+    pub budget: Option<(usize, f64)>,
+}
+
+impl Default for CoalesceParams {
+    fn default() -> Self {
+        Self {
+            snap_gsd_factor: DEFAULT_SNAP_GSD_FACTOR,
+            junction_angle_deg: DEFAULT_JUNCTION_ANGLE_DEG,
+            budget: None,
+        }
+    }
+}
+
 /// Coalesce one level's candidate lines: chain within compatibility groups
-/// through degree-2 endpoint nodes, then apply the visibility gate and
-/// cell-winner thinning to the merged chains. Returns the surviving chains
-/// ordered by ascending `rep` index.
+/// through endpoint nodes (degree-2 always; junction continuation per
+/// [`CoalesceParams::junction_angle_deg`]), then apply the visibility gate,
+/// cell-winner thinning, and the optional chain budget. Returns the
+/// surviving chains ordered by ascending `rep` index.
 ///
 /// - `gsd_m`: the level's GSD in meters (governs snap tolerance, gate, and
 ///   thinning grid). Non-positive GSD returns every input as an ungated
 ///   singleton (degenerate; callers pass canonical levels elsewhere).
 /// - `config`: the assignment configuration; `line_visibility`,
 ///   `line_thinning`, and `sort_direction` are used.
-/// - `snap_gsd_factor`: endpoint snap tolerance in GSD multiples. `<= 0`
-///   means exact coordinate matching only.
 pub fn coalesce_level_lines(
     lines: &[CoalesceInput<'_>],
     gsd_m: f64,
     crs: Crs,
     config: &AssignConfig,
-    snap_gsd_factor: f64,
+    params: &CoalesceParams,
 ) -> Vec<CoalescedLine> {
     if lines.is_empty() {
         return Vec::new();
     }
+    let budget = params.budget;
     let gsd_units = crs.meters_to_units(gsd_m);
     let snap_tol = if gsd_units > 0.0 {
-        snap_gsd_factor * gsd_units
+        params.snap_gsd_factor * gsd_units
     } else {
         0.0
     };
 
-    // --- 1+2. Build chains (grouped, degree-2 endpoint joins). --------------
-    let chains = build_chains(lines, snap_tol);
+    // --- 1+2. Build chains (grouped endpoint joins + junction continuation).
+    let chains = build_chains(lines, snap_tol, params.junction_angle_deg);
 
     // --- Priorities + sort keys of the members (the cell-winner order, Q1). --
     let mut prio: HashMap<usize, Priority> = HashMap::with_capacity(lines.len());
@@ -210,43 +257,107 @@ pub fn coalesce_level_lines(
 
     // --- 4b. Cell-winner thinning among the surviving chains. ----------------
     let cell_size = gsd_units * config.line_thinning;
-    let survivors: Vec<CoalescedLine> = if cell_size > 0.0 && !cell_size.is_nan() {
-        let chain_prio: Vec<Priority> = gated
-            .iter()
-            .map(|(_, f)| Priority::new(f, config.sort_direction))
-            .collect();
-        // cell -> position of the best chain so far in `gated`.
-        let mut grid: HashMap<(i64, i64), usize> = HashMap::new();
-        for (pos, (_, feat)) in gated.iter().enumerate() {
-            let (cx, cy) = feat.center();
-            let key = (
-                (cx / cell_size).floor() as i64,
-                (cy / cell_size).floor() as i64,
-            );
-            grid.entry(key)
-                .and_modify(|best| {
-                    if chain_prio[pos].beats(&chain_prio[*best]) {
-                        *best = pos;
-                    }
-                })
-                .or_insert(pos);
-        }
-        let mut keep: Vec<usize> = grid.into_values().collect();
-        keep.sort_unstable();
-        let mut out = Vec::with_capacity(keep.len());
-        let mut gated = gated;
-        // Drain winners in ascending position order (stable, deterministic).
-        for (offset, pos) in keep.into_iter().enumerate() {
-            out.push(gated.remove(pos - offset).0);
-        }
-        out
-    } else {
-        gated.into_iter().map(|(l, _)| l).collect()
-    };
+    let mut survivors: Vec<(CoalescedLine, AssignFeature)> =
+        if cell_size > 0.0 && !cell_size.is_nan() {
+            let chain_prio: Vec<Priority> = gated
+                .iter()
+                .map(|(_, f)| Priority::new(f, config.sort_direction))
+                .collect();
+            // cell -> position of the best chain so far in `gated`.
+            let mut grid: HashMap<(i64, i64), usize> = HashMap::new();
+            for (pos, (_, feat)) in gated.iter().enumerate() {
+                let (cx, cy) = feat.center();
+                let key = (
+                    (cx / cell_size).floor() as i64,
+                    (cy / cell_size).floor() as i64,
+                );
+                grid.entry(key)
+                    .and_modify(|best| {
+                        if chain_prio[pos].beats(&chain_prio[*best]) {
+                            *best = pos;
+                        }
+                    })
+                    .or_insert(pos);
+            }
+            // Keep winners in ascending position order (stable, deterministic;
+            // O(n) — a per-winner `Vec::remove` here is quadratic on real data).
+            let mut keep = vec![false; gated.len()];
+            for pos in grid.into_values() {
+                keep[pos] = true;
+            }
+            gated
+                .into_iter()
+                .zip(&keep)
+                .filter(|(_, &k)| k)
+                .map(|(pair, _)| pair)
+                .collect()
+        } else {
+            gated
+        };
 
-    let mut survivors = survivors;
+    // --- 4c. Per-level density budget on chains (Q2 analog). -----------------
+    if let Some((max_chains, gamma)) = budget {
+        if survivors.len() > max_chains {
+            let feats: Vec<AssignFeature> = survivors
+                .iter()
+                .enumerate()
+                .map(|(pos, (_, f))| AssignFeature { index: pos, ..*f })
+                .collect();
+            let prio: Vec<Priority> = feats
+                .iter()
+                .map(|f| Priority::new(f, config.sort_direction))
+                .collect();
+            let cands: Vec<usize> = (0..survivors.len()).collect();
+            let mut chosen = super::assign::select_budget_survivors(
+                &cands, max_chains, &feats, &prio, gsd_m, crs, gamma,
+            );
+            chosen.sort_unstable();
+            let mut keep = vec![false; survivors.len()];
+            for pos in chosen {
+                keep[pos] = true;
+            }
+            survivors = survivors
+                .into_iter()
+                .zip(&keep)
+                .filter(|(_, &k)| k)
+                .map(|(pair, _)| pair)
+                .collect();
+        }
+    }
+
+    let mut survivors: Vec<CoalescedLine> = survivors.into_iter().map(|(l, _)| l).collect();
     survivors.sort_by_key(|c| c.rep);
     survivors
+}
+
+/// Unit direction of `p` at its `end`, pointing INTO the line away from
+/// the endpoint (toward the first distinct vertex). `None` when every
+/// vertex coincides (degenerate).
+fn piece_direction(p: &Piece, end: End) -> Option<(f64, f64)> {
+    let c = &p.coords;
+    let (anchor, inward) = if end == 0 {
+        (c[0], c.iter().skip(1).find(|&&q| q != c[0]).copied())
+    } else {
+        let last = c[c.len() - 1];
+        (last, c.iter().rev().skip(1).find(|&&q| q != last).copied())
+    };
+    let q = inward?;
+    let (dx, dy) = (q.x - anchor.x, q.y - anchor.y);
+    let len = (dx * dx + dy * dy).sqrt();
+    if len > 0.0 {
+        Some((dx / len, dy / len))
+    } else {
+        None
+    }
+}
+
+/// Angular deviation (degrees) of continuing from a line with inward
+/// direction `a` onto a line with inward direction `b` at a shared node:
+/// `0°` = perfectly straight (the directions are opposite), `90°` = a
+/// right-angle turn.
+fn continuation_deviation_deg(a: (f64, f64), b: (f64, f64)) -> f64 {
+    let dot = (a.0 * b.0 + a.1 * b.1).clamp(-1.0, 1.0);
+    180.0 - dot.acos().to_degrees()
 }
 
 /// `[xmin, ymin, xmax, ymax]` of a geometry (`[0;4]` when undefined).
@@ -297,11 +408,20 @@ fn snap_key(group: u32, c: geo::Coord<f64>, tol: f64) -> NodeKey {
 ///    segments are far shorter than the snap tolerance (the coarse-zoom
 ///    norm, where a one-phase snapped graph would collapse a short
 ///    segment's own two endpoints into a single node and never join it).
-/// 2. **Snap pass**: re-run the same degree-2 join over the *resulting
-///    chains'* free endpoints, quantized to `snap_tol` grid cells —
-///    closing small digitization gaps at the level's resolution. Skipped
-///    when `snap_tol <= 0` (exact matching only).
-fn build_chains(lines: &[CoalesceInput<'_>], snap_tol: f64) -> Vec<RawChain> {
+/// 2. **Snap pass**: re-run the same join over the *resulting chains'*
+///    free endpoints, quantized to `snap_tol` grid cells — closing small
+///    digitization gaps at the level's resolution. Skipped when
+///    `snap_tol <= 0` (exact matching only).
+///
+/// Both phases join degree-2 nodes unconditionally and, when
+/// `junction_angle_deg > 0`, continue through junctions (degree >= 3) by
+/// repeatedly pairing the incident lines that best continue each other
+/// within that angular deviation (stroke building).
+fn build_chains(
+    lines: &[CoalesceInput<'_>],
+    snap_tol: f64,
+    junction_angle_deg: f64,
+) -> Vec<RawChain> {
     // Chainable = plain LineString with >= 2 coordinates. Everything else
     // (MultiLineString, Line, degenerate) is an unmerged singleton.
     let mut pieces: Vec<Piece> = Vec::new();
@@ -318,9 +438,9 @@ fn build_chains(lines: &[CoalesceInput<'_>], snap_tol: f64) -> Vec<RawChain> {
     }
 
     // Phase 1: exact endpoint matching; phase 2: snapped matching.
-    let pieces = join_pieces(pieces, exact_key);
+    let pieces = join_pieces(pieces, exact_key, junction_angle_deg);
     let pieces = if snap_tol > 0.0 {
-        join_pieces(pieces, |g, c| snap_key(g, c, snap_tol))
+        join_pieces(pieces, |g, c| snap_key(g, c, snap_tol), junction_angle_deg)
     } else {
         pieces
     };
@@ -343,13 +463,26 @@ fn build_chains(lines: &[CoalesceInput<'_>], snap_tol: f64) -> Vec<RawChain> {
     chains
 }
 
-/// One round of degree-2 endpoint joining over `pieces`, with node keys
-/// produced by `key(group, endpoint)`. Nodes with exactly two incident
-/// endpoints from two DISTINCT pieces join; junctions (degree >= 3) and
-/// self-loops never do. Deterministic: components are walked in ascending
-/// piece index, starting from a free end (or the lowest-index piece of a
-/// cycle).
-fn join_pieces(pieces: Vec<Piece>, key: impl Fn(u32, geo::Coord<f64>) -> NodeKey) -> Vec<Piece> {
+/// One round of endpoint joining over `pieces`, with node keys produced by
+/// `key(group, endpoint)`.
+///
+/// - Nodes with exactly two incident endpoints from two DISTINCT pieces
+///   join unconditionally (a degree-2 node is an unambiguous continuation).
+/// - Junctions (degree >= 3): when `junction_angle_deg > 0`, incident pairs
+///   from distinct pieces whose directions continue each other within that
+///   deviation from straight are joined best-pair-first (so a 4-way
+///   crossing continues BOTH through-streets); remaining incidents
+///   terminate. `<= 0` restores strict degree-2-only behavior.
+/// - Self-loops never join.
+///
+/// Deterministic: components are walked in ascending piece index, starting
+/// from a free end (or the lowest-index piece of a cycle); junction pairs
+/// are ordered by (deviation, incident order).
+fn join_pieces(
+    pieces: Vec<Piece>,
+    key: impl Fn(u32, geo::Coord<f64>) -> NodeKey,
+    junction_angle_deg: f64,
+) -> Vec<Piece> {
     // Endpoint node map: node -> incident (piece idx, end).
     let mut nodes: HashMap<NodeKey, Vec<(usize, End)>> = HashMap::new();
     for (pi, p) in pieces.iter().enumerate() {
@@ -362,11 +495,49 @@ fn join_pieces(pieces: Vec<Piece>, key: impl Fn(u32, geo::Coord<f64>) -> NodeKey
     // Joins: per piece, the (other piece, other end) connected at each end.
     let mut joins: Vec<[Option<(usize, End)>; 2]> = vec![[None, None]; pieces.len()];
     for incidents in nodes.values() {
-        if incidents.len() == 2 && incidents[0].0 != incidents[1].0 {
+        let d = incidents.len();
+        if d == 2 && incidents[0].0 != incidents[1].0 {
             let (a, a_end) = incidents[0];
             let (b, b_end) = incidents[1];
             joins[a][a_end as usize] = Some((b, b_end));
             joins[b][b_end as usize] = Some((a, a_end));
+        } else if d >= 3 && junction_angle_deg > 0.0 {
+            // Junction continuation (stroke building): pair up incidents
+            // that continue each other within the angular threshold,
+            // straightest pair first. Each node's pairing is independent of
+            // every other node's (an end belongs to exactly one node), so
+            // map iteration order cannot affect the result.
+            let dirs: Vec<Option<(f64, f64)>> = incidents
+                .iter()
+                .map(|&(pi, e)| piece_direction(&pieces[pi], e))
+                .collect();
+            let mut cands: Vec<(f64, usize, usize)> = Vec::new();
+            for i in 0..d {
+                for j in (i + 1)..d {
+                    if incidents[i].0 == incidents[j].0 {
+                        continue; // self-loops never join
+                    }
+                    if let (Some(a), Some(b)) = (dirs[i], dirs[j]) {
+                        let dev = continuation_deviation_deg(a, b);
+                        if dev <= junction_angle_deg {
+                            cands.push((dev, i, j));
+                        }
+                    }
+                }
+            }
+            cands.sort_by(|x, y| x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal));
+            let mut used = vec![false; d];
+            for (_, i, j) in cands {
+                if used[i] || used[j] {
+                    continue;
+                }
+                used[i] = true;
+                used[j] = true;
+                let (a, a_end) = incidents[i];
+                let (b, b_end) = incidents[j];
+                joins[a][a_end as usize] = Some((b, b_end));
+                joins[b][b_end as usize] = Some((a, a_end));
+            }
         }
     }
 
@@ -479,8 +650,25 @@ mod tests {
         AssignConfig::default()
     }
 
+    fn params(snap: f64, junction: f64, budget: Option<(usize, f64)>) -> CoalesceParams {
+        CoalesceParams {
+            snap_gsd_factor: snap,
+            junction_angle_deg: junction,
+            budget,
+        }
+    }
+
     fn run<'a>(lines: &[CoalesceInput<'a>], gsd_m: f64) -> Vec<CoalescedLine> {
-        coalesce_level_lines(lines, gsd_m, Crs::Epsg3857, &cfg(), DEFAULT_SNAP_GSD_FACTOR)
+        coalesce_level_lines(
+            lines,
+            gsd_m,
+            Crs::Epsg3857,
+            &cfg(),
+            &CoalesceParams {
+                junction_angle_deg: 0.0, // strict degree-2 (junction tests are explicit)
+                ..CoalesceParams::default()
+            },
+        )
     }
 
     fn coords_of(g: &Geometry<f64>) -> Vec<(f64, f64)> {
@@ -548,6 +736,108 @@ mod tests {
         assert!(out.iter().all(|l| l.count == 1));
     }
 
+    // --- junction continuation (stroke building) ------------------------------
+
+    /// T-junction with the junction knob on: the collinear pair chains
+    /// straight through; the perpendicular branch stays separate.
+    #[test]
+    fn junction_continuation_merges_straight_pair_at_t() {
+        let a = ls(&[(0.0, 0.0), (100.0, 0.0)]);
+        let b = ls(&[(100.0, 0.0), (200.0, 0.0)]);
+        let c = ls(&[(100.0, 0.0), (100.0, 100.0)]);
+        let lines = [input(0, &a), input(1, &b), input(2, &c)];
+        let out = coalesce_level_lines(
+            &lines,
+            TINY_GSD,
+            Crs::Epsg3857,
+            &cfg(),
+            &params(1.0, 30.0, None),
+        );
+        assert_eq!(
+            out.len(),
+            2,
+            "straight pair merges, branch survives: {out:?}"
+        );
+        let merged = out.iter().find(|l| l.count == 2).expect("merged pair");
+        assert_eq!(coords_of(&merged.geom).len(), 3);
+        assert_eq!(out.iter().find(|l| l.count == 1).map(|l| l.rep), Some(2));
+    }
+
+    /// Four-way crossing: BOTH through-streets continue (two pairs merge).
+    /// The crossing is asymmetric so the two merged chains land in
+    /// different thinning cells (equal bbox centers would thin to one).
+    #[test]
+    fn junction_continuation_pairs_both_streets_at_crossing() {
+        let e = ls(&[(0.0, 0.0), (100.0, 0.0)]);
+        let w = ls(&[(100.0, 0.0), (300.0, 0.0)]);
+        let n = ls(&[(100.0, 0.0), (100.0, 100.0)]);
+        let s = ls(&[(100.0, -300.0), (100.0, 0.0)]);
+        let lines = [input(0, &e), input(1, &w), input(2, &n), input(3, &s)];
+        let out = coalesce_level_lines(
+            &lines,
+            TINY_GSD,
+            Crs::Epsg3857,
+            &cfg(),
+            &params(1.0, 30.0, None),
+        );
+        assert_eq!(out.len(), 2, "both through-streets continue: {out:?}");
+        assert!(out.iter().all(|l| l.count == 2));
+    }
+
+    /// A bend sharper than the threshold does not merge through a junction.
+    #[test]
+    fn junction_continuation_respects_angle_threshold() {
+        let a = ls(&[(0.0, 0.0), (100.0, 0.0)]);
+        let bent = ls(&[(100.0, 0.0), (170.0, 70.0)]); // 45° off straight
+        let branch = ls(&[(100.0, 0.0), (100.0, 100.0)]); // 90° off
+        let lines = [input(0, &a), input(1, &bent), input(2, &branch)];
+        // 30° threshold: nothing continues (45° and 90° both exceed it).
+        let strict = coalesce_level_lines(
+            &lines,
+            TINY_GSD,
+            Crs::Epsg3857,
+            &cfg(),
+            &params(1.0, 30.0, None),
+        );
+        assert_eq!(strict.len(), 3, "45° bend exceeds 30°: {strict:?}");
+        // 60° threshold: the 45° pair merges; the 90° branch still doesn't.
+        let loose = coalesce_level_lines(
+            &lines,
+            TINY_GSD,
+            Crs::Epsg3857,
+            &cfg(),
+            &params(1.0, 60.0, None),
+        );
+        assert_eq!(loose.len(), 2, "45° bend within 60°: {loose:?}");
+        assert_eq!(loose.iter().map(|l| l.count).max(), Some(2));
+    }
+
+    /// Junction continuation still never crosses class groups.
+    #[test]
+    fn junction_continuation_respects_groups() {
+        let a = ls(&[(0.0, 0.0), (100.0, 0.0)]);
+        let b = ls(&[(100.0, 0.0), (200.0, 0.0)]); // straight, WRONG class
+        let c = ls(&[(100.0, 0.0), (100.0, 100.0)]); // same class, 90° off
+        let mut ia = input(0, &a);
+        let mut ib = input(1, &b);
+        let mut ic = input(2, &c);
+        ia.group = 1;
+        ib.group = 2;
+        ic.group = 1;
+        let out = coalesce_level_lines(
+            &[ia, ib, ic],
+            TINY_GSD,
+            Crs::Epsg3857,
+            &cfg(),
+            &params(1.0, 30.0, None),
+        );
+        // Within group 1 the node is degree 2 (a + c) — but they meet at
+        // 90°... degree-2 joins are unconditional, so a + c chain; b stays.
+        assert_eq!(out.len(), 2, "no cross-group merge: {out:?}");
+        let merged = out.iter().find(|l| l.count == 2).expect("a+c chain");
+        assert!(merged.rep == 0 || merged.rep == 2);
+    }
+
     #[test]
     fn snap_tolerance_joins_near_endpoints() {
         // gsd = 1 m, snap 1.0 => endpoints quantized to 1 m cells. Endpoints
@@ -569,7 +859,7 @@ mod tests {
         let b = ls(&[(100.0, 0.0), (200.0, 0.0)]); // exact match
         let c = ls(&[(200.0000001, 0.0), (300.0, 0.0)]); // near, not exact
         let lines = [input(0, &a), input(1, &b), input(2, &c)];
-        let out = coalesce_level_lines(&lines, 1.0, Crs::Epsg3857, &cfg(), 0.0);
+        let out = coalesce_level_lines(&lines, 1.0, Crs::Epsg3857, &cfg(), &params(0.0, 0.0, None));
         assert_eq!(out.len(), 2);
         assert_eq!(out.iter().map(|l| l.count).max(), Some(2));
     }
@@ -695,7 +985,8 @@ mod tests {
             line_visibility: 0.5, // gate 500 m < 900 m diag
             ..AssignConfig::default()
         };
-        let out = coalesce_level_lines(&lines, 1000.0, Crs::Epsg3857, &cfg, 1.0);
+        let out =
+            coalesce_level_lines(&lines, 1000.0, Crs::Epsg3857, &cfg, &params(1.0, 0.0, None));
         assert_eq!(out.len(), 1, "one chain per thinning cell: {out:?}");
     }
 
@@ -709,7 +1000,8 @@ mod tests {
             line_visibility: 0.1,
             ..AssignConfig::default()
         };
-        let out = coalesce_level_lines(&lines, 1000.0, Crs::Epsg3857, &cfg, 1.0);
+        let out =
+            coalesce_level_lines(&lines, 1000.0, Crs::Epsg3857, &cfg, &params(1.0, 0.0, None));
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].rep, 0, "longer chain out-ranks in its cell");
     }
@@ -728,6 +1020,33 @@ mod tests {
         o1.sort_by_key(|l| l.rep);
         o2.sort_by_key(|l| l.rep);
         assert_eq!(o1, o2, "results independent of input order");
+    }
+
+    #[test]
+    fn chain_budget_caps_survivors_by_priority() {
+        // Three disjoint chains in separate thinning cells; a budget of 2
+        // keeps the two highest-priority (longest) ones.
+        let long = ls(&[(0.0, 0.0), (5000.0, 0.0)]);
+        let mid = ls(&[(0.0, 20_000.0), (3000.0, 20_000.0)]);
+        let short = ls(&[(0.0, 40_000.0), (1000.0, 40_000.0)]);
+        let lines = [input(0, &long), input(1, &mid), input(2, &short)];
+        let cfg = AssignConfig {
+            line_visibility: 0.1,
+            ..AssignConfig::default()
+        };
+        let all =
+            coalesce_level_lines(&lines, 1000.0, Crs::Epsg3857, &cfg, &params(1.0, 0.0, None));
+        assert_eq!(all.len(), 3, "no budget keeps all: {all:?}");
+        let cut = coalesce_level_lines(
+            &lines,
+            1000.0,
+            Crs::Epsg3857,
+            &cfg,
+            &params(1.0, 0.0, Some((2, 1.0))),
+        );
+        assert_eq!(cut.len(), 2, "budget of 2 binds: {cut:?}");
+        let reps: Vec<usize> = cut.iter().map(|c| c.rep).collect();
+        assert_eq!(reps, vec![0, 1], "lowest-priority (shortest) chain drops");
     }
 
     #[test]

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -327,11 +327,12 @@ pub struct ConvertOptions {
     /// breaking the streaming pipeline's memory bound.
     pub coalesce_max_level_rows: usize,
     /// Junction continuation threshold for coalescing, in degrees (default
-    /// [`DEFAULT_JUNCTION_ANGLE_DEG`]): at junction nodes (degree >= 3),
-    /// compatible incident lines that continue each other within this
-    /// deviation from straight merge best-pair-first, so arterials chain
-    /// THROUGH the same-class crossings that otherwise terminate every
-    /// stroke. `0` restores strict degree-2-only chaining.
+    /// [`DEFAULT_JUNCTION_ANGLE_DEG`] = `0` = OFF, per maintainer render
+    /// review — strict degree-2 chaining looks better on road networks).
+    /// When `> 0`: at junction nodes (degree >= 3), compatible incident
+    /// lines that continue each other within this deviation from straight
+    /// merge best-pair-first, so arterials chain THROUGH same-class
+    /// crossings (fewer, longer strokes at the cost of over-merging).
     pub coalesce_junction_angle: f64,
 }
 

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -54,8 +54,8 @@ use super::assign::{
 };
 use super::cluster::{build_cluster_tables, AccumulateSpec, ClusterEntry, POINT_COUNT_COLUMN};
 use super::coalesce::{
-    coalesce_level_lines, CoalesceInput, COALESCED_COUNT_COLUMN, DEFAULT_COALESCE_MAX_LEVEL_ROWS,
-    DEFAULT_SNAP_GSD_FACTOR,
+    coalesce_level_lines, CoalesceInput, CoalesceParams, COALESCED_COUNT_COLUMN,
+    DEFAULT_COALESCE_MAX_LEVEL_ROWS, DEFAULT_JUNCTION_ANGLE_DEG, DEFAULT_SNAP_GSD_FACTOR,
 };
 use super::level::{
     gsd_with_base, AccumulatedColumn, ClusteringProvenance, CoalescingProvenance, Crs,
@@ -298,14 +298,22 @@ pub struct ConvertOptions {
     /// absorbed features at that level. Requires [`cluster`](Self::cluster).
     /// Empty by default.
     pub accumulate: Vec<AccumulateSpec>,
-    /// Enable line network coalescing (plan Q3; opt-in). Duplicating mode
-    /// only. At each non-canonical level, touching same-class line segments
+    /// Enable line network coalescing (plan Q3). **Default `true`** (like
+    /// `line_thinning = 1.0` and the clustering point grid, chosen by
+    /// maintainer render review: defaults should look right). At each
+    /// non-canonical duplicating level, touching same-class line segments
     /// are chained into single "stroke" LineStrings BEFORE the visibility
     /// gate and thinning run (see [`super::coalesce`]), so fragmented
     /// networks read as connected arteries at coarse zooms. The output
     /// gains a `coalesced_count` INT32 NOT NULL column (source segments
     /// merged per row; 1 for unmerged rows and at the canonical level).
-    /// Points and polygons are unaffected. Default `false`.
+    /// Points and polygons are unaffected.
+    ///
+    /// **Partitioning mode**: coalescing cannot be represented there (a
+    /// merged chain violates §2.3's feature-once/verbatim contract), so
+    /// this option is treated as INERT for partitioning conversions — the
+    /// output has no `coalesced_count` column and no coalescing provenance.
+    /// (The CLI additionally rejects an *explicit* request.)
     pub coalesce_lines: bool,
     /// Endpoint snap tolerance for coalescing, in GSD multiples (default
     /// [`DEFAULT_SNAP_GSD_FACTOR`] = 1.0): after exact-endpoint chaining,
@@ -318,6 +326,13 @@ pub struct ConvertOptions {
     /// candidate lines than this skip coalescing (with a log) instead of
     /// breaking the streaming pipeline's memory bound.
     pub coalesce_max_level_rows: usize,
+    /// Junction continuation threshold for coalescing, in degrees (default
+    /// [`DEFAULT_JUNCTION_ANGLE_DEG`]): at junction nodes (degree >= 3),
+    /// compatible incident lines that continue each other within this
+    /// deviation from straight merge best-pair-first, so arterials chain
+    /// THROUGH the same-class crossings that otherwise terminate every
+    /// stroke. `0` restores strict degree-2-only chaining.
+    pub coalesce_junction_angle: f64,
 }
 
 /// Default rows per read batch for the streaming pipeline (H3).
@@ -345,9 +360,10 @@ impl Default for ConvertOptions {
             read_batch_size: DEFAULT_READ_BATCH_SIZE,
             cluster: false,
             accumulate: Vec::new(),
-            coalesce_lines: false,
+            coalesce_lines: true,
             coalesce_snap: DEFAULT_SNAP_GSD_FACTOR,
             coalesce_max_level_rows: DEFAULT_COALESCE_MAX_LEVEL_ROWS,
+            coalesce_junction_angle: DEFAULT_JUNCTION_ANGLE_DEG,
         }
     }
 }
@@ -484,19 +500,6 @@ pub enum ConvertError {
          converting with --cluster"
     )]
     PointCountColumnPresent,
-    /// `--coalesce-lines` was requested in partitioning mode. Partitioning
-    /// requires every source feature to appear exactly once with its
-    /// geometry verbatim (§2.3); a merged chain is a new geometry replacing
-    /// several source rows, so coalescing has no sound construction in a
-    /// feature-once layout (it also breaks the prefix-read semantics:
-    /// segments merged at a coarse level would have to vanish from every
-    /// finer band they belong to).
-    #[error(
-        "--coalesce-lines requires duplicating mode: partitioning places each \
-         feature exactly once with geometry verbatim, which a merged chain \
-         cannot satisfy"
-    )]
-    CoalescePartitioningUnsupported,
     /// The input already contains a `coalesced_count` column (coalescing
     /// enabled).
     #[error(
@@ -527,11 +530,28 @@ pub fn convert_to_overviews(
     if !options.accumulate.is_empty() && !options.cluster {
         return Err(ConvertError::AccumulateWithoutCluster);
     }
-    // Coalescing option sanity (Q3): partitioning mode cannot represent
-    // merged chains (see the error's rationale).
-    if options.coalesce_lines && matches!(options.mode, Mode::Partitioning) {
-        return Err(ConvertError::CoalescePartitioningUnsupported);
-    }
+    // Coalescing is INERT in partitioning mode (Q3, spec §13.5): a merged
+    // chain is a new geometry replacing several source rows, which the
+    // feature-once/verbatim contract of §2.3 cannot represent, and removing
+    // merged members from finer bands would break prefix reads. Coalescing
+    // is on by default, so partitioning conversions silently proceed
+    // without it (no column, no provenance); the CLI rejects an EXPLICIT
+    // request instead.
+    let inert_options: ConvertOptions;
+    let options: &ConvertOptions =
+        if options.coalesce_lines && matches!(options.mode, Mode::Partitioning) {
+            log::info!(
+                "line coalescing is inert in partitioning mode (feature-once / \
+                 geometry-verbatim contract); converting without it"
+            );
+            inert_options = ConvertOptions {
+                coalesce_lines: false,
+                ..options.clone()
+            };
+            &inert_options
+        } else {
+            options
+        };
 
     // Two-pass bounded-memory pipeline (H3, default). The in-memory path below
     // is kept as the reference implementation (`streaming: false`).
@@ -715,7 +735,9 @@ pub fn convert_to_overviews(
                     group: line_groups.as_ref().map_or(0, |g| g[f.index]),
                 })
                 .collect();
-            Some(build_level_coalesce_table(&inputs, gsd_m, crs, options))
+            Some(build_level_coalesce_table(
+                &inputs, level, finest, gsd_m, crs, options,
+            ))
         } else {
             None
         };
@@ -1342,19 +1364,61 @@ impl GroupInterner {
     }
 }
 
-/// Build one level's [`CoalesceTable`]: chain + gate + thin the candidate
-/// lines ([`coalesce_level_lines`]), then simplify each surviving chain for
-/// the level. Chains that degenerate during simplification are dropped
-/// (default knobs never hit this: the 2×GSD gate is stricter than the 1×GSD
-/// simplify drop gate). Deterministic; shared verbatim by both pipelines so
-/// their outputs stay identical.
+/// Run the chain stage for one level: chain + gate + thin + per-level
+/// density budget. The budget mirrors the Q2 geometric ladder over the LINE
+/// candidate count — `budget(L) = num_lines / drop_rate^(finest − L)`, with
+/// the same [`MIN_DENSITY_LEVEL_FEATURES`](super::assign) floor and
+/// spatial-fairness gamma — so coalescing does not bypass the mid-zoom cap
+/// the budget was calibrated for. Deterministic; shared verbatim by both
+/// pipelines (and the streaming counting pass) so their outputs and hints
+/// stay identical.
+pub(super) fn coalesce_level_chains(
+    inputs: &[CoalesceInput<'_>],
+    level: usize,
+    finest: usize,
+    gsd_m: f64,
+    crs: Crs,
+    options: &ConvertOptions,
+) -> Vec<super::coalesce::CoalescedLine> {
+    let budget = if options.density.enabled
+        && options.density.drop_rate > 1.0
+        && !options.density.drop_rate.is_nan()
+        && level < finest
+    {
+        let keep = 1.0 / options.density.drop_rate;
+        let raw = inputs.len() as f64 * keep.powi((finest - level) as i32);
+        let max_chains = (raw.round() as usize).max(super::assign::MIN_DENSITY_LEVEL_FEATURES);
+        Some((max_chains, options.density.gamma))
+    } else {
+        None
+    };
+    coalesce_level_lines(
+        inputs,
+        gsd_m,
+        crs,
+        &options.assign,
+        &CoalesceParams {
+            snap_gsd_factor: options.coalesce_snap,
+            junction_angle_deg: options.coalesce_junction_angle,
+            budget,
+        },
+    )
+}
+
+/// Build one level's [`CoalesceTable`]: run the chain stage
+/// ([`coalesce_level_chains`]), then simplify each surviving chain for the
+/// level. Chains that degenerate during simplification are dropped (default
+/// knobs never hit this: the 2×GSD gate is stricter than the 1×GSD simplify
+/// drop gate).
 pub(super) fn build_level_coalesce_table(
     inputs: &[CoalesceInput<'_>],
+    level: usize,
+    finest: usize,
     gsd_m: f64,
     crs: Crs,
     options: &ConvertOptions,
 ) -> CoalesceTable {
-    let chains = coalesce_level_lines(inputs, gsd_m, crs, &options.assign, options.coalesce_snap);
+    let chains = coalesce_level_chains(inputs, level, finest, gsd_m, crs, options);
     let mut table = CoalesceTable::with_capacity(chains.len());
     for chain in chains {
         match simplify_for_level(&chain.geom, gsd_m, crs, &options.simplify) {
@@ -3254,30 +3318,34 @@ mod tests {
         let tin = tempfile::NamedTempFile::new().unwrap();
         write_input(tin.path(), &geoms, false, None);
 
-        let base = ConvertOptions {
+        let opts = ConvertOptions {
             levels: LevelPlan::ZoomRange {
                 min_zoom: 4,
                 max_zoom: 10,
             },
             no_auto_rank: true,
-            ..Default::default()
+            ..Default::default() // coalescing is ON by default
         };
 
-        // Baseline: fragments vanish from the coarse level.
+        // Baseline (opt-out): fragments vanish from the coarse level.
         let tout_off = tempfile::NamedTempFile::new().unwrap();
-        let off = convert_to_overviews(tin.path(), tout_off.path(), &base).unwrap();
+        let off = convert_to_overviews(
+            tin.path(),
+            tout_off.path(),
+            &ConvertOptions {
+                coalesce_lines: false,
+                ..opts.clone()
+            },
+        )
+        .unwrap();
         assert_eq!(
             off.levels[0].feature_count, 1,
             "without coalescing only the point survives level 0: {:?}",
             off.levels
         );
 
-        // Coalescing: the chain survives as ONE feature with count 6.
+        // Coalescing (default): the chain survives as ONE feature, count 6.
         let tout = tempfile::NamedTempFile::new().unwrap();
-        let opts = ConvertOptions {
-            coalesce_lines: true,
-            ..base
-        };
         let report = convert_to_overviews(tin.path(), tout.path(), &opts).unwrap();
         assert_eq!(
             report.levels[0].feature_count, 2,
@@ -3360,28 +3428,46 @@ mod tests {
     }
 
     #[test]
-    fn coalesce_rejects_partitioning() {
+    fn coalesce_inert_in_partitioning() {
+        // Partitioning cannot represent merged chains (§13.5); with
+        // coalescing on by default, partitioning conversions proceed
+        // WITHOUT it: no coalesced_count column, no coalescing provenance.
         let geoms = fragment_chain_geoms(3);
         let tin = tempfile::NamedTempFile::new().unwrap();
-        let tout = tempfile::NamedTempFile::new().unwrap();
         write_input(tin.path(), &geoms, false, None);
 
         for streaming in [true, false] {
-            let err = convert_to_overviews(
+            let tout = tempfile::NamedTempFile::new().unwrap();
+            let report = convert_to_overviews(
                 tin.path(),
                 tout.path(),
                 &ConvertOptions {
                     mode: Mode::Partitioning,
-                    coalesce_lines: true,
+                    coalesce_lines: true, // the default; explicit for clarity
                     streaming,
                     ..Default::default()
                 },
             )
-            .unwrap_err();
+            .unwrap();
+            // Feature-once: total rows == input rows, no merging happened.
+            assert_eq!(report.total_rows, geoms.len(), "streaming={streaming}");
+            let reader = OverviewReader::open(tout.path()).unwrap();
             assert!(
-                matches!(err, ConvertError::CoalescePartitioningUnsupported),
-                "streaming={streaming}: got {err:?}"
+                reader
+                    .meta()
+                    .generalization
+                    .as_ref()
+                    .unwrap()
+                    .coalescing
+                    .is_none(),
+                "no coalescing provenance in partitioning mode"
             );
+            let batch_schema = reader.read_level(0, None).unwrap().next().unwrap().unwrap();
+            assert!(
+                batch_schema.schema().index_of("coalesced_count").is_err(),
+                "no coalesced_count column in partitioning mode"
+            );
+            assert!(validate_file(tout.path()).unwrap().is_valid());
         }
     }
 
@@ -3438,8 +3524,16 @@ mod tests {
                 "streaming={streaming}: got {err:?}"
             );
         }
-        // Without coalescing the column is an ordinary property.
-        convert_to_overviews(tin.path(), tout.path(), &ConvertOptions::default()).unwrap();
+        // With coalescing disabled the column is an ordinary property.
+        convert_to_overviews(
+            tin.path(),
+            tout.path(),
+            &ConvertOptions {
+                coalesce_lines: false,
+                ..Default::default()
+            },
+        )
+        .unwrap();
     }
 
     #[test]
@@ -3468,9 +3562,17 @@ mod tests {
         assert_eq!(c.snap_tolerance_gsd_factor, 1.5);
         assert_eq!(c.coalesced_count_column, "coalesced_count");
 
-        // Off by default: no coalescing block, no coalesced_count column.
+        // Opt-out (`--no-coalesce-lines`): no coalescing block recorded.
         let tout_off = tempfile::NamedTempFile::new().unwrap();
-        convert_to_overviews(tin.path(), tout_off.path(), &ConvertOptions::default()).unwrap();
+        convert_to_overviews(
+            tin.path(),
+            tout_off.path(),
+            &ConvertOptions {
+                coalesce_lines: false,
+                ..Default::default()
+            },
+        )
+        .unwrap();
         let r_off = OverviewReader::open(tout_off.path()).unwrap();
         assert!(r_off
             .meta()

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -53,9 +53,13 @@ use super::assign::{
     FeatureKind, SUPERCELL_GSD_FACTOR,
 };
 use super::cluster::{build_cluster_tables, AccumulateSpec, ClusterEntry, POINT_COUNT_COLUMN};
+use super::coalesce::{
+    coalesce_level_lines, CoalesceInput, COALESCED_COUNT_COLUMN, DEFAULT_COALESCE_MAX_LEVEL_ROWS,
+    DEFAULT_SNAP_GSD_FACTOR,
+};
 use super::level::{
-    gsd_with_base, AccumulatedColumn, ClusteringProvenance, Crs, DensityProvenance, Generalization,
-    GeneralizationLevel, Mode, RankingProvenance, GSD_TILE_BASE,
+    gsd_with_base, AccumulatedColumn, ClusteringProvenance, CoalescingProvenance, Crs,
+    DensityProvenance, Generalization, GeneralizationLevel, Mode, RankingProvenance, GSD_TILE_BASE,
 };
 use super::simplify::{simplify_for_level, Simplified, SimplifyOptions};
 use super::writer::{LevelSpec, OverviewWriter, OverviewWriterOptions, WriterError, LEVEL_COLUMN};
@@ -294,6 +298,26 @@ pub struct ConvertOptions {
     /// absorbed features at that level. Requires [`cluster`](Self::cluster).
     /// Empty by default.
     pub accumulate: Vec<AccumulateSpec>,
+    /// Enable line network coalescing (plan Q3; opt-in). Duplicating mode
+    /// only. At each non-canonical level, touching same-class line segments
+    /// are chained into single "stroke" LineStrings BEFORE the visibility
+    /// gate and thinning run (see [`super::coalesce`]), so fragmented
+    /// networks read as connected arteries at coarse zooms. The output
+    /// gains a `coalesced_count` INT32 NOT NULL column (source segments
+    /// merged per row; 1 for unmerged rows and at the canonical level).
+    /// Points and polygons are unaffected. Default `false`.
+    pub coalesce_lines: bool,
+    /// Endpoint snap tolerance for coalescing, in GSD multiples (default
+    /// [`DEFAULT_SNAP_GSD_FACTOR`] = 1.0): after exact-endpoint chaining,
+    /// chain ends within `factor × gsd` of each other are joined. `<= 0`
+    /// disables the snap pass (exact coordinate matching only).
+    pub coalesce_snap: f64,
+    /// Per-level candidate ceiling for coalescing (default
+    /// [`DEFAULT_COALESCE_MAX_LEVEL_ROWS`]): chaining holds the level's
+    /// candidate line geometries in memory at once, so levels with more
+    /// candidate lines than this skip coalescing (with a log) instead of
+    /// breaking the streaming pipeline's memory bound.
+    pub coalesce_max_level_rows: usize,
 }
 
 /// Default rows per read batch for the streaming pipeline (H3).
@@ -321,6 +345,9 @@ impl Default for ConvertOptions {
             read_batch_size: DEFAULT_READ_BATCH_SIZE,
             cluster: false,
             accumulate: Vec::new(),
+            coalesce_lines: false,
+            coalesce_snap: DEFAULT_SNAP_GSD_FACTOR,
+            coalesce_max_level_rows: DEFAULT_COALESCE_MAX_LEVEL_ROWS,
         }
     }
 }
@@ -457,6 +484,26 @@ pub enum ConvertError {
          converting with --cluster"
     )]
     PointCountColumnPresent,
+    /// `--coalesce-lines` was requested in partitioning mode. Partitioning
+    /// requires every source feature to appear exactly once with its
+    /// geometry verbatim (§2.3); a merged chain is a new geometry replacing
+    /// several source rows, so coalescing has no sound construction in a
+    /// feature-once layout (it also breaks the prefix-read semantics:
+    /// segments merged at a coarse level would have to vanish from every
+    /// finer band they belong to).
+    #[error(
+        "--coalesce-lines requires duplicating mode: partitioning places each \
+         feature exactly once with geometry verbatim, which a merged chain \
+         cannot satisfy"
+    )]
+    CoalescePartitioningUnsupported,
+    /// The input already contains a `coalesced_count` column (coalescing
+    /// enabled).
+    #[error(
+        "input already contains a '{COALESCED_COUNT_COLUMN}' column; rename it \
+         before converting with --coalesce-lines"
+    )]
+    CoalescedCountColumnPresent,
     /// The input has no features, or every feature was dropped from every level.
     #[error("no output rows produced (empty input or all features dropped)")]
     NoData,
@@ -479,6 +526,11 @@ pub fn convert_to_overviews(
     }
     if !options.accumulate.is_empty() && !options.cluster {
         return Err(ConvertError::AccumulateWithoutCluster);
+    }
+    // Coalescing option sanity (Q3): partitioning mode cannot represent
+    // merged chains (see the error's rationale).
+    if options.coalesce_lines && matches!(options.mode, Mode::Partitioning) {
+        return Err(ConvertError::CoalescePartitioningUnsupported);
     }
 
     // Two-pass bounded-memory pipeline (H3, default). The in-memory path below
@@ -526,6 +578,8 @@ pub fn convert_to_overviews(
 
     // Clustering schema checks + accumulate column resolution (Q4).
     let acc_cols = validate_cluster_schema(&input_schema, options)?;
+    // Coalescing schema check (Q3).
+    validate_coalesce_schema(&input_schema, options)?;
 
     let reader = builder.build()?;
     let mut batches: Vec<RecordBatch> = Vec::new();
@@ -547,6 +601,24 @@ pub fn convert_to_overviews(
     // per-feature sort keys and the provenance recorded in the footer (§3.5).
     let (sort_keys, ranking_provenance) =
         resolve_ranking(&input_schema, &full, &geometries, options)?;
+
+    // --- Coalescing groups (Q3): interned class values, when class-ranked. ---
+    let num_lines = geometries
+        .iter()
+        .filter(|g| feature_kind(g) == FeatureKind::Line)
+        .count();
+    let coalesce_on = coalesce_effective(options, num_lines);
+    let line_groups: Option<Vec<u32>> = if coalesce_on {
+        coalesce_group_column(&ranking_provenance).map(|col| {
+            let idx = input_schema.index_of(col).expect("ranking column exists");
+            let mut interner = GroupInterner::default();
+            let mut groups = Vec::with_capacity(full.num_rows());
+            interner.extend(full.column(idx).as_ref(), &mut groups);
+            groups
+        })
+    } else {
+        None
+    };
 
     // --- Level assignment. ---------------------------------------------------
     let level_specs = options.levels.resolve(options.gsd_base)?;
@@ -611,6 +683,9 @@ pub fn convert_to_overviews(
         indices: Vec<usize>,
         geoms: Vec<Geometry<f64>>,
         vertex_count: usize,
+        /// Coalescing (Q3): this level's chain table (rep row → merged
+        /// geometry + member count). `None` at non-coalesced levels.
+        coalesce: Option<CoalesceTable>,
     }
     let mut emitted: Vec<EmittedLevel> = Vec::new();
 
@@ -623,6 +698,38 @@ pub fn convert_to_overviews(
         // Verbatim path: partitioning at every level (§2.3), and duplicating at
         // the canonical (finest) level (§2.4). Otherwise simplify per feature.
         let verbatim = matches!(options.mode, Mode::Partitioning) || level == finest;
+
+        // Coalescing (Q3): at non-canonical duplicating levels, ALL line rows
+        // enter the per-level chain stage (pre-gate, pre-thinning — chains of
+        // sub-visibility fragments must be reclaimable) and the winner-table
+        // path handles only the non-line rows. The chain table's rep rows are
+        // added back below with their merged, pre-simplified geometry.
+        let coalesce: Option<CoalesceTable> = if coalesce_on && !verbatim {
+            let inputs: Vec<CoalesceInput<'_>> = features
+                .iter()
+                .filter(|f| f.kind == FeatureKind::Line)
+                .map(|f| CoalesceInput {
+                    index: f.index,
+                    geom: &geometries[f.index],
+                    sort_key: f.sort_key,
+                    group: line_groups.as_ref().map_or(0, |g| g[f.index]),
+                })
+                .collect();
+            Some(build_level_coalesce_table(&inputs, gsd_m, crs, options))
+        } else {
+            None
+        };
+        let member_indices: Vec<usize> = if let Some(table) = &coalesce {
+            let mut v: Vec<usize> = member_indices
+                .into_iter()
+                .filter(|&i| features[i].kind != FeatureKind::Line)
+                .collect();
+            v.extend(table.keys().copied());
+            v.sort_unstable();
+            v
+        } else {
+            member_indices
+        };
 
         let mut indices = Vec::with_capacity(member_indices.len());
         let mut geoms = Vec::with_capacity(member_indices.len());
@@ -637,6 +744,13 @@ pub fn convert_to_overviews(
             }
         } else {
             for i in member_indices {
+                // Chain reps carry their merged, already-simplified geometry.
+                if let Some((g, _)) = coalesce.as_ref().and_then(|t| t.get(&i)) {
+                    vertex_count += count_vertices(g);
+                    indices.push(i);
+                    geoms.push(g.clone());
+                    continue;
+                }
                 match simplify_for_level(&geometries[i], gsd_m, crs, &options.simplify) {
                     Simplified::Keep(g) => {
                         vertex_count += count_vertices(&g);
@@ -659,6 +773,7 @@ pub fn convert_to_overviews(
             indices,
             geoms,
             vertex_count,
+            coalesce,
         });
     }
 
@@ -673,11 +788,17 @@ pub fn convert_to_overviews(
     // same type so RecordBatch assembly matches.
     let geom_out_field = mixed_geometry_field(&geom_name);
     let source_schema = build_source_schema(&input_schema, geom_idx, geom_out_field.clone());
-    // Writer schema: base + point_count when clustering (Q4).
-    let out_schema = if options.cluster {
+    // Writer schema: base + point_count when clustering (Q4) + coalesced_count
+    // when coalescing (Q3).
+    let cluster_schema = if options.cluster {
         append_point_count_field(&source_schema)
     } else {
         source_schema.clone()
+    };
+    let out_schema = if options.coalesce_lines {
+        append_coalesced_count_field(&cluster_schema)
+    } else {
+        cluster_schema.clone()
     };
 
     let writer_levels: Vec<LevelSpec> = emitted
@@ -716,7 +837,11 @@ pub fn convert_to_overviews(
         if let Some(tables) = &cluster_tables {
             // Canonical level: singleton clusters, columns verbatim (§2.4).
             let table = (e.orig != finest).then(|| &tables[e.orig]);
-            batch = apply_cluster_columns(batch, &out_schema, &e.indices, table, &acc_cols)?;
+            batch = apply_cluster_columns(batch, &cluster_schema, &e.indices, table, &acc_cols)?;
+        }
+        if options.coalesce_lines {
+            // Canonical level (and guard-skipped runs): table is None ⇒ all 1.
+            batch = apply_coalesced_count(batch, &out_schema, &e.indices, e.coalesce.as_ref())?;
         }
         writer.write_level(level_idx, Some(e.indices.len()), std::iter::once(batch))?;
         level_reports.push(LevelReport {
@@ -1105,6 +1230,165 @@ fn overwrite_numeric_column(
     }
 }
 
+// ============================================================================
+// Coalescing helpers (Q3) — shared by the in-memory and streaming pipelines
+// ============================================================================
+
+/// One level's coalescing result: rep source row → (simplified merged
+/// geometry, number of source segments merged).
+pub(super) type CoalesceTable = HashMap<usize, (Geometry<f64>, i32)>;
+
+/// Validate the coalescing-related schema constraint: the input must not
+/// already carry a `coalesced_count` column (case-insensitive, mirroring the
+/// `level` / `point_count` rules).
+pub(super) fn validate_coalesce_schema(
+    schema: &Schema,
+    options: &ConvertOptions,
+) -> Result<(), ConvertError> {
+    if !options.coalesce_lines {
+        return Ok(());
+    }
+    if schema
+        .fields()
+        .iter()
+        .any(|f| f.name().eq_ignore_ascii_case(COALESCED_COUNT_COLUMN))
+    {
+        return Err(ConvertError::CoalescedCountColumnPresent);
+    }
+    Ok(())
+}
+
+/// The writer schema with the trailing `coalesced_count` INT32 NOT NULL
+/// column appended (coalescing enabled).
+pub(super) fn append_coalesced_count_field(schema: &Schema) -> Schema {
+    let mut fields: Vec<Arc<Field>> = schema.fields().iter().cloned().collect();
+    fields.push(Arc::new(Field::new(
+        COALESCED_COUNT_COLUMN,
+        DataType::Int32,
+        false,
+    )));
+    Schema::new(fields)
+}
+
+/// Append the `coalesced_count` column to a level batch: chain reps take
+/// their member count from `table`; every other row (non-lines, unmerged
+/// lines, canonical rows — `table` is `None` there) carries `1`.
+pub(super) fn apply_coalesced_count(
+    batch: RecordBatch,
+    out_schema: &Schema,
+    global_indices: &[usize],
+    table: Option<&CoalesceTable>,
+) -> Result<RecordBatch, ConvertError> {
+    use arrow_array::Int32Array;
+
+    debug_assert_eq!(batch.num_rows(), global_indices.len());
+    let mut columns: Vec<Arc<dyn Array>> = batch.columns().to_vec();
+    let counts: Vec<i32> = global_indices
+        .iter()
+        .map(|g| table.and_then(|t| t.get(g)).map_or(1, |(_, c)| *c))
+        .collect();
+    columns.push(Arc::new(Int32Array::from(counts)));
+    Ok(RecordBatch::try_new(Arc::new(out_schema.clone()), columns)?)
+}
+
+/// The class column driving coalescing compatibility groups, when the Q1
+/// ranking is class-based (explicit `--class-rank` or auto-detected Overture
+/// roads). Numeric rankings (`--sort-key`, auto-confidence) and the size
+/// fallback have no class semantics: all lines are compatible.
+pub(super) fn coalesce_group_column(ranking: &RankingProvenance) -> Option<&str> {
+    match ranking.mode.as_str() {
+        "class-ranking" | "auto-overture-roads" => ranking.column.as_deref(),
+        _ => None,
+    }
+}
+
+/// Incremental string→id interner for coalescing compatibility groups.
+/// Null values map to [`GroupInterner::NULL_GROUP`] (all nulls compatible
+/// with each other, never with a named class).
+#[derive(Debug, Default)]
+pub(super) struct GroupInterner {
+    map: HashMap<String, u32>,
+}
+
+impl GroupInterner {
+    /// Group id assigned to null/missing class values.
+    pub(super) const NULL_GROUP: u32 = u32::MAX;
+
+    /// Intern one column's values, appending a group id per row to `out`.
+    /// Non-string columns intern every row as [`Self::NULL_GROUP`] (callers
+    /// only pass validated class-ranking columns, which are strings).
+    pub(super) fn extend(&mut self, col: &dyn Array, out: &mut Vec<u32>) {
+        use arrow_array::cast::AsArray;
+
+        macro_rules! intern {
+            ($arr:expr) => {{
+                let a = $arr;
+                for i in 0..a.len() {
+                    if a.is_null(i) {
+                        out.push(Self::NULL_GROUP);
+                    } else {
+                        let next = self.map.len() as u32;
+                        let id = *self.map.entry(a.value(i).to_string()).or_insert(next);
+                        out.push(id);
+                    }
+                }
+            }};
+        }
+        match col.data_type() {
+            DataType::Utf8 => intern!(col.as_string::<i32>()),
+            DataType::LargeUtf8 => intern!(col.as_string::<i64>()),
+            _ => out.extend(std::iter::repeat(Self::NULL_GROUP).take(col.len())),
+        }
+    }
+}
+
+/// Build one level's [`CoalesceTable`]: chain + gate + thin the candidate
+/// lines ([`coalesce_level_lines`]), then simplify each surviving chain for
+/// the level. Chains that degenerate during simplification are dropped
+/// (default knobs never hit this: the 2×GSD gate is stricter than the 1×GSD
+/// simplify drop gate). Deterministic; shared verbatim by both pipelines so
+/// their outputs stay identical.
+pub(super) fn build_level_coalesce_table(
+    inputs: &[CoalesceInput<'_>],
+    gsd_m: f64,
+    crs: Crs,
+    options: &ConvertOptions,
+) -> CoalesceTable {
+    let chains = coalesce_level_lines(inputs, gsd_m, crs, &options.assign, options.coalesce_snap);
+    let mut table = CoalesceTable::with_capacity(chains.len());
+    for chain in chains {
+        match simplify_for_level(&chain.geom, gsd_m, crs, &options.simplify) {
+            Simplified::Keep(g) => {
+                table.insert(chain.rep, (g, chain.count));
+            }
+            Simplified::Dropped => {}
+        }
+    }
+    table
+}
+
+/// Whether coalescing is effectively active for this conversion: enabled,
+/// and the candidate line count fits the per-level memory guard. Logs when
+/// the guard trips (the file still carries the `coalesced_count` column,
+/// all 1, and the coalescing provenance).
+pub(super) fn coalesce_effective(options: &ConvertOptions, num_lines: usize) -> bool {
+    if !options.coalesce_lines {
+        return false;
+    }
+    if num_lines > options.coalesce_max_level_rows {
+        log::warn!(
+            "coalescing skipped: {num_lines} candidate lines exceed \
+             --coalesce-max-level-rows {} (chaining holds a level's line \
+             geometries in memory; near-canonical levels this large need \
+             coalescing least). Output keeps the coalesced_count column \
+             (all 1).",
+            options.coalesce_max_level_rows
+        );
+        return false;
+    }
+    true
+}
+
 /// Build informative generalization provenance (§3.5) from the emitted gsds.
 pub(super) fn build_generalization(
     gsds: &[f64],
@@ -1143,6 +1427,17 @@ pub(super) fn build_generalization(
                 drop_rate: options.density.drop_rate,
                 gamma: options.density.gamma,
                 supercell_gsd_factor: SUPERCELL_GSD_FACTOR,
+            })
+        } else {
+            None
+        },
+        // Recorded only when coalescing was requested; a non-coalesced run
+        // emits a byte-identical footer to before this feature existed.
+        coalescing: if options.coalesce_lines {
+            Some(CoalescingProvenance {
+                enabled: true,
+                snap_tolerance_gsd_factor: options.coalesce_snap,
+                coalesced_count_column: COALESCED_COUNT_COLUMN.to_string(),
             })
         } else {
             None
@@ -2914,6 +3209,414 @@ mod tests {
                 read_point_counts(&mr, level),
                 read_point_counts(&sr, level),
                 "level {level} point_count differs"
+            );
+        }
+    }
+
+    // --- Q3 line coalescing ---------------------------------------------------
+
+    /// Read the `coalesced_count` column for one level, in row order.
+    fn read_coalesced_counts(reader: &OverviewReader, level: usize) -> Vec<i32> {
+        use arrow_array::cast::AsArray;
+        use arrow_array::types::Int32Type;
+        let rdr = reader.read_level(level, None).unwrap();
+        let mut out = Vec::new();
+        for batch in rdr {
+            let batch = batch.unwrap();
+            let idx = batch.schema().index_of("coalesced_count").unwrap();
+            let col = batch.column(idx).as_primitive::<Int32Type>().clone();
+            assert_eq!(col.null_count(), 0, "coalesced_count must be NOT NULL");
+            out.extend(col.values().iter().copied());
+        }
+        out
+    }
+
+    /// A chain of `n` touching collinear segments (each 0.01° long) starting
+    /// at (0,0), plus one far-away point. Each segment alone is below the
+    /// coarse-level line visibility gate; the chain is well above it.
+    fn fragment_chain_geoms(n: usize) -> Vec<Geometry<f64>> {
+        let mut geoms: Vec<Geometry<f64>> = (0..n)
+            .map(|i| {
+                let x0 = i as f64 * 0.01;
+                Geometry::LineString(LineString::from(vec![(x0, 0.0), (x0 + 0.01, 0.0)]))
+            })
+            .collect();
+        geoms.push(Geometry::Point(Point::new(5.0, 5.0)));
+        geoms
+    }
+
+    #[test]
+    fn coalesce_reclaims_sub_visibility_fragments_and_keeps_canonical() {
+        // z4 gsd ≈ 2446 m ⇒ gate 2·gsd ≈ 0.0439°. Segments are 0.01° (fail
+        // alone); the 6-segment chain is 0.06° (passes). Without coalescing
+        // the coarse level holds only the point; with it, point + one artery.
+        let geoms = fragment_chain_geoms(6);
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        write_input(tin.path(), &geoms, false, None);
+
+        let base = ConvertOptions {
+            levels: LevelPlan::ZoomRange {
+                min_zoom: 4,
+                max_zoom: 10,
+            },
+            no_auto_rank: true,
+            ..Default::default()
+        };
+
+        // Baseline: fragments vanish from the coarse level.
+        let tout_off = tempfile::NamedTempFile::new().unwrap();
+        let off = convert_to_overviews(tin.path(), tout_off.path(), &base).unwrap();
+        assert_eq!(
+            off.levels[0].feature_count, 1,
+            "without coalescing only the point survives level 0: {:?}",
+            off.levels
+        );
+
+        // Coalescing: the chain survives as ONE feature with count 6.
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        let opts = ConvertOptions {
+            coalesce_lines: true,
+            ..base
+        };
+        let report = convert_to_overviews(tin.path(), tout.path(), &opts).unwrap();
+        assert_eq!(
+            report.levels[0].feature_count, 2,
+            "chain + point at level 0: {:?}",
+            report.levels
+        );
+
+        let vr = validate_file(tout.path()).unwrap();
+        assert!(
+            vr.is_valid(),
+            "failures: {:?}",
+            vr.failures().collect::<Vec<_>>()
+        );
+
+        let reader = OverviewReader::open(tout.path()).unwrap();
+        let counts0 = read_coalesced_counts(&reader, 0);
+        let mut sorted = counts0.clone();
+        sorted.sort_unstable();
+        assert_eq!(sorted, vec![1, 6], "point=1, merged chain=6: {counts0:?}");
+
+        // Canonical level: every source row verbatim, all counts 1.
+        let canonical = reader.num_levels() - 1;
+        let rows = read_level_rows(&reader, canonical);
+        assert_eq!(rows.len(), geoms.len());
+        for (id, _, _, geom) in &rows {
+            assert_eq!(
+                geom, &geoms[*id as usize],
+                "canonical geometry verbatim (never coalesced)"
+            );
+        }
+        assert!(read_coalesced_counts(&reader, canonical)
+            .iter()
+            .all(|&c| c == 1));
+    }
+
+    #[test]
+    fn coalesce_groups_by_auto_detected_class() {
+        // Two touching motorway segments merge; the footway touching the
+        // same chain end does not (class mismatch). Extra far-away classed
+        // lines trigger the Overture auto-detection vocab gate.
+        let mut geoms = vec![
+            Geometry::LineString(LineString::from(vec![(0.0, 0.0), (0.1, 0.0)])),
+            Geometry::LineString(LineString::from(vec![(0.1, 0.0), (0.2, 0.0)])),
+            Geometry::LineString(LineString::from(vec![(0.2, 0.0), (0.2, 0.1)])),
+        ];
+        let mut classes = vec![Some("motorway"), Some("motorway"), Some("footway")];
+        for (i, c) in ["primary", "service", "residential"].iter().enumerate() {
+            geoms.push(Geometry::LineString(LineString::from(vec![
+                (3.0 + i as f64, 3.0),
+                (3.1 + i as f64, 3.05),
+            ])));
+            classes.push(Some(*c));
+        }
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        write_class_input(tin.path(), &geoms, &classes);
+
+        let opts = ConvertOptions {
+            levels: LevelPlan::ZoomRange {
+                min_zoom: 4,
+                max_zoom: 10,
+            },
+            coalesce_lines: true,
+            ..Default::default()
+        };
+        convert_to_overviews(tin.path(), tout.path(), &opts).unwrap();
+        assert_eq!(ranking_mode_of(tout.path()), "auto-overture-roads");
+
+        let reader = OverviewReader::open(tout.path()).unwrap();
+        let counts0 = read_coalesced_counts(&reader, 0);
+        assert_eq!(
+            counts0.iter().filter(|&&c| c == 2).count(),
+            1,
+            "exactly one 2-segment motorway chain: {counts0:?}"
+        );
+        assert!(
+            counts0.iter().all(|&c| c <= 2),
+            "footway never merges into the motorway chain: {counts0:?}"
+        );
+    }
+
+    #[test]
+    fn coalesce_rejects_partitioning() {
+        let geoms = fragment_chain_geoms(3);
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        write_input(tin.path(), &geoms, false, None);
+
+        for streaming in [true, false] {
+            let err = convert_to_overviews(
+                tin.path(),
+                tout.path(),
+                &ConvertOptions {
+                    mode: Mode::Partitioning,
+                    coalesce_lines: true,
+                    streaming,
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+            assert!(
+                matches!(err, ConvertError::CoalescePartitioningUnsupported),
+                "streaming={streaming}: got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn coalesce_rejects_existing_coalesced_count_column() {
+        // An input already carrying a `coalesced_count` column is rejected
+        // when coalescing (case-insensitively), accepted when off.
+        let geoms = fragment_chain_geoms(2);
+        let n = geoms.len();
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        {
+            let id = Int64Array::from((0..n as i64).collect::<Vec<_>>());
+            let cc = arrow_array::Int32Array::from(vec![7i32; n]);
+            let geom_arr = build_geometry_array(&geoms);
+            let geom_field = geom_arr.data_type().to_field("geometry", true);
+            let fields = vec![
+                Arc::new(Field::new("id", DataType::Int64, false)),
+                Arc::new(Field::new("Coalesced_Count", DataType::Int32, false)),
+                Arc::new(geom_field),
+            ];
+            let columns: Vec<Arc<dyn Array>> =
+                vec![Arc::new(id), Arc::new(cc), geom_arr.to_array_ref()];
+            let schema = Arc::new(Schema::new(fields));
+            let batch = RecordBatch::try_new(schema.clone(), columns).unwrap();
+            let gpq_options = GeoParquetWriterOptionsBuilder::default()
+                .set_encoding(GeoParquetWriterEncoding::WKB)
+                .set_generate_covering(true)
+                .build();
+            let mut encoder = GeoParquetRecordBatchEncoder::try_new(&schema, &gpq_options).unwrap();
+            let target_schema = encoder.target_schema();
+            let file = std::fs::File::create(tin.path()).unwrap();
+            let mut writer = ArrowWriter::try_new(file, target_schema, None).unwrap();
+            writer
+                .write(&encoder.encode_record_batch(&batch).unwrap())
+                .unwrap();
+            writer.append_key_value_metadata(encoder.into_keyvalue().unwrap());
+            writer.close().unwrap();
+        }
+
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        for streaming in [true, false] {
+            let err = convert_to_overviews(
+                tin.path(),
+                tout.path(),
+                &ConvertOptions {
+                    coalesce_lines: true,
+                    streaming,
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+            assert!(
+                matches!(err, ConvertError::CoalescedCountColumnPresent),
+                "streaming={streaming}: got {err:?}"
+            );
+        }
+        // Without coalescing the column is an ordinary property.
+        convert_to_overviews(tin.path(), tout.path(), &ConvertOptions::default()).unwrap();
+    }
+
+    #[test]
+    fn coalesce_footer_provenance_recorded() {
+        let geoms = fragment_chain_geoms(3);
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        write_input(tin.path(), &geoms, false, None);
+
+        let opts = ConvertOptions {
+            coalesce_lines: true,
+            coalesce_snap: 1.5,
+            ..Default::default()
+        };
+        convert_to_overviews(tin.path(), tout.path(), &opts).unwrap();
+        let reader = OverviewReader::open(tout.path()).unwrap();
+        let c = reader
+            .meta()
+            .generalization
+            .as_ref()
+            .unwrap()
+            .coalescing
+            .clone()
+            .expect("coalescing provenance recorded");
+        assert!(c.enabled);
+        assert_eq!(c.snap_tolerance_gsd_factor, 1.5);
+        assert_eq!(c.coalesced_count_column, "coalesced_count");
+
+        // Off by default: no coalescing block, no coalesced_count column.
+        let tout_off = tempfile::NamedTempFile::new().unwrap();
+        convert_to_overviews(tin.path(), tout_off.path(), &ConvertOptions::default()).unwrap();
+        let r_off = OverviewReader::open(tout_off.path()).unwrap();
+        assert!(r_off
+            .meta()
+            .generalization
+            .as_ref()
+            .unwrap()
+            .coalescing
+            .is_none());
+    }
+
+    #[test]
+    fn coalesce_guard_skips_chaining_but_keeps_column() {
+        // A max-level-rows guard smaller than the line count: no chaining
+        // happens (fragments still vanish at coarse levels) but the schema
+        // and provenance stay stable (coalesced_count all 1).
+        let geoms = fragment_chain_geoms(6);
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        write_input(tin.path(), &geoms, false, None);
+
+        let opts = ConvertOptions {
+            levels: LevelPlan::ZoomRange {
+                min_zoom: 4,
+                max_zoom: 10,
+            },
+            no_auto_rank: true,
+            coalesce_lines: true,
+            coalesce_max_level_rows: 2, // < 6 lines → guard trips
+            ..Default::default()
+        };
+        let report = convert_to_overviews(tin.path(), tout.path(), &opts).unwrap();
+        assert_eq!(
+            report.levels[0].feature_count, 1,
+            "guard-skipped run behaves like non-coalesced: {:?}",
+            report.levels
+        );
+        let reader = OverviewReader::open(tout.path()).unwrap();
+        for level in 0..reader.num_levels() {
+            assert!(read_coalesced_counts(&reader, level)
+                .iter()
+                .all(|&c| c == 1));
+        }
+        assert!(validate_file(tout.path()).unwrap().is_valid());
+    }
+
+    #[test]
+    fn streaming_matches_in_memory_coalescing() {
+        // Coalescing must be byte-equivalent between the streaming and
+        // in-memory pipelines, including with tiny read batches (chain reps
+        // scattered across batch boundaries).
+        let geoms = fragment_chain_geoms(6);
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        write_input(tin.path(), &geoms, false, None);
+
+        let base = ConvertOptions {
+            levels: LevelPlan::ZoomRange {
+                min_zoom: 4,
+                max_zoom: 10,
+            },
+            no_auto_rank: true,
+            coalesce_lines: true,
+            read_batch_size: 2,
+            ..Default::default()
+        };
+        assert_streaming_equivalent(tin.path(), &base);
+
+        // Explicitly compare coalesced_count per level too.
+        let mem_out = tempfile::NamedTempFile::new().unwrap();
+        let stream_out = tempfile::NamedTempFile::new().unwrap();
+        convert_to_overviews(
+            tin.path(),
+            mem_out.path(),
+            &ConvertOptions {
+                streaming: false,
+                ..base.clone()
+            },
+        )
+        .unwrap();
+        convert_to_overviews(tin.path(), stream_out.path(), &base).unwrap();
+        let mr = OverviewReader::open(mem_out.path()).unwrap();
+        let sr = OverviewReader::open(stream_out.path()).unwrap();
+        for level in 0..mr.num_levels() {
+            assert_eq!(
+                read_coalesced_counts(&mr, level),
+                read_coalesced_counts(&sr, level),
+                "level {level} coalesced_count differs"
+            );
+        }
+    }
+
+    #[test]
+    fn streaming_matches_in_memory_coalescing_with_class_groups() {
+        // Same equivalence with the auto-detected class ranking driving the
+        // compatibility groups (interner parity across batch boundaries).
+        let mut geoms = vec![
+            Geometry::LineString(LineString::from(vec![(0.0, 0.0), (0.1, 0.0)])),
+            Geometry::LineString(LineString::from(vec![(0.1, 0.0), (0.2, 0.0)])),
+            Geometry::LineString(LineString::from(vec![(0.2, 0.0), (0.2, 0.1)])),
+        ];
+        let mut classes = vec![Some("motorway"), Some("motorway"), Some("footway")];
+        for (i, c) in ["primary", "service", "residential", "trunk"]
+            .iter()
+            .enumerate()
+        {
+            geoms.push(Geometry::LineString(LineString::from(vec![
+                (3.0 + i as f64, 3.0),
+                (3.1 + i as f64, 3.05),
+            ])));
+            classes.push(Some(*c));
+        }
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        write_class_input(tin.path(), &geoms, &classes);
+
+        let base = ConvertOptions {
+            levels: LevelPlan::ZoomRange {
+                min_zoom: 4,
+                max_zoom: 10,
+            },
+            coalesce_lines: true,
+            read_batch_size: 2,
+            ..Default::default()
+        };
+        let mem_out = tempfile::NamedTempFile::new().unwrap();
+        let stream_out = tempfile::NamedTempFile::new().unwrap();
+        convert_to_overviews(
+            tin.path(),
+            mem_out.path(),
+            &ConvertOptions {
+                streaming: false,
+                ..base.clone()
+            },
+        )
+        .unwrap();
+        convert_to_overviews(tin.path(), stream_out.path(), &base).unwrap();
+        assert_eq!(
+            overviews_footer_json(mem_out.path()),
+            overviews_footer_json(stream_out.path())
+        );
+        let mr = OverviewReader::open(mem_out.path()).unwrap();
+        let sr = OverviewReader::open(stream_out.path()).unwrap();
+        assert_eq!(mr.num_levels(), sr.num_levels());
+        for level in 0..mr.num_levels() {
+            assert_eq!(
+                read_coalesced_counts(&mr, level),
+                read_coalesced_counts(&sr, level),
+                "level {level} coalesced_count differs"
             );
         }
     }

--- a/crates/core/src/overview/level.rs
+++ b/crates/core/src/overview/level.rs
@@ -150,6 +150,34 @@ pub struct Generalization {
     /// before this field existed; readers MUST tolerate its absence.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub clustering: Option<ClusteringProvenance>,
+    /// OPTIONAL line-coalescing provenance (§3.5, additive; spec §13 draft).
+    ///
+    /// Records that line network coalescing was enabled (Q3): the endpoint
+    /// snap tolerance (in GSD multiples) and the name of the
+    /// merged-segment-count column (`coalesced_count`). Absent when
+    /// coalescing was off (`--coalesce-lines` not passed) or on files
+    /// written before this field existed; readers MUST tolerate its absence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coalescing: Option<CoalescingProvenance>,
+}
+
+/// How line coalescing was applied for a conversion (Q3, spec §13 draft).
+///
+/// Additive, OPTIONAL provenance embedded in [`Generalization`] (§3.5).
+/// When present with `enabled: true`, the file carries the named
+/// `coalesced_count` column (INT32 NOT NULL, all 1 at the canonical level);
+/// the validator checks those structural facts.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CoalescingProvenance {
+    /// Whether coalescing was applied. Always `true` when the block is
+    /// emitted; present for forward compatibility.
+    pub enabled: bool,
+    /// Endpoint snap tolerance in GSD multiples (per level, the snap
+    /// distance is `snap_tolerance_gsd_factor × gsd`).
+    pub snap_tolerance_gsd_factor: f64,
+    /// Name of the merged-segment-count column (this implementation:
+    /// `coalesced_count`).
+    pub coalesced_count_column: String,
 }
 
 /// How point clustering was applied for a conversion (Q4, spec §12 draft).
@@ -829,6 +857,7 @@ mod tests {
             }),
             density_drop: None,
             clustering: None,
+            coalescing: None,
         });
         let json = meta.to_json().unwrap();
         let parsed = OverviewsMeta::from_json(&json).unwrap();
@@ -856,6 +885,7 @@ mod tests {
                 supercell_gsd_factor: 128.0,
             }),
             clustering: None,
+            coalescing: None,
         });
         let json = meta.to_json().unwrap();
         let parsed = OverviewsMeta::from_json(&json).unwrap();
@@ -879,6 +909,41 @@ mod tests {
     }
 
     #[test]
+    fn coalescing_provenance_roundtrip_and_absent_tolerated() {
+        // A coalescing block survives JSON round-trip; absent key → None.
+        let mut meta = duplicating_example();
+        meta.generalization = Some(Generalization {
+            engine: "gpq-tiles test".to_string(),
+            gsd_base: None,
+            levels: vec![],
+            ranking: None,
+            density_drop: None,
+            clustering: None,
+            coalescing: Some(CoalescingProvenance {
+                enabled: true,
+                snap_tolerance_gsd_factor: 1.0,
+                coalesced_count_column: "coalesced_count".to_string(),
+            }),
+        });
+        let json = meta.to_json().unwrap();
+        let parsed = OverviewsMeta::from_json(&json).unwrap();
+        assert_eq!(meta, parsed);
+        let c = parsed.generalization.unwrap().coalescing.unwrap();
+        assert!(c.enabled);
+        assert_eq!(c.snap_tolerance_gsd_factor, 1.0);
+        assert_eq!(c.coalesced_count_column, "coalesced_count");
+
+        // Absent key → None (additive-field tolerance).
+        let src = r#"{
+            "version": "0.1.0", "mode": "duplicating", "canonical_level": 0,
+            "levels": [ { "row_group_end": 0, "gsd": 611.50, "zoom": 6 } ],
+            "generalization": { "engine": "gpq-tiles 0.1.0", "levels": [] }
+        }"#;
+        let m = OverviewsMeta::from_json(src).unwrap();
+        assert!(m.generalization.unwrap().coalescing.is_none());
+    }
+
+    #[test]
     fn clustering_provenance_roundtrip_and_absent_tolerated() {
         // A clustering block survives JSON round-trip; absent key → None.
         let mut meta = duplicating_example();
@@ -896,6 +961,7 @@ mod tests {
                     op: "mean".to_string(),
                 }],
             }),
+            coalescing: None,
         });
         let json = meta.to_json().unwrap();
         let parsed = OverviewsMeta::from_json(&json).unwrap();

--- a/crates/core/src/overview/mod.rs
+++ b/crates/core/src/overview/mod.rs
@@ -11,6 +11,7 @@
 pub mod assign;
 pub mod check;
 pub mod cluster;
+pub mod coalesce;
 pub mod convert;
 pub mod export;
 pub mod level;

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -67,11 +67,12 @@ use super::coalesce::CoalesceInput;
 use super::convert::{
     append_coalesced_count_field, append_point_count_field, apply_cluster_columns,
     apply_coalesced_count, build_generalization, build_level_batch, build_level_coalesce_table,
-    build_source_schema, class_ranking_provenance, coalesce_effective, count_vertices, detect_crs,
-    extract_class_ranks, extract_sort_keys, feature_kind, fill_level_bytes, find_geometry_column,
-    geometry_bbox, mixed_geometry_field, overture_road_ranking, validate_cluster_schema,
-    validate_coalesce_schema, ClassRanking, CoalesceTable, ConvertError, ConvertOptions,
-    ConvertReport, GroupInterner, LevelReport, KNOWN_ROAD_CLASSES, ROAD_VOCAB_MIN_DISTINCT,
+    build_source_schema, class_ranking_provenance, coalesce_effective, coalesce_level_chains,
+    count_vertices, detect_crs, extract_class_ranks, extract_sort_keys, feature_kind,
+    fill_level_bytes, find_geometry_column, geometry_bbox, mixed_geometry_field,
+    overture_road_ranking, validate_cluster_schema, validate_coalesce_schema, ClassRanking,
+    CoalesceTable, ConvertError, ConvertOptions, ConvertReport, GroupInterner, LevelReport,
+    KNOWN_ROAD_CLASSES, ROAD_VOCAB_MIN_DISTINCT,
 };
 use super::level::{Crs, Mode, RankingProvenance};
 use super::simplify::{
@@ -239,14 +240,9 @@ pub(super) fn convert_streaming(
             if level == finest {
                 counts[level] += scratch.rows.len(); // canonical: verbatim
             } else {
-                counts[level] += super::coalesce::coalesce_level_lines(
-                    &inputs,
-                    level_gsds[level],
-                    crs,
-                    &options.assign,
-                    options.coalesce_snap,
-                )
-                .len();
+                counts[level] +=
+                    coalesce_level_chains(&inputs, level, finest, level_gsds[level], crs, options)
+                        .len();
             }
         }
     }
@@ -318,7 +314,16 @@ pub(super) fn convert_streaming(
         let coalesce_table: Option<CoalesceTable> = coalesce_scratch
             .as_ref()
             .filter(|_| !verbatim)
-            .map(|scratch| build_level_coalesce_table(&scratch.inputs(), e.gsd, crs, options));
+            .map(|scratch| {
+                build_level_coalesce_table(
+                    &scratch.inputs(),
+                    e.orig as usize,
+                    finest,
+                    e.gsd,
+                    crs,
+                    options,
+                )
+            });
         let ctx = LevelStreamCtx {
             source_schema: &source_schema,
             cluster_schema: &cluster_schema,

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -63,13 +63,15 @@ use crate::batch_processor::extract_geometries_from_array;
 
 use super::assign::{apply_density_budget, assign_levels, AssignFeature, FeatureKind};
 use super::cluster::{build_cluster_tables, ClusterEntry, ClusterTables};
+use super::coalesce::CoalesceInput;
 use super::convert::{
-    append_point_count_field, apply_cluster_columns, build_generalization, build_level_batch,
-    build_source_schema, class_ranking_provenance, count_vertices, detect_crs, extract_class_ranks,
-    extract_sort_keys, feature_kind, fill_level_bytes, find_geometry_column, geometry_bbox,
-    mixed_geometry_field, overture_road_ranking, validate_cluster_schema, ClassRanking,
-    ConvertError, ConvertOptions, ConvertReport, LevelReport, KNOWN_ROAD_CLASSES,
-    ROAD_VOCAB_MIN_DISTINCT,
+    append_coalesced_count_field, append_point_count_field, apply_cluster_columns,
+    apply_coalesced_count, build_generalization, build_level_batch, build_level_coalesce_table,
+    build_source_schema, class_ranking_provenance, coalesce_effective, count_vertices, detect_crs,
+    extract_class_ranks, extract_sort_keys, feature_kind, fill_level_bytes, find_geometry_column,
+    geometry_bbox, mixed_geometry_field, overture_road_ranking, validate_cluster_schema,
+    validate_coalesce_schema, ClassRanking, CoalesceTable, ConvertError, ConvertOptions,
+    ConvertReport, GroupInterner, LevelReport, KNOWN_ROAD_CLASSES, ROAD_VOCAB_MIN_DISTINCT,
 };
 use super::level::{Crs, Mode, RankingProvenance};
 use super::simplify::{
@@ -121,11 +123,17 @@ pub(super) fn convert_streaming(
 
     // Clustering schema checks + accumulate column resolution (Q4).
     let acc_cols = validate_cluster_schema(&input_schema, options)?;
+    // Coalescing schema check (Q3).
+    validate_coalesce_schema(&input_schema, options)?;
 
     // --- Pass 1: stream → AssignFeatures + resolved ranking. -----------------
     let t_pass1 = Instant::now();
-    let (mut features, ranking_provenance, acc_values) =
-        run_pass1(input_path, &input_schema, geom_idx, options, &acc_cols)?;
+    let Pass1Output {
+        mut features,
+        provenance: ranking_provenance,
+        acc_values,
+        coalesce: coalesce_scratch,
+    } = run_pass1(input_path, &input_schema, geom_idx, options, &acc_cols)?;
     let num_features = features.len();
     log::debug!(
         "[profile] pass1 stream+scan: {:.2}s",
@@ -178,6 +186,19 @@ pub(super) fn convert_streaming(
         None
     };
     drop(acc_values);
+
+    // Coalescing (Q3): keep the per-row kinds (1 byte/feature — line rows
+    // bypass the winner table at coalesced levels) and the pass-1 line
+    // scratch; apply the memory guard.
+    let coalesce_on = coalesce_effective(
+        options,
+        coalesce_scratch.as_ref().map_or(0, |s| s.rows.len()),
+    );
+    let kinds: Option<Vec<FeatureKind>> = options
+        .coalesce_lines
+        .then(|| features.iter().map(|f| f.kind).collect());
+    let coalesce_scratch = coalesce_scratch.filter(|_| coalesce_on);
+
     features.clear();
     features.shrink_to_fit(); // free the pass-1 O(N)·48B scratch before pass 2
 
@@ -186,12 +207,21 @@ pub(super) fn convert_streaming(
 
     // Per-level winner counts (exact row counts in partitioning mode; in
     // duplicating mode exact up to simplification drops — used as the writer's
-    // row-group sizing hint and for empty-level omission).
+    // row-group sizing hint and for empty-level omission). With coalescing,
+    // line rows leave the winner table at non-canonical levels: their count
+    // is the level's surviving chain count instead (computed by running the
+    // chain stage per level — cheap relative to decode; the tables are
+    // rebuilt, with simplification, per level in pass 2 rather than held for
+    // every level at once).
     let mut hist = vec![0usize; num_levels];
-    for &ml in &min_levels {
+    for (pos, &ml) in min_levels.iter().enumerate() {
+        if coalesce_scratch.is_some() && kinds.as_ref().is_some_and(|k| k[pos] == FeatureKind::Line)
+        {
+            continue; // counted via the per-level chain stage below
+        }
         hist[(ml as usize).min(finest)] += 1;
     }
-    let counts: Vec<usize> = match options.mode {
+    let mut counts: Vec<usize> = match options.mode {
         Mode::Duplicating => hist
             .iter()
             .scan(0usize, |acc, &c| {
@@ -201,6 +231,25 @@ pub(super) fn convert_streaming(
             .collect(),
         Mode::Partitioning => hist,
     };
+    if let Some(scratch) = &coalesce_scratch {
+        // Duplicating only (partitioning + coalescing is rejected upstream).
+        let inputs = scratch.inputs();
+        #[allow(clippy::needless_range_loop)]
+        for level in 0..num_levels {
+            if level == finest {
+                counts[level] += scratch.rows.len(); // canonical: verbatim
+            } else {
+                counts[level] += super::coalesce::coalesce_level_lines(
+                    &inputs,
+                    level_gsds[level],
+                    crs,
+                    &options.assign,
+                    options.coalesce_snap,
+                )
+                .len();
+            }
+        }
+    }
 
     let emitted: Vec<EmitLevel> = level_specs
         .iter()
@@ -221,11 +270,17 @@ pub(super) fn convert_streaming(
     let geom_name = geom_field.name().clone();
     let geom_out_field = mixed_geometry_field(&geom_name);
     let source_schema = build_source_schema(&input_schema, geom_idx, geom_out_field);
-    // Writer schema: base + point_count when clustering (Q4).
-    let out_schema = if options.cluster {
+    // Writer schema: base + point_count when clustering (Q4) + coalesced_count
+    // when coalescing (Q3).
+    let cluster_schema = if options.cluster {
         append_point_count_field(&source_schema)
     } else {
         source_schema.clone()
+    };
+    let out_schema = if options.coalesce_lines {
+        append_coalesced_count_field(&cluster_schema)
+    } else {
+        cluster_schema.clone()
     };
 
     let writer_levels: Vec<LevelSpec> = emitted
@@ -257,8 +312,16 @@ pub(super) fn convert_streaming(
         // Verbatim path: partitioning at every level (§2.3), and duplicating at
         // the canonical (finest) level (§2.4).
         let verbatim = matches!(options.mode, Mode::Partitioning) || e.orig as usize == finest;
+        // Coalescing (Q3): rebuild this level's chain table (chains + gate +
+        // thin + simplify) from the pass-1 line scratch. Canonical level is
+        // never coalesced (§2.4). Memory: one level's surviving chains.
+        let coalesce_table: Option<CoalesceTable> = coalesce_scratch
+            .as_ref()
+            .filter(|_| !verbatim)
+            .map(|scratch| build_level_coalesce_table(&scratch.inputs(), e.gsd, crs, options));
         let ctx = LevelStreamCtx {
             source_schema: &source_schema,
+            cluster_schema: &cluster_schema,
             out_schema: &out_schema,
             non_geom_cols: &non_geom_cols,
             geom_idx,
@@ -276,6 +339,9 @@ pub(super) fn convert_streaming(
                 .filter(|_| e.orig as usize != finest)
                 .map(|t| &t[e.orig as usize]),
             acc_cols: &acc_cols,
+            coalesce_enabled: options.coalesce_lines,
+            kinds: kinds.as_deref(),
+            coalesce_table: coalesce_table.as_ref(),
         };
         let (rows, vertices) = write_level_streaming(
             &mut writer,
@@ -336,6 +402,10 @@ struct RoadCandidate {
     found: HashSet<&'static str>,
     /// Per-row class-rank keys, extracted as we stream.
     keys: Vec<Option<f64>>,
+    /// Per-row interned class values (coalescing groups, Q3). Populated
+    /// only when coalescing is enabled.
+    groups: Vec<u32>,
+    interner: GroupInterner,
 }
 
 /// The ranking tier resolved from the options + schema *before* reading data
@@ -405,6 +475,8 @@ fn build_rank_plan(schema: &Schema, options: &ConvertOptions) -> Result<RankPlan
                 ranking: overture_road_ranking(f.name().clone()),
                 found: HashSet::new(),
                 keys: Vec::new(),
+                groups: Vec::new(),
+                interner: GroupInterner::default(),
             })
             .collect();
         // Candidate Overture places confidence column (point-majority gate is
@@ -458,9 +530,52 @@ fn scan_road_vocab(col: &dyn Array, found: &mut HashSet<&'static str>) {
     }
 }
 
-/// Result of [`run_pass1`]: the per-feature [`AssignFeature`]s, the resolved
-/// ranking provenance, and the per-accumulate-spec source values.
-type Pass1Output = (Vec<AssignFeature>, RankingProvenance, Vec<Vec<Option<f64>>>);
+/// Line geometries (+ compatibility groups) collected during pass 1 for the
+/// coalescing stage (Q3). This is the streaming pipeline's one deliberate
+/// residual `O(lines)` allocation: chaining needs a level's candidate line
+/// geometries together, and the candidate set at every non-canonical
+/// duplicating level is ALL lines (chains of sub-visibility fragments must
+/// be reclaimable, so no winner-table pre-filter applies). Bounded by
+/// [`ConvertOptions::coalesce_max_level_rows`]; beyond it coalescing is
+/// skipped and this scratch is never built.
+struct CoalesceScratch {
+    /// Source row index per collected line, ascending input order.
+    rows: Vec<usize>,
+    /// The lines' decoded geometries, parallel to `rows`.
+    geoms: Vec<Geometry<f64>>,
+    /// Sort key per line (Q1 ranking), parallel to `rows`; filled after the
+    /// ranking tier resolves.
+    sort_keys: Vec<Option<f64>>,
+    /// Interned class group per line, parallel to `rows`; `None` = no class
+    /// ranking active (all lines compatible).
+    groups: Option<Vec<u32>>,
+}
+
+impl CoalesceScratch {
+    /// The per-level chaining inputs (borrowing the collected geometries).
+    fn inputs(&self) -> Vec<CoalesceInput<'_>> {
+        (0..self.rows.len())
+            .map(|i| CoalesceInput {
+                index: self.rows[i],
+                geom: &self.geoms[i],
+                sort_key: self.sort_keys[i],
+                group: self.groups.as_ref().map_or(0, |g| g[i]),
+            })
+            .collect()
+    }
+}
+
+/// Result of [`run_pass1`].
+struct Pass1Output {
+    /// Per-feature assignment inputs (bbox, kind, resolved sort key).
+    features: Vec<AssignFeature>,
+    /// Resolved ranking provenance (§3.5).
+    provenance: RankingProvenance,
+    /// Per-accumulate-spec source values (Q4), parallel to `acc_cols`.
+    acc_values: Vec<Vec<Option<f64>>>,
+    /// Line geometries + groups for coalescing (Q3); `None` unless enabled.
+    coalesce: Option<CoalesceScratch>,
+}
 
 /// Pass 1: stream the input (geometry + ranking/accumulate columns only) and
 /// produce the per-feature [`AssignFeature`]s (with resolved sort keys), the
@@ -509,6 +624,13 @@ fn run_pass1(
     let mut confidence_keys: Vec<Option<f64>> = Vec::new();
     let mut acc_values: Vec<Vec<Option<f64>>> = vec![Vec::new(); acc_cols.len()];
     let mut geoms_buf: Vec<Geometry<f64>> = Vec::new();
+    // Coalescing (Q3): line rows + geometries, and — for an explicit class
+    // ranking — the interned per-row class groups.
+    let collect_lines = options.coalesce_lines;
+    let mut line_rows: Vec<usize> = Vec::new();
+    let mut line_geoms: Vec<Geometry<f64>> = Vec::new();
+    let mut explicit_groups: Vec<u32> = Vec::new();
+    let mut explicit_interner = GroupInterner::default();
 
     for batch in reader {
         let batch = batch?;
@@ -526,6 +648,10 @@ fn run_pass1(
             if matches!(kind, FeatureKind::Point) {
                 point_count += 1;
             }
+            if collect_lines && matches!(kind, FeatureKind::Line) {
+                line_rows.push(base + i);
+                line_geoms.push(g.clone());
+            }
             features.push(AssignFeature {
                 index: base + i,
                 bbox: geometry_bbox(g),
@@ -539,10 +665,11 @@ fn run_pass1(
                 explicit_keys.extend(extract_sort_keys(batch.column(proj(*idx)).as_ref()));
             }
             RankPlan::ExplicitClass { idx, ranking } => {
-                explicit_keys.extend(extract_class_ranks(
-                    batch.column(proj(*idx)).as_ref(),
-                    ranking,
-                )?);
+                let col = batch.column(proj(*idx));
+                explicit_keys.extend(extract_class_ranks(col.as_ref(), ranking)?);
+                if collect_lines {
+                    explicit_interner.extend(col.as_ref(), &mut explicit_groups);
+                }
             }
             RankPlan::Auto { roads, confidence } => {
                 for cand in roads.iter_mut() {
@@ -550,6 +677,9 @@ fn run_pass1(
                     scan_road_vocab(col.as_ref(), &mut cand.found);
                     cand.keys
                         .extend(extract_class_ranks(col.as_ref(), &cand.ranking)?);
+                    if collect_lines {
+                        cand.interner.extend(col.as_ref(), &mut cand.groups);
+                    }
                 }
                 if let Some((idx, _)) = confidence {
                     confidence_keys.extend(extract_sort_keys(batch.column(proj(*idx)).as_ref()));
@@ -578,8 +708,15 @@ fn run_pass1(
         }
     };
 
-    // Resolve the tier (same order + logging as the in-memory path).
-    let (keys, provenance): (Option<Vec<Option<f64>>>, RankingProvenance) = match plan {
+    // Resolve the tier (same order + logging as the in-memory path). The
+    // third element is the all-row class-group vector for coalescing, present
+    // only for the class-based tiers (matches `coalesce_group_column`).
+    type Resolved = (
+        Option<Vec<Option<f64>>>,
+        RankingProvenance,
+        Option<Vec<u32>>,
+    );
+    let (keys, provenance, all_groups): Resolved = match plan {
         RankPlan::ExplicitSort { name, .. } => {
             log::info!("overview ranking: explicit numeric sort-key column {name:?}");
             (
@@ -590,6 +727,7 @@ fn run_pass1(
                     ranks: None,
                     unknown_rank: None,
                 },
+                None,
             )
         }
         RankPlan::ExplicitClass { ranking, .. } => {
@@ -602,6 +740,7 @@ fn run_pass1(
             (
                 Some(explicit_keys),
                 class_ranking_provenance("class-ranking", &ranking),
+                collect_lines.then_some(explicit_groups),
             )
         }
         RankPlan::Auto { roads, confidence } => {
@@ -615,7 +754,7 @@ fn run_pass1(
                     cand.ranking.column
                 );
                 let prov = class_ranking_provenance("auto-overture-roads", &cand.ranking);
-                (Some(cand.keys), prov)
+                (Some(cand.keys), prov, collect_lines.then_some(cand.groups))
             } else if let Some((_, col_name)) = confidence.filter(|_| n > 0 && point_count * 2 >= n)
             {
                 log::info!(
@@ -630,12 +769,13 @@ fn run_pass1(
                         ranks: None,
                         unknown_rank: None,
                     },
+                    None,
                 )
             } else {
-                (None, size_fallback())
+                (None, size_fallback(), None)
             }
         }
-        RankPlan::SizeFallback => (None, size_fallback()),
+        RankPlan::SizeFallback => (None, size_fallback(), None),
     };
 
     if let Some(keys) = keys {
@@ -645,7 +785,20 @@ fn run_pass1(
         }
     }
 
-    Ok((features, provenance, acc_values))
+    // Coalescing scratch (Q3): line sort keys + per-line groups.
+    let coalesce = collect_lines.then(|| CoalesceScratch {
+        sort_keys: line_rows.iter().map(|&r| features[r].sort_key).collect(),
+        groups: all_groups.map(|g| line_rows.iter().map(|&r| g[r]).collect()),
+        rows: line_rows,
+        geoms: line_geoms,
+    });
+
+    Ok(Pass1Output {
+        features,
+        provenance,
+        acc_values,
+        coalesce,
+    })
 }
 
 // ============================================================================
@@ -674,8 +827,11 @@ impl Pass2Timers {
 /// Immutable context for one level's pass-2 stream.
 struct LevelStreamCtx<'a> {
     source_schema: &'a Schema,
-    /// Output schema: `source_schema` + trailing `point_count` when
-    /// clustering, otherwise identical.
+    /// `source_schema` + trailing `point_count` when clustering, otherwise
+    /// identical (the schema [`apply_cluster_columns`] produces).
+    cluster_schema: &'a Schema,
+    /// Final writer schema: `cluster_schema` + trailing `coalesced_count`
+    /// when coalescing, otherwise identical.
     out_schema: &'a Schema,
     non_geom_cols: &'a [usize],
     geom_idx: usize,
@@ -696,6 +852,15 @@ struct LevelStreamCtx<'a> {
     cluster_table: Option<&'a std::collections::HashMap<usize, ClusterEntry>>,
     /// Schema indices of the accumulate columns.
     acc_cols: &'a [usize],
+    /// Coalescing (Q3): append `coalesced_count` at every level.
+    coalesce_enabled: bool,
+    /// Per-row geometry kinds (line rows bypass the winner table at
+    /// coalesced levels); `Some` iff coalescing is enabled.
+    kinds: Option<&'a [FeatureKind]>,
+    /// This level's chain table (rep row → merged simplified geometry +
+    /// member count); `None` at verbatim levels or when coalescing is
+    /// off/guard-skipped.
+    coalesce_table: Option<&'a CoalesceTable>,
 }
 
 /// Stream one level from the input file into the writer. Returns
@@ -794,7 +959,15 @@ fn process_level_batch(
     let t_decode = Instant::now();
     let selected: Vec<usize> = (0..n)
         .filter(|&i| {
-            let ml = ctx.min_levels[row_offset + i];
+            let g = row_offset + i;
+            // Coalesced level: line rows bypass the winner table entirely —
+            // only surviving chain reps are emitted (with merged geometry).
+            if let Some(table) = ctx.coalesce_table {
+                if ctx.kinds.expect("kinds present when coalescing")[g] == FeatureKind::Line {
+                    return table.contains_key(&g);
+                }
+            }
+            let ml = ctx.min_levels[g];
             if ctx.duplicating {
                 ml <= ctx.orig_level
             } else {
@@ -834,9 +1007,20 @@ fn process_level_batch(
         // preserves within-batch order, so the output stays byte-identical to
         // the serial path; the writer (our single caller) remains
         // single-threaded, and memory stays bounded by one read batch.
+        // Chain reps substitute their merged, already-simplified geometry
+        // (simplified once in `build_level_coalesce_table`, identically to
+        // the in-memory path).
         let simplified: Vec<Simplified> = geoms
             .par_iter()
-            .map(|g| simplify_for_level(g, ctx.gsd_m, ctx.crs, ctx.simplify))
+            .zip(&selected)
+            .map(|(g, &i)| {
+                if let Some((merged, _)) = ctx.coalesce_table.and_then(|t| t.get(&(row_offset + i)))
+                {
+                    Simplified::Keep(merged.clone())
+                } else {
+                    simplify_for_level(g, ctx.gsd_m, ctx.crs, ctx.simplify)
+                }
+            })
             .collect();
         let mut out = Vec::with_capacity(selected.len());
         for (s, &i) in simplified.into_iter().zip(&selected) {
@@ -866,16 +1050,23 @@ fn process_level_batch(
         &kept_idx,
         &kept_geoms,
     )?;
-    if ctx.cluster_enabled {
-        // Cluster-table keys are global row indices; kept_idx is batch-local.
+    if ctx.cluster_enabled || ctx.coalesce_enabled {
+        // Cluster/coalesce-table keys are global row indices; kept_idx is
+        // batch-local.
         let globals: Vec<usize> = kept_idx.iter().map(|&i| row_offset + i).collect();
-        out_batch = apply_cluster_columns(
-            out_batch,
-            ctx.out_schema,
-            &globals,
-            ctx.cluster_table,
-            ctx.acc_cols,
-        )?;
+        if ctx.cluster_enabled {
+            out_batch = apply_cluster_columns(
+                out_batch,
+                ctx.cluster_schema,
+                &globals,
+                ctx.cluster_table,
+                ctx.acc_cols,
+            )?;
+        }
+        if ctx.coalesce_enabled {
+            out_batch =
+                apply_coalesced_count(out_batch, ctx.out_schema, &globals, ctx.coalesce_table)?;
+        }
     }
     Pass2Timers::add(&timers.build, t_build);
     Ok(Some((out_batch, verts)))

--- a/docs/OVERVIEW_TUNING.md
+++ b/docs/OVERVIEW_TUNING.md
@@ -335,6 +335,87 @@ exists as INT64 NOT NULL and that canonical-level values are all 1.
 
 ---
 
+## Line coalescing: `--coalesce-lines`, `--coalesce-snap`, `--coalesce-max-level-rows`
+
+At coarse levels a line network (roads, rivers) can degrade into scattered
+dashes: a segment whose bbox diagonal is below the visibility gate
+(`--line-visibility × gsd`) is dropped outright, and cell-winner thinning
+keeps disconnected fragments of what remains. Selection is smart;
+*continuity* is destroyed.
+
+**`--coalesce-lines`** (opt-in, duplicating mode only) chains touching
+compatible segments into single "stroke" LineStrings at each non-canonical
+level, **before** the gate and thinning run:
+
+- A chain of individually sub-visibility segments survives as **one long
+  visible artery** — the gate evaluates the chain's extent, not each
+  fragment's. This ordering is the entire payoff.
+- Chains never merge **across class values** (when a class ranking is
+  active — explicit `--class-rank` or auto-detected Overture
+  `class`/`road_class`) and never merge **through junctions** where 3+
+  compatible endpoints meet (degree-2 nodes only; network topology is
+  preserved). With no class ranking, all lines are compatible.
+- The merged feature keeps the **attributes of its highest-priority
+  member** (same class-rank → size → hash order as the cell-winner stage)
+  and the output gains a **`coalesced_count`** INT32 NOT NULL column
+  (source segments merged per row; 1 for unmerged rows and everywhere at
+  the canonical level, which is never coalesced).
+- Points and polygons are untouched. MultiLineString rows pass through
+  unmerged.
+
+```bash
+gpq-tiles overview roads.parquet roads_overview.parquet \
+  --min-zoom 0 --max-zoom 14 \
+  --coalesce-lines        # auto class ranking groups by road class
+```
+
+### `--coalesce-snap` (default 1.0, GSD multiples)
+
+Exactly-touching endpoints always chain (Overture/OSM segments share exact
+node coordinates). The snap pass additionally joins chain ends within
+`factor × gsd` of each other — two endpoints closer than one ground sample
+are indistinguishable at that level. BIGGER bridges larger digitization
+gaps but risks fusing the ends of nearby parallel lines; `0` disables the
+snap pass (exact matches only).
+
+### `--coalesce-max-level-rows` (default 2,000,000): memory guard
+
+Chaining needs a level's candidate line geometries in memory at once, and
+the candidate set at every non-canonical level is **all** lines (dropped
+fragments must be reclaimable, so no winner-table pre-filter applies).
+Datasets with more lines than this ceiling skip coalescing with a warning
+— the file still carries the `coalesced_count` column (all 1) and the
+provenance block, so the schema is stable. Levels that large are
+near-canonical anyway, where segments are individually visible and
+coalescing matters least. This is the streaming pipeline's one deliberate
+`O(lines)` residual allocation.
+
+### Interactions
+
+- **`--line-visibility` / `--line-thinning`** now act on *chains*: the
+  gate tests the merged extent, and one **chain** (not one segment)
+  survives per thinning cell. Expect coarse levels to show **fewer rows
+  but much more retained line length** than a non-coalesced run.
+- **Class ranking** does double duty: it both prioritizes which chain wins
+  a cell and defines the compatibility groups. `--no-auto-rank` (or a
+  numeric `--sort-key`) makes all lines compatible — fine for
+  single-class datasets (rivers), usually wrong for mixed road networks.
+- **Density budget (Q2)**: line rows leave the winner table at coalesced
+  levels, so the drop-rate budget does not apply to them there (chaining
+  already collapses line counts far harder); points and polygons keep the
+  budget as usual.
+- **Partitioning mode is rejected.** Partitioning places each feature
+  exactly once with geometry verbatim; a merged chain is a new geometry
+  replacing several source rows, which that contract cannot represent.
+
+Coalescing is recorded in the footer `geo:overviews` →
+`generalization.coalescing` provenance (`enabled`,
+`snap_tolerance_gsd_factor`, `coalesced_count_column`); `gpq-tiles
+validate` checks that the column exists as INT32 NOT NULL, all values are
+>= 1, and canonical-level values are all 1.
+
+---
+
 ## File layout knobs: `--row-group-size`, `--full-column-stats`
 
 These do not change *which* features or vertices survive — geometry and

--- a/docs/OVERVIEW_TUNING.md
+++ b/docs/OVERVIEW_TUNING.md
@@ -335,7 +335,7 @@ exists as INT64 NOT NULL and that canonical-level values are all 1.
 
 ---
 
-## Line coalescing: `--coalesce-lines`, `--coalesce-snap`, `--coalesce-max-level-rows`
+## Line coalescing: `--no-coalesce-lines`, `--coalesce-junction-angle`, `--coalesce-snap`, `--coalesce-max-level-rows`
 
 At coarse levels a line network (roads, rivers) can degrade into scattered
 dashes: a segment whose bbox diagonal is below the visibility gate
@@ -343,18 +343,23 @@ dashes: a segment whose bbox diagonal is below the visibility gate
 keeps disconnected fragments of what remains. Selection is smart;
 *continuity* is destroyed.
 
-**`--coalesce-lines`** (opt-in, duplicating mode only) chains touching
-compatible segments into single "stroke" LineStrings at each non-canonical
-level, **before** the gate and thinning run:
+Line coalescing is therefore **ON by default** (maintainer render review
+2026-07-03 — like `--line-thinning 1.0` and the clustered point grid,
+defaults should look right; pass **`--no-coalesce-lines`** to opt out). It
+chains touching compatible segments into single "stroke" LineStrings at
+each non-canonical duplicating level, **before** the gate and thinning
+run:
 
 - A chain of individually sub-visibility segments survives as **one long
   visible artery** — the gate evaluates the chain's extent, not each
   fragment's. This ordering is the entire payoff.
 - Chains never merge **across class values** (when a class ranking is
   active — explicit `--class-rank` or auto-detected Overture
-  `class`/`road_class`) and never merge **through junctions** where 3+
-  compatible endpoints meet (degree-2 nodes only; network topology is
-  preserved). With no class ranking, all lines are compatible.
+  `class`/`road_class`). With no class ranking, all lines are compatible.
+- At **junctions** (3+ compatible endpoints meeting), chains continue only
+  through the pair of lines that best continue each other within
+  `--coalesce-junction-angle` of straight (see below); everything else
+  terminates there, preserving network topology.
 - The merged feature keeps the **attributes of its highest-priority
   member** (same class-rank → size → hash order as the cell-winner stage)
   and the output gains a **`coalesced_count`** INT32 NOT NULL column
@@ -364,10 +369,27 @@ level, **before** the gate and thinning run:
   unmerged.
 
 ```bash
+# Coalescing is on by default (auto class ranking groups by road class):
 gpq-tiles overview roads.parquet roads_overview.parquet \
-  --min-zoom 0 --max-zoom 14 \
-  --coalesce-lines        # auto class ranking groups by road class
+  --min-zoom 0 --max-zoom 14
+
+# Opt out (pre-Q3 behavior, no coalesced_count column):
+gpq-tiles overview roads.parquet roads_overview.parquet \
+  --min-zoom 0 --max-zoom 14 --no-coalesce-lines
 ```
+
+### `--coalesce-junction-angle` (default 30, degrees)
+
+Chains would otherwise break at every same-class crossing — on a road
+network that is almost every block, so strokes stay short exactly where
+the maintainer wants long arteries. At each junction the best-continuing
+pair of lines merges when its deviation from a straight continuation is
+at most this angle, best pair first (a 4-way crossing continues **both**
+through-streets). BIGGER = chains bend further through junctions (fewer,
+longer strokes; a genuine turn may get absorbed); `0` = never merge
+through junctions (strict degree-2 chaining, the original Q3 behavior).
+The Portland sweep for picking the default lives at
+`corpus/data/bench/q3/portland-roads-junction{00,30,60}.pmtiles`.
 
 ### `--coalesce-snap` (default 1.0, GSD multiples)
 
@@ -400,13 +422,20 @@ coalescing matters least. This is the streaming pipeline's one deliberate
   a cell and defines the compatibility groups. `--no-auto-rank` (or a
   numeric `--sort-key`) makes all lines compatible — fine for
   single-class datasets (rivers), usually wrong for mixed road networks.
-- **Density budget (Q2)**: line rows leave the winner table at coalesced
-  levels, so the drop-rate budget does not apply to them there (chaining
-  already collapses line counts far harder); points and polygons keep the
-  budget as usual.
-- **Partitioning mode is rejected.** Partitioning places each feature
-  exactly once with geometry verbatim; a merged chain is a new geometry
-  replacing several source rows, which that contract cannot represent.
+- **Density budget (Q2)** applies to **chains**: after gate + thinning,
+  each level keeps at most `num_lines / drop_rate^(finest − level)` chains
+  (same geometric ladder, floor, and spatial-fairness gamma as the
+  point/polygon budget), cutting the lowest-priority chains first. Without
+  this the reclaimed fragments would re-inflate exactly the mid-zoom
+  counts the budget was calibrated to cap. `--no-density-drop` disables
+  the chain budget too. Points and polygons keep the row-level budget as
+  usual.
+- **Partitioning mode: inert.** Partitioning places each feature exactly
+  once with geometry verbatim; a merged chain is a new geometry replacing
+  several source rows, which that contract cannot represent. Since
+  coalescing is on by default, partitioning conversions simply proceed
+  without it (no `coalesced_count` column, no provenance, info log); an
+  explicit `--coalesce-lines` with `--mode partitioning` is rejected.
 
 Coalescing is recorded in the footer `geo:overviews` →
 `generalization.coalescing` provenance (`enabled`,

--- a/docs/OVERVIEW_TUNING.md
+++ b/docs/OVERVIEW_TUNING.md
@@ -356,10 +356,9 @@ run:
 - Chains never merge **across class values** (when a class ranking is
   active — explicit `--class-rank` or auto-detected Overture
   `class`/`road_class`). With no class ranking, all lines are compatible.
-- At **junctions** (3+ compatible endpoints meeting), chains continue only
-  through the pair of lines that best continue each other within
-  `--coalesce-junction-angle` of straight (see below); everything else
-  terminates there, preserving network topology.
+- **Junctions** (3+ compatible endpoints meeting) terminate chains by
+  default, preserving network topology. `--coalesce-junction-angle` (see
+  below) can optionally continue the best-aligned pair through them.
 - The merged feature keeps the **attributes of its highest-priority
   member** (same class-rank → size → hash order as the cell-winner stage)
   and the output gains a **`coalesced_count`** INT32 NOT NULL column
@@ -378,18 +377,18 @@ gpq-tiles overview roads.parquet roads_overview.parquet \
   --min-zoom 0 --max-zoom 14 --no-coalesce-lines
 ```
 
-### `--coalesce-junction-angle` (default 30, degrees)
+### `--coalesce-junction-angle` (default 0 = off, degrees)
 
-Chains would otherwise break at every same-class crossing — on a road
-network that is almost every block, so strokes stay short exactly where
-the maintainer wants long arteries. At each junction the best-continuing
-pair of lines merges when its deviation from a straight continuation is
-at most this angle, best pair first (a 4-way crossing continues **both**
-through-streets). BIGGER = chains bend further through junctions (fewer,
-longer strokes; a genuine turn may get absorbed); `0` = never merge
-through junctions (strict degree-2 chaining, the original Q3 behavior).
-The Portland sweep for picking the default lives at
-`corpus/data/bench/q3/portland-roads-junction{00,30,60}.pmtiles`.
+By default chains stop at junctions (strict degree-2 chaining) — the
+Portland sweep (`corpus/data/bench/q3/portland-roads-junction{00,30}.pmtiles`,
+maintainer review 2026-07-03) found this renders better than junction
+continuation, which over-merges. Set an angle to opt in: at each junction
+the best-continuing pair of lines merges when its deviation from a
+straight continuation is at most this angle, best pair first (a 4-way
+crossing continues **both** through-streets). BIGGER = chains bend
+further through junctions (fewer, longer strokes; z0–z1 gain giant
+arterial strokes on Portland at 30°) at the cost of merging through
+genuine turns and smearing attributes across crossings.
 
 ### `--coalesce-snap` (default 1.0, GSD multiples)
 


### PR DESCRIPTION
## Summary

Q3, the last quality-ladder item: at coarse overview levels, connected same-class line segments are **chained into strokes before visibility/thinning**, so road/river networks read as continuous arteries instead of scattered dashes. A chain of individually sub-visibility fragments survives as one long visible feature — the ordering is the entire payoff.

**On by default** (`--no-coalesce-lines` to opt out), per maintainer render review — completing the defaults trilogy (lt=1, pt=16-with-cluster, coalesce-on/junction-off), all chosen by the same sweep ritual on real data.

## Design

- **Two-phase chaining** (`overview/coalesce.rs`): exact endpoint matching first (essential — at coarse GSDs segments are shorter than the snap tolerance and one-phase snapping collapses them), then a snap pass over chain free-ends quantized to `--coalesce-snap` × GSD cells (default 1.0; 0 = exact-only). Deterministic, O(n).
- **Junctions terminate chains by default** (degree-2 nodes only merge). Angle-bounded continuation exists behind `--coalesce-junction-angle` (default 0/off) — maintainer sweep found strict degree-2 renders better; 30° is the documented opt-in for arteries-at-z0 use cases.
- **Q2 density budget applies to chains** — without it, mid-zoom counts inflated 3× over the calibrated baseline (caught on real data, fixed).
- **Attributes**: merged row = highest-priority member (same Q1 priority order); grouping by the active class-ranking column (explicit or auto-Overture); `coalesced_count` INT32 NOT NULL mirrors `point_count` (validator-enforced: ≥1 everywhere, all-1 at canonical).
- **Canonical level never coalesced** (§2.4 fidelity). **Partitioning: no sound construction** — merged chains violate feature-once/geometry-verbatim (spec §13.5: MUST NOT); default-on is inert there, explicit request errors.
- Footer provenance `generalization.coalescing{...}`; spec §13 (v0.2.0-draft); tuning-guide section; streaming path byte-equivalent to in-memory (tested).

## Portland roads (295,881 Overture segments, z0–z14, auto class ranking)

| level/zoom | rows | retained length vs base | source segments represented |
|---|---|---|---|
| 0 / z2 | 7 | **1.54×** | 16 |
| 2 / z4 | 138 | **2.20×** | 1,588 |
| 4 / z6 | 1,756 | **1.88×** | 11,856 |
| 6 / z8 | 14,663 (= base, budget-capped) | 1.15× | 38,084 |
| 12 / z14 | 295,881 | 1.00 (verbatim) | all |

Coarse levels carry ~2× the network length; mid zooms stay budget-identical to baseline; canonical byte-verbatim. Both exports: 0 oversized tiles; validator 12/12. Streaming Portland: 15.7 s / 379 MB RSS (one documented O(lines) residual, bounded by `--coalesce-max-level-rows`, default 2M).

Comparison artifacts for review: `corpus/data/bench/q3/portland-roads-{base,coalesced,junction30}.pmtiles`.

## Divergences (documented in module header + spec)

Tippecanoe's `--coalesce` merges consecutive same-attribute features without topology; our endpoint chaining through degree-2 nodes matches planetiler's `mergeLineStrings` stroke-building while keeping tippecanoe's philosophy (never across class boundaries, junctions preserved, deterministic). Chain density budget is the Q2 analog of tippecanoe's drop-rate applied to strokes.

## Tests

185 `overview::` tests green (23 coalesce unit incl. junction/budget cases, 8 convert integration, 3 streaming-equivalence with coalescing, 5 validator, 1 provenance roundtrip). fmt + clippy `-D warnings` clean per commit. Two real bugs found and fixed during real-data verification: a quadratic `Vec::remove` in chain thinning (minutes → 16 s on Portland) and the mid-zoom budget bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)