### PR TITLE
fix(core): hostile-input hardening for the overview pipeline (H4)

### DIFF
--- a/crates/core/src/batch_processor.rs
+++ b/crates/core/src/batch_processor.rs
@@ -518,9 +518,31 @@ where
 }
 
 /// Extract geometries from a GeoArrow array into a Vec.
+///
+/// Null slots and slots that cannot convert to a `geo::Geometry` are
+/// **silently skipped**, so `output` may end up shorter than the array.
+/// Callers that must keep row indices aligned with other columns should use
+/// [`extract_geometries_opt_from_array`] instead.
 pub fn extract_geometries_from_array(
     array: &dyn GeoArrowArray,
     output: &mut Vec<Geometry<f64>>,
+) -> Result<()> {
+    let mut opts: Vec<Option<Geometry<f64>>> = Vec::with_capacity(array.len());
+    extract_geometries_opt_from_array(array, &mut opts)?;
+    output.extend(opts.into_iter().flatten());
+    Ok(())
+}
+
+/// Extract geometries from a GeoArrow array into a **row-aligned** Vec of
+/// `Option`s: exactly one entry per array slot, `None` for null slots (and
+/// for the rare slot that decodes but has no `geo::Geometry` conversion).
+///
+/// Structurally invalid geometry payloads (e.g. an empty or corrupt WKB
+/// value) still return a hard [`Error::GeoParquetRead`]; only *absent*
+/// geometry maps to `None`.
+pub fn extract_geometries_opt_from_array(
+    array: &dyn GeoArrowArray,
+    output: &mut Vec<Option<Geometry<f64>>>,
 ) -> Result<()> {
     match array.data_type() {
         GeoArrowType::Point(_) => {
@@ -586,21 +608,25 @@ pub fn extract_geometries_from_array(
     }
 }
 
-/// Extract geometries from a typed GeoArrow array into a Vec.
-fn extract_typed_array<'a, A>(accessor: &'a A, output: &mut Vec<Geometry<f64>>) -> Result<()>
+/// Extract geometries from a typed GeoArrow array into a row-aligned Vec of
+/// `Option`s (one entry per slot; see [`extract_geometries_opt_from_array`]).
+fn extract_typed_array<'a, A>(
+    accessor: &'a A,
+    output: &mut Vec<Option<Geometry<f64>>>,
+) -> Result<()>
 where
     A: GeoArrowArrayAccessor<'a>,
     A::Item: ToGeoGeometry<f64>,
 {
     for (i, item) in accessor.iter().enumerate() {
-        if let Some(geom_result) = item {
-            let geom_trait = geom_result.map_err(|e| {
-                Error::GeoParquetRead(format!("Invalid geometry at index {}: {}", i, e))
-            })?;
-
-            if let Some(geo_geom) = geom_trait.try_to_geometry() {
-                output.push(geo_geom);
+        match item {
+            Some(geom_result) => {
+                let geom_trait = geom_result.map_err(|e| {
+                    Error::GeoParquetRead(format!("Invalid geometry at index {}: {}", i, e))
+                })?;
+                output.push(geom_trait.try_to_geometry());
             }
+            None => output.push(None),
         }
     }
     Ok(())

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -537,11 +537,57 @@ pub enum ConvertError {
 ///
 /// See the module documentation for the pipeline. Returns a [`ConvertReport`]
 /// describing the levels written.
+/// Validate the numeric conversion knobs (H4 hostile-input hardening).
+///
+/// A NaN, infinite, or non-positive thinning factor (or GSD base) silently
+/// degenerates the assignment grid — every cell-winner pass would skip every
+/// feature — so nonsensical values are rejected up front with a clear error
+/// instead of producing an "everything at the canonical level" file.
+fn validate_options(options: &ConvertOptions) -> Result<(), ConvertError> {
+    let positive = |name: &str, v: f64| {
+        if !v.is_finite() || v <= 0.0 {
+            return Err(ConvertError::InvalidConfig(format!(
+                "{name} = {v} must be a finite value > 0"
+            )));
+        }
+        Ok(())
+    };
+    let non_negative = |name: &str, v: f64| {
+        if !v.is_finite() || v < 0.0 {
+            return Err(ConvertError::InvalidConfig(format!(
+                "{name} = {v} must be a finite value >= 0"
+            )));
+        }
+        Ok(())
+    };
+    positive("gsd-base", options.gsd_base)?;
+    positive("point-thinning", options.assign.point_thinning)?;
+    positive("line-thinning", options.assign.line_thinning)?;
+    positive("polygon-thinning", options.assign.polygon_thinning)?;
+    non_negative("line-visibility", options.assign.line_visibility)?;
+    non_negative("polygon-visibility", options.assign.polygon_visibility)?;
+    // Negative snap / junction-angle values are documented OFF switches; only
+    // NaN is meaningless.
+    if options.coalesce_snap.is_nan() {
+        return Err(ConvertError::InvalidConfig(
+            "coalesce-snap must not be NaN (use <= 0 to disable snapping)".to_string(),
+        ));
+    }
+    if options.coalesce_junction_angle.is_nan() {
+        return Err(ConvertError::InvalidConfig(
+            "coalesce-junction-angle must not be NaN (use 0 to disable)".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 pub fn convert_to_overviews(
     input_path: impl AsRef<Path>,
     output_path: impl AsRef<Path>,
     options: &ConvertOptions,
 ) -> Result<ConvertReport, ConvertError> {
+    // Knob sanity (H4), shared by both pipelines.
+    validate_options(options)?;
     // Clustering option sanity (Q4), shared by both pipelines: partitioning
     // mode cannot represent per-level counts (see the error's rationale), and
     // aggregation is meaningless without clustering.

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -46,7 +46,7 @@ use geoarrow_array::GeoArrowArray;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use serde::Serialize;
 
-use crate::batch_processor::extract_geometries_from_array;
+use crate::batch_processor::extract_geometries_opt_from_array;
 
 use super::assign::{
     apply_density_budget, assign_levels, AssignConfig, AssignFeature, DensityBudgetConfig,
@@ -80,6 +80,12 @@ pub enum LevelPlan {
     Gsds(Vec<f64>),
 }
 
+/// Maximum number of levels a plan may resolve to. The per-feature winner
+/// tables store level indices as `u8` (with `u8::MAX` reserved as the
+/// streaming pipeline's "no feature on this row" sentinel), so plans beyond
+/// 255 levels are rejected instead of silently wrapping.
+pub(super) const MAX_LEVELS: usize = 255;
+
 impl LevelPlan {
     /// Resolve to the coarse→fine list of `(gsd_meters, zoom?)` level specs.
     ///
@@ -88,6 +94,14 @@ impl LevelPlan {
     /// effect on an explicit [`Gsds`](LevelPlan::Gsds) plan (those GSDs are
     /// already in meters).
     pub(super) fn resolve(&self, gsd_base: f64) -> Result<Vec<(f64, Option<u8>)>, ConvertError> {
+        let check_len = |n: usize| {
+            if n > MAX_LEVELS {
+                return Err(ConvertError::InvalidLevels(format!(
+                    "{n} levels requested; at most {MAX_LEVELS} levels are supported"
+                )));
+            }
+            Ok(())
+        };
         match self {
             LevelPlan::ZoomRange { min_zoom, max_zoom } => {
                 if min_zoom > max_zoom {
@@ -95,6 +109,7 @@ impl LevelPlan {
                         "min_zoom {min_zoom} must be <= max_zoom {max_zoom}"
                     )));
                 }
+                check_len(*max_zoom as usize - *min_zoom as usize + 1)?;
                 Ok((*min_zoom..=*max_zoom)
                     .map(|z| (gsd_with_base(z, gsd_base), Some(z)))
                     .collect())
@@ -105,6 +120,7 @@ impl LevelPlan {
                         "explicit gsd list must be non-empty".to_string(),
                     ));
                 }
+                check_len(gsds.len())?;
                 let mut prev: Option<f64> = None;
                 for (i, &g) in gsds.iter().enumerate() {
                     if g <= 0.0 || g.is_nan() {
@@ -463,6 +479,10 @@ pub enum ConvertError {
     /// The level plan is invalid (empty / non-monotonic / bad zoom range).
     #[error("invalid level specification: {0}")]
     InvalidLevels(String),
+    /// A conversion knob carries a nonsensical value (non-finite or
+    /// non-positive where a positive finite value is required).
+    #[error("invalid option: {0}")]
+    InvalidConfig(String),
     /// `--cluster` was requested in partitioning mode. A partitioning row is
     /// read at MANY display zooms (prefix reads, §2.3) but exists at exactly
     /// one level, so a single stored `point_count` cannot reflect "that
@@ -608,14 +628,41 @@ pub fn convert_to_overviews(
         batches.push(batch?);
     }
     let full = concat_batches(&input_schema, &batches)?;
-    let num_features = full.num_rows();
 
-    // Decode geometries once (in-memory v1).
+    // Decode geometries once (in-memory v1), row-aligned. Rows with a null,
+    // empty, or non-finite geometry cannot participate in level assignment:
+    // they are dropped HERE, from the batch and the geometry vec together, so
+    // every downstream index stays aligned (H4: an interleaved null geometry
+    // must never shift attributes onto a neighboring row's geometry).
     let geom_array: Arc<dyn GeoArrowArray> =
         from_arrow_array(full.column(geom_idx).as_ref(), &geom_field)
             .map_err(|e| crate::Error::GeoParquetRead(format!("geometry decode: {e}")))?;
-    let mut geometries: Vec<Geometry<f64>> = Vec::with_capacity(num_features);
-    extract_geometries_from_array(geom_array.as_ref(), &mut geometries)?;
+    let mut geom_opts: Vec<Option<Geometry<f64>>> = Vec::with_capacity(full.num_rows());
+    extract_geometries_opt_from_array(geom_array.as_ref(), &mut geom_opts)?;
+    let keep: Vec<bool> = geom_opts
+        .iter()
+        .map(|g| g.as_ref().is_some_and(usable_geometry))
+        .collect();
+    let skipped = keep.iter().filter(|k| !**k).count();
+    let (full, geometries): (RecordBatch, Vec<Geometry<f64>>) = if skipped > 0 {
+        log::warn!(
+            "skipping {skipped} of {} input rows with a null, empty, or \
+             non-finite geometry",
+            full.num_rows()
+        );
+        let mask = arrow_array::BooleanArray::from(keep.clone());
+        let filtered = arrow_select::filter::filter_record_batch(&full, &mask)?;
+        let geoms = geom_opts
+            .into_iter()
+            .zip(&keep)
+            .filter(|(_, k)| **k)
+            .map(|(g, _)| g.expect("kept rows are Some"))
+            .collect();
+        (filtered, geoms)
+    } else {
+        (full, geom_opts.into_iter().flatten().collect())
+    };
+    let num_features = full.num_rows();
 
     // Resolve the cell-winner ranking (Q1): explicit sort key / explicit class
     // ranking / auto-detected well-known schema / size fallback. Returns the
@@ -944,6 +991,25 @@ pub(super) fn geometry_bbox(g: &Geometry<f64>) -> [f64; 4] {
         Some(r) => [r.min().x, r.min().y, r.max().x, r.max().y],
         None => [0.0, 0.0, 0.0, 0.0],
     }
+}
+
+/// Whether a decoded geometry can participate in level assignment: it must
+/// carry at least one coordinate and every coordinate must be finite.
+///
+/// Rows failing this check (alongside null-geometry rows) are **skipped with
+/// a warning** rather than converted: an empty geometry has no location to
+/// thin against, and a NaN/infinite coordinate would silently collapse into
+/// grid cell `(0, 0)` (H4 hostile-input hardening).
+pub(super) fn usable_geometry(g: &Geometry<f64>) -> bool {
+    use geo::coords_iter::CoordsIter;
+    let mut any = false;
+    for c in g.coords_iter() {
+        if !c.x.is_finite() || !c.y.is_finite() {
+            return false;
+        }
+        any = true;
+    }
+    any
 }
 
 /// Map a geometry to the [`FeatureKind`] used for thinning / visibility.
@@ -1810,6 +1876,8 @@ mod tests {
         GeoParquetRecordBatchEncoder, GeoParquetWriterEncoding, GeoParquetWriterOptionsBuilder,
     };
     use parquet::arrow::ArrowWriter;
+
+    use crate::batch_processor::extract_geometries_from_array;
 
     // --- synthetic GeoParquet input builders --------------------------------
 

--- a/crates/core/src/overview/hostile.rs
+++ b/crates/core/src/overview/hostile.rs
@@ -1,0 +1,891 @@
+//! Hostile-input hardening tests for the overview pipeline (issue H4).
+//!
+//! Every input class from the H4 checklist gets a synthetic fixture and a
+//! test asserting the pipeline either produces correct output or fails fast
+//! with a typed, actionable error — never a panic, never silent wrong output.
+//!
+//! Fixtures are generated programmatically (no binary fixtures checked in).
+
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow_array::{Array, BinaryArray, Int32Array, Int64Array, RecordBatch, StringArray};
+use arrow_schema::{DataType, Field, Schema};
+use geo::{Geometry, GeometryCollection, LineString, Point, Polygon};
+use geoarrow::array::GeometryBuilder;
+use geoarrow::datatypes::GeometryType;
+use geoarrow_array::GeoArrowArray;
+use geoparquet::writer::{
+    GeoParquetRecordBatchEncoder, GeoParquetWriterEncoding, GeoParquetWriterOptionsBuilder,
+};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::arrow::ArrowWriter;
+use parquet::format::KeyValue;
+
+use super::check::validate_file;
+use super::convert::{convert_to_overviews, ConvertError, ConvertOptions, LevelPlan};
+use super::export::{export_pmtiles, ExportError, ExportOptions};
+use super::level::Mode;
+use super::reader::{OverviewReader, ReaderError};
+
+// ============================================================================
+// Fixture builders
+// ============================================================================
+
+/// Write a GeoParquet file with `id` (Int64), `name` (Utf8) property columns
+/// and the given (possibly null) geometries. `covering` toggles bbox covering
+/// generation; `extra_col` injects an additional Int32 column with the given
+/// name (reserved-column rejection tests).
+fn write_input(
+    path: &Path,
+    geoms: &[Option<Geometry<f64>>],
+    covering: bool,
+    extra_col: Option<&str>,
+) {
+    let n = geoms.len();
+    let id = Int64Array::from((0..n as i64).collect::<Vec<_>>());
+    let name = StringArray::from((0..n).map(|i| format!("f{i}")).collect::<Vec<_>>());
+
+    let typ = GeometryType::new(Default::default());
+    let mut b = GeometryBuilder::new(typ).with_prefer_multi(false);
+    b.extend_from_iter(geoms.iter().map(|g| g.as_ref()));
+    let geom_arr = b.finish();
+    let geom_field = geom_arr.data_type().to_field("geometry", true);
+
+    let mut fields = vec![
+        Arc::new(Field::new("id", DataType::Int64, false)),
+        Arc::new(Field::new("name", DataType::Utf8, false)),
+    ];
+    let mut columns: Vec<Arc<dyn Array>> = vec![Arc::new(id), Arc::new(name)];
+    if let Some(col) = extra_col {
+        fields.push(Arc::new(Field::new(col, DataType::Int32, false)));
+        columns.push(Arc::new(Int32Array::from(vec![0i32; n])));
+    }
+    fields.push(Arc::new(geom_field));
+    columns.push(geom_arr.to_array_ref());
+
+    let schema = Arc::new(Schema::new(fields));
+    let batch = RecordBatch::try_new(schema.clone(), columns).unwrap();
+
+    let gpq_options = GeoParquetWriterOptionsBuilder::default()
+        .set_encoding(GeoParquetWriterEncoding::WKB)
+        .set_generate_covering(covering)
+        .build();
+    let mut encoder = GeoParquetRecordBatchEncoder::try_new(&schema, &gpq_options).unwrap();
+    let target_schema = encoder.target_schema();
+
+    let file = std::fs::File::create(path).unwrap();
+    let mut writer = ArrowWriter::try_new(file, target_schema, None).unwrap();
+    let encoded = encoder.encode_record_batch(&batch).unwrap();
+    writer.write(&encoded).unwrap();
+    writer.append_key_value_metadata(encoder.into_keyvalue().unwrap());
+    writer.close().unwrap();
+}
+
+/// Spread-out points that survive as distinct cell winners.
+fn spread_points(n: usize) -> Vec<Option<Geometry<f64>>> {
+    (0..n)
+        .map(|i| {
+            Some(Geometry::Point(Point::new(
+                -60.0 + i as f64 * 20.0,
+                -30.0 + i as f64 * 12.0,
+            )))
+        })
+        .collect()
+}
+
+/// Default duplicating conversion options over a modest zoom range, with the
+/// given streaming flag.
+fn opts(streaming: bool) -> ConvertOptions {
+    ConvertOptions {
+        levels: LevelPlan::ZoomRange {
+            min_zoom: 2,
+            max_zoom: 6,
+        },
+        streaming,
+        ..Default::default()
+    }
+}
+
+/// Read `(id, geometry)` pairs for a level of an overview file, in row order.
+fn read_level_ids_geoms(path: &Path, level: usize) -> Vec<(i64, Geometry<f64>)> {
+    use crate::batch_processor::extract_geometries_from_array;
+    use arrow_array::cast::AsArray;
+    use geoarrow::array::from_arrow_array;
+
+    let reader = OverviewReader::open(path).unwrap();
+    let rdr = reader.read_level(level, None).unwrap();
+    let mut out = Vec::new();
+    for batch in rdr {
+        let batch = batch.unwrap();
+        let schema = batch.schema();
+        let ids = batch
+            .column(schema.index_of("id").unwrap())
+            .as_primitive::<arrow_array::types::Int64Type>()
+            .clone();
+        let gidx = schema.index_of("geometry").unwrap();
+        let garr = from_arrow_array(batch.column(gidx).as_ref(), schema.field(gidx)).unwrap();
+        let mut geoms = Vec::new();
+        extract_geometries_from_array(garr.as_ref(), &mut geoms).unwrap();
+        assert_eq!(
+            geoms.len(),
+            batch.num_rows(),
+            "output level {level} contains null/undecodable geometry rows"
+        );
+        for (i, g) in geoms.into_iter().enumerate() {
+            out.push((ids.value(i), g));
+        }
+    }
+    out
+}
+
+/// Rewrite an overview file with a tampered `geo:overviews` footer value.
+/// Batches and the `geo` key are copied verbatim; the file is written as a
+/// single row group (which is itself a footer/data mismatch for multi-level
+/// footers).
+fn rewrite_with_tampered_footer(src: &Path, dst: &Path, edit: impl FnOnce(&mut serde_json::Value)) {
+    let file = std::fs::File::open(src).unwrap();
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
+    let schema = builder.schema().clone();
+    let kvs = builder
+        .metadata()
+        .file_metadata()
+        .key_value_metadata()
+        .unwrap()
+        .clone();
+    let batches: Vec<RecordBatch> = builder.build().unwrap().map(|b| b.unwrap()).collect();
+
+    let out = std::fs::File::create(dst).unwrap();
+    let mut writer = ArrowWriter::try_new(out, schema, None).unwrap();
+    for b in &batches {
+        writer.write(b).unwrap();
+    }
+    let mut edit = Some(edit);
+    for kv in kvs {
+        match kv.key.as_str() {
+            "geo:overviews" => {
+                let mut v: serde_json::Value = serde_json::from_str(&kv.value.unwrap()).unwrap();
+                (edit.take().expect("single geo:overviews key"))(&mut v);
+                writer.append_key_value_metadata(KeyValue::new(
+                    "geo:overviews".to_string(),
+                    serde_json::to_string(&v).unwrap(),
+                ));
+            }
+            "geo" => writer.append_key_value_metadata(kv),
+            _ => {}
+        }
+    }
+    writer.close().unwrap();
+}
+
+/// Convert `spread_points` input to a valid overview file at `out`.
+fn make_valid_overview(out: &Path) {
+    let tin = tempfile::NamedTempFile::new().unwrap();
+    write_input(tin.path(), &spread_points(6), true, None);
+    convert_to_overviews(tin.path(), out, &opts(true)).unwrap();
+}
+
+// ============================================================================
+// Class 1: empty file (0 rows) / all-null geometry column
+// ============================================================================
+
+#[test]
+fn empty_input_zero_rows_errors_nodata() {
+    for streaming in [true, false] {
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        write_input(tin.path(), &[], true, None);
+        let err = convert_to_overviews(tin.path(), tout.path(), &opts(streaming)).unwrap_err();
+        assert!(
+            matches!(err, ConvertError::NoData),
+            "streaming={streaming}: expected NoData, got: {err}"
+        );
+    }
+}
+
+#[test]
+fn all_null_geometry_errors_nodata() {
+    for streaming in [true, false] {
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        write_input(tin.path(), &[None, None, None], true, None);
+        let err = convert_to_overviews(tin.path(), tout.path(), &opts(streaming)).unwrap_err();
+        assert!(
+            matches!(err, ConvertError::NoData),
+            "streaming={streaming}: expected NoData, got: {err}"
+        );
+    }
+}
+
+#[test]
+fn partial_null_geometry_rows_skipped_with_aligned_attributes() {
+    // Null geometry rows interleaved with valid ones must be skipped WITHOUT
+    // shifting the attribute<->geometry pairing of the surviving rows.
+    for streaming in [true, false] {
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        let mut geoms = spread_points(5);
+        geoms.insert(1, None); // id 1 null
+        geoms.insert(4, None); // id 4 null
+        write_input(tin.path(), &geoms, true, None);
+
+        let report = convert_to_overviews(tin.path(), tout.path(), &opts(streaming))
+            .unwrap_or_else(|e| panic!("streaming={streaming}: conversion failed: {e}"));
+        assert_eq!(report.input_features, 5, "streaming={streaming}");
+
+        let vr = validate_file(tout.path()).unwrap();
+        assert!(vr.is_valid(), "streaming={streaming}");
+
+        // Canonical level: exactly the 5 non-null rows, each id paired with
+        // ITS OWN geometry (regression: misalignment pairs id with the next
+        // non-null row's geometry).
+        let reader = OverviewReader::open(tout.path()).unwrap();
+        let canonical = reader.num_levels() - 1;
+        let rows = read_level_ids_geoms(tout.path(), canonical);
+        let expected_ids: Vec<i64> = vec![0, 2, 3, 5, 6];
+        assert_eq!(
+            rows.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+            expected_ids,
+            "streaming={streaming}"
+        );
+        for (id, g) in &rows {
+            let Geometry::Point(p) = g else {
+                panic!("expected point");
+            };
+            // Original spread_points index for this id (nulls at 1 and 4).
+            let orig = match id {
+                0 => 0,
+                2 => 1,
+                3 => 2,
+                5 => 3,
+                6 => 4,
+                _ => unreachable!(),
+            };
+            let expected = Point::new(-60.0 + orig as f64 * 20.0, -30.0 + orig as f64 * 12.0);
+            assert_eq!(p, &expected, "streaming={streaming}: id {id}");
+        }
+    }
+}
+
+// ============================================================================
+// Class 2: invalid / degenerate source geometries
+// ============================================================================
+
+#[test]
+fn nonfinite_coordinate_rows_skipped() {
+    // NaN / infinite coordinates cannot be placed on any grid: those rows are
+    // skipped like nulls instead of silently landing in cell (0, 0).
+    for streaming in [true, false] {
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        let mut geoms = spread_points(4);
+        geoms.push(Some(Geometry::Point(Point::new(f64::NAN, 1.0))));
+        geoms.push(Some(Geometry::Point(Point::new(2.0, f64::INFINITY))));
+        // Covering generation over NaN bboxes is itself hostile; skip it.
+        write_input(tin.path(), &geoms, false, None);
+
+        let report = convert_to_overviews(tin.path(), tout.path(), &opts(streaming))
+            .unwrap_or_else(|e| panic!("streaming={streaming}: conversion failed: {e}"));
+        assert_eq!(report.input_features, 4, "streaming={streaming}");
+
+        let reader = OverviewReader::open(tout.path()).unwrap();
+        let canonical = reader.num_levels() - 1;
+        let rows = read_level_ids_geoms(tout.path(), canonical);
+        assert_eq!(
+            rows.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+            vec![0, 1, 2, 3],
+            "streaming={streaming}"
+        );
+        for (_, g) in &rows {
+            let Geometry::Point(p) = g else {
+                panic!("expected point")
+            };
+            assert!(
+                p.x().is_finite() && p.y().is_finite(),
+                "streaming={streaming}: non-finite geometry leaked into output"
+            );
+        }
+    }
+}
+
+#[test]
+fn empty_coordinate_geometries_skipped() {
+    // A LineString with zero coordinates has no spatial content; it is
+    // skipped like a null rather than parked at a fabricated [0,0,0,0] bbox.
+    for streaming in [true, false] {
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        let mut geoms = spread_points(3);
+        geoms.push(Some(Geometry::LineString(LineString::new(vec![]))));
+        write_input(tin.path(), &geoms, false, None);
+
+        let report = convert_to_overviews(tin.path(), tout.path(), &opts(streaming))
+            .unwrap_or_else(|e| panic!("streaming={streaming}: conversion failed: {e}"));
+        assert_eq!(report.input_features, 3, "streaming={streaming}");
+        let reader = OverviewReader::open(tout.path()).unwrap();
+        let canonical = reader.num_levels() - 1;
+        let rows = read_level_ids_geoms(tout.path(), canonical);
+        assert_eq!(
+            rows.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+            vec![0, 1, 2],
+            "streaming={streaming}"
+        );
+    }
+}
+
+#[test]
+fn empty_wkb_value_errors_typed() {
+    // A zero-length WKB value is undecodable: the conversion must surface a
+    // typed error (never a panic).
+    let tin = tempfile::NamedTempFile::new().unwrap();
+    let tout = tempfile::NamedTempFile::new().unwrap();
+
+    // Hand-built GeoParquet: Binary geometry column with one empty value.
+    let mut md = std::collections::HashMap::new();
+    md.insert(
+        "ARROW:extension:name".to_string(),
+        "geoarrow.wkb".to_string(),
+    );
+    let geom_field = Field::new("geometry", DataType::Binary, true).with_metadata(md);
+    let schema = Arc::new(Schema::new(vec![
+        Arc::new(Field::new("id", DataType::Int64, false)),
+        Arc::new(geom_field),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int64Array::from(vec![0i64])),
+            Arc::new(BinaryArray::from_vec(vec![b"" as &[u8]])),
+        ],
+    )
+    .unwrap();
+    let file = std::fs::File::create(tin.path()).unwrap();
+    let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
+    writer.write(&batch).unwrap();
+    writer.append_key_value_metadata(KeyValue::new(
+        "geo".to_string(),
+        r#"{"version":"1.1.0","primary_column":"geometry","columns":{"geometry":{"encoding":"WKB","geometry_types":[]}}}"#
+            .to_string(),
+    ));
+    writer.close().unwrap();
+
+    for streaming in [true, false] {
+        let result = convert_to_overviews(tin.path(), tout.path(), &opts(streaming));
+        assert!(
+            result.is_err(),
+            "streaming={streaming}: empty WKB must error"
+        );
+    }
+}
+
+#[test]
+fn self_intersecting_polygon_converts() {
+    // A bowtie (self-intersecting ring) is structurally valid WKB; the
+    // pipeline carries it through rather than crashing on it.
+    let tin = tempfile::NamedTempFile::new().unwrap();
+    let tout = tempfile::NamedTempFile::new().unwrap();
+    let bowtie = Polygon::new(
+        LineString::from(vec![
+            (0.0, 0.0),
+            (20.0, 20.0),
+            (20.0, 0.0),
+            (0.0, 20.0),
+            (0.0, 0.0),
+        ]),
+        vec![],
+    );
+    let mut geoms = spread_points(3);
+    geoms.push(Some(Geometry::Polygon(bowtie)));
+    write_input(tin.path(), &geoms, true, None);
+
+    let report = convert_to_overviews(tin.path(), tout.path(), &opts(true)).unwrap();
+    assert_eq!(report.input_features, 4);
+    let vr = validate_file(tout.path()).unwrap();
+    assert!(vr.is_valid());
+}
+
+// ============================================================================
+// Class 3: mixed geometry types / GeometryCollections
+// ============================================================================
+
+#[test]
+fn geometry_collection_passes_through() {
+    let tin = tempfile::NamedTempFile::new().unwrap();
+    let tout = tempfile::NamedTempFile::new().unwrap();
+    let gc = GeometryCollection::from(vec![
+        Geometry::Point(Point::new(10.0, 10.0)),
+        Geometry::LineString(LineString::from(vec![(11.0, 10.0), (12.0, 11.0)])),
+    ]);
+    let mut geoms = spread_points(3);
+    geoms.push(Some(Geometry::GeometryCollection(gc)));
+    write_input(tin.path(), &geoms, true, None);
+
+    for streaming in [true, false] {
+        let report = convert_to_overviews(tin.path(), tout.path(), &opts(streaming))
+            .unwrap_or_else(|e| panic!("streaming={streaming}: conversion failed: {e}"));
+        assert_eq!(report.input_features, 4, "streaming={streaming}");
+        let reader = OverviewReader::open(tout.path()).unwrap();
+        let canonical = reader.num_levels() - 1;
+        let rows = read_level_ids_geoms(tout.path(), canonical);
+        assert!(
+            rows.iter()
+                .any(|(_, g)| matches!(g, Geometry::GeometryCollection(_))),
+            "streaming={streaming}: GeometryCollection lost from canonical level"
+        );
+    }
+}
+
+// ============================================================================
+// Class 4: antimeridian-crossing / pole-adjacent geometries
+// ============================================================================
+
+#[test]
+fn antimeridian_and_pole_features_convert() {
+    let tin = tempfile::NamedTempFile::new().unwrap();
+    let tout = tempfile::NamedTempFile::new().unwrap();
+    let geoms: Vec<Option<Geometry<f64>>> = vec![
+        Some(Geometry::Point(Point::new(179.95, 0.0))),
+        Some(Geometry::Point(Point::new(-179.95, 5.0))),
+        Some(Geometry::Point(Point::new(0.0, 89.9))),
+        Some(Geometry::Point(Point::new(0.0, -89.9))),
+        // Raw antimeridian-crossing linestring (as stored: a long east-west line).
+        Some(Geometry::LineString(LineString::from(vec![
+            (179.5, 10.0),
+            (-179.5, 10.5),
+        ]))),
+    ];
+    write_input(tin.path(), &geoms, true, None);
+
+    let report = convert_to_overviews(tin.path(), tout.path(), &opts(true)).unwrap();
+    assert_eq!(report.input_features, 5);
+    let vr = validate_file(tout.path()).unwrap();
+    assert!(
+        vr.is_valid(),
+        "failures: {:?}",
+        vr.failures().collect::<Vec<_>>()
+    );
+    let reader = OverviewReader::open(tout.path()).unwrap();
+    let canonical = reader.num_levels() - 1;
+    assert_eq!(read_level_ids_geoms(tout.path(), canonical).len(), 5);
+}
+
+// ============================================================================
+// Class 5: degenerate extents
+// ============================================================================
+
+#[test]
+fn single_point_dataset_converts() {
+    let tin = tempfile::NamedTempFile::new().unwrap();
+    let tout = tempfile::NamedTempFile::new().unwrap();
+    write_input(tin.path(), &spread_points(1), true, None);
+
+    for streaming in [true, false] {
+        let report = convert_to_overviews(tin.path(), tout.path(), &opts(streaming))
+            .unwrap_or_else(|e| panic!("streaming={streaming}: conversion failed: {e}"));
+        assert_eq!(report.input_features, 1, "streaming={streaming}");
+        let vr = validate_file(tout.path()).unwrap();
+        assert!(vr.is_valid(), "streaming={streaming}");
+        // The single point survives at every emitted level.
+        let reader = OverviewReader::open(tout.path()).unwrap();
+        for l in 0..reader.num_levels() {
+            assert_eq!(
+                read_level_ids_geoms(tout.path(), l).len(),
+                1,
+                "streaming={streaming} level={l}"
+            );
+        }
+    }
+}
+
+#[test]
+fn all_identical_geometries_convert() {
+    let tin = tempfile::NamedTempFile::new().unwrap();
+    let tout = tempfile::NamedTempFile::new().unwrap();
+    let geoms: Vec<Option<Geometry<f64>>> = (0..10)
+        .map(|_| Some(Geometry::Point(Point::new(7.5, 45.0))))
+        .collect();
+    write_input(tin.path(), &geoms, true, None);
+
+    let report = convert_to_overviews(tin.path(), tout.path(), &opts(true)).unwrap();
+    assert_eq!(report.input_features, 10);
+    let vr = validate_file(tout.path()).unwrap();
+    assert!(vr.is_valid());
+    // Coarse levels keep exactly one cell winner; canonical keeps all 10.
+    let reader = OverviewReader::open(tout.path()).unwrap();
+    let canonical = reader.num_levels() - 1;
+    assert_eq!(read_level_ids_geoms(tout.path(), 0).len(), 1);
+    assert_eq!(read_level_ids_geoms(tout.path(), canonical).len(), 10);
+}
+
+#[test]
+fn extent_smaller_than_finest_gsd_converts() {
+    // All features within ~100 m of each other, converted over a coarse zoom
+    // range whose finest GSD is ~2.4 km: everything lands in one cell per
+    // level, so each coarse level has one winner and canonical has all rows.
+    let tin = tempfile::NamedTempFile::new().unwrap();
+    let tout = tempfile::NamedTempFile::new().unwrap();
+    let geoms: Vec<Option<Geometry<f64>>> = (0..5)
+        .map(|i| {
+            Some(Geometry::Point(Point::new(
+                10.0 + i as f64 * 0.0002,
+                50.0 + i as f64 * 0.0002,
+            )))
+        })
+        .collect();
+    write_input(tin.path(), &geoms, true, None);
+
+    let o = ConvertOptions {
+        levels: LevelPlan::ZoomRange {
+            min_zoom: 0,
+            max_zoom: 4,
+        },
+        ..Default::default()
+    };
+    let report = convert_to_overviews(tin.path(), tout.path(), &o).unwrap();
+    assert_eq!(report.input_features, 5);
+    let vr = validate_file(tout.path()).unwrap();
+    assert!(vr.is_valid());
+    let reader = OverviewReader::open(tout.path()).unwrap();
+    let canonical = reader.num_levels() - 1;
+    assert_eq!(read_level_ids_geoms(tout.path(), 0).len(), 1);
+    assert_eq!(read_level_ids_geoms(tout.path(), canonical).len(), 5);
+}
+
+// ============================================================================
+// Class 6: absurd knob combos
+// ============================================================================
+
+#[test]
+fn min_zoom_greater_than_max_zoom_rejected() {
+    let tin = tempfile::NamedTempFile::new().unwrap();
+    let tout = tempfile::NamedTempFile::new().unwrap();
+    write_input(tin.path(), &spread_points(3), true, None);
+    let o = ConvertOptions {
+        levels: LevelPlan::ZoomRange {
+            min_zoom: 8,
+            max_zoom: 2,
+        },
+        ..Default::default()
+    };
+    let err = convert_to_overviews(tin.path(), tout.path(), &o).unwrap_err();
+    assert!(matches!(err, ConvertError::InvalidLevels(_)), "got: {err}");
+}
+
+#[test]
+fn forty_plus_zoom_levels_convert() {
+    let tin = tempfile::NamedTempFile::new().unwrap();
+    let tout = tempfile::NamedTempFile::new().unwrap();
+    write_input(tin.path(), &spread_points(4), true, None);
+    let o = ConvertOptions {
+        levels: LevelPlan::ZoomRange {
+            min_zoom: 0,
+            max_zoom: 45,
+        },
+        ..Default::default()
+    };
+    let report = convert_to_overviews(tin.path(), tout.path(), &o).unwrap();
+    assert_eq!(report.input_features, 4);
+    let vr = validate_file(tout.path()).unwrap();
+    assert!(vr.is_valid());
+}
+
+#[test]
+fn more_than_255_levels_rejected() {
+    // The per-feature level table is u8-indexed; plans beyond 255 levels are
+    // rejected up front instead of silently wrapping.
+    let tin = tempfile::NamedTempFile::new().unwrap();
+    let tout = tempfile::NamedTempFile::new().unwrap();
+    write_input(tin.path(), &spread_points(3), true, None);
+    let gsds: Vec<f64> = (0..300).map(|i| 1.0e6 * 0.99f64.powi(i)).collect();
+    let o = ConvertOptions {
+        levels: LevelPlan::Gsds(gsds),
+        ..Default::default()
+    };
+    let err = convert_to_overviews(tin.path(), tout.path(), &o).unwrap_err();
+    assert!(matches!(err, ConvertError::InvalidLevels(_)), "got: {err}");
+}
+
+#[test]
+fn gsd_base_extremes_rejected() {
+    let tin = tempfile::NamedTempFile::new().unwrap();
+    let tout = tempfile::NamedTempFile::new().unwrap();
+    write_input(tin.path(), &spread_points(3), true, None);
+    for bad in [0.0, -1024.0, f64::NAN, f64::INFINITY] {
+        let o = ConvertOptions {
+            gsd_base: bad,
+            ..opts(true)
+        };
+        let err = convert_to_overviews(tin.path(), tout.path(), &o).unwrap_err();
+        assert!(
+            matches!(err, ConvertError::InvalidConfig(_)),
+            "gsd_base={bad}: got: {err}"
+        );
+    }
+}
+
+#[test]
+fn thinning_zero_negative_nan_rejected() {
+    let tin = tempfile::NamedTempFile::new().unwrap();
+    let tout = tempfile::NamedTempFile::new().unwrap();
+    write_input(tin.path(), &spread_points(3), true, None);
+    for bad in [0.0, -4.0, f64::NAN, f64::INFINITY] {
+        for knob in 0..3 {
+            let mut o = opts(true);
+            match knob {
+                0 => o.assign.point_thinning = bad,
+                1 => o.assign.line_thinning = bad,
+                _ => o.assign.polygon_thinning = bad,
+            }
+            let err = convert_to_overviews(tin.path(), tout.path(), &o).unwrap_err();
+            assert!(
+                matches!(err, ConvertError::InvalidConfig(_)),
+                "thinning knob {knob}={bad}: got: {err}"
+            );
+        }
+    }
+}
+
+#[test]
+fn visibility_negative_nan_rejected() {
+    let tin = tempfile::NamedTempFile::new().unwrap();
+    let tout = tempfile::NamedTempFile::new().unwrap();
+    write_input(tin.path(), &spread_points(3), true, None);
+    for bad in [-2.0, f64::NAN, f64::INFINITY] {
+        for knob in 0..2 {
+            let mut o = opts(true);
+            match knob {
+                0 => o.assign.line_visibility = bad,
+                _ => o.assign.polygon_visibility = bad,
+            }
+            let err = convert_to_overviews(tin.path(), tout.path(), &o).unwrap_err();
+            assert!(
+                matches!(err, ConvertError::InvalidConfig(_)),
+                "visibility knob {knob}={bad}: got: {err}"
+            );
+        }
+    }
+}
+
+#[test]
+fn coalesce_nan_knobs_rejected() {
+    let tin = tempfile::NamedTempFile::new().unwrap();
+    let tout = tempfile::NamedTempFile::new().unwrap();
+    write_input(tin.path(), &spread_points(3), true, None);
+    let o = ConvertOptions {
+        coalesce_snap: f64::NAN,
+        ..opts(true)
+    };
+    let err = convert_to_overviews(tin.path(), tout.path(), &o).unwrap_err();
+    assert!(matches!(err, ConvertError::InvalidConfig(_)), "got: {err}");
+
+    let o = ConvertOptions {
+        coalesce_junction_angle: f64::NAN,
+        ..opts(true)
+    };
+    let err = convert_to_overviews(tin.path(), tout.path(), &o).unwrap_err();
+    assert!(matches!(err, ConvertError::InvalidConfig(_)), "got: {err}");
+}
+
+// ============================================================================
+// Class 7: pre-existing reserved columns (verify-only; case-insensitive)
+// ============================================================================
+
+#[test]
+fn reserved_columns_rejected_case_insensitive() {
+    // `LEVEL` (any casing) is always rejected.
+    let tin = tempfile::NamedTempFile::new().unwrap();
+    let tout = tempfile::NamedTempFile::new().unwrap();
+    write_input(tin.path(), &spread_points(3), true, Some("LEVEL"));
+    for streaming in [true, false] {
+        let err = convert_to_overviews(tin.path(), tout.path(), &opts(streaming)).unwrap_err();
+        assert!(
+            matches!(err, ConvertError::LevelColumnPresent),
+            "streaming={streaming}: got: {err}"
+        );
+    }
+
+    // `Point_Count` is rejected when clustering is enabled.
+    let tin = tempfile::NamedTempFile::new().unwrap();
+    write_input(tin.path(), &spread_points(3), true, Some("Point_Count"));
+    let o = ConvertOptions {
+        cluster: true,
+        ..opts(true)
+    };
+    let err = convert_to_overviews(tin.path(), tout.path(), &o).unwrap_err();
+    assert!(
+        matches!(err, ConvertError::PointCountColumnPresent),
+        "got: {err}"
+    );
+
+    // `COALESCED_COUNT` is rejected when coalescing is enabled (the default).
+    let tin = tempfile::NamedTempFile::new().unwrap();
+    write_input(tin.path(), &spread_points(3), true, Some("COALESCED_COUNT"));
+    let err = convert_to_overviews(tin.path(), tout.path(), &opts(true)).unwrap_err();
+    assert!(
+        matches!(err, ConvertError::CoalescedCountColumnPresent),
+        "got: {err}"
+    );
+}
+
+// ============================================================================
+// Class 8: zero-row levels after thinning (empty-level omission, all routes)
+// ============================================================================
+
+#[test]
+fn empty_coarse_levels_omitted_across_pipelines() {
+    // Tiny lines fail the visibility gate at every coarse level: with
+    // coalescing off those levels are empty and must be omitted (not written,
+    // not EmptyLevel-crashed), leaving a valid file with fewer levels.
+    let tiny_lines: Vec<Option<Geometry<f64>>> = (0..4)
+        .map(|i| {
+            let x = 10.0 + i as f64 * 5.0;
+            Some(Geometry::LineString(LineString::from(vec![
+                (x, 20.0),
+                (x + 0.00005, 20.00005),
+            ])))
+        })
+        .collect();
+
+    for streaming in [true, false] {
+        for coalesce in [false, true] {
+            let tin = tempfile::NamedTempFile::new().unwrap();
+            let tout = tempfile::NamedTempFile::new().unwrap();
+            write_input(tin.path(), &tiny_lines, true, None);
+            let o = ConvertOptions {
+                levels: LevelPlan::ZoomRange {
+                    min_zoom: 0,
+                    max_zoom: 10,
+                },
+                coalesce_lines: coalesce,
+                streaming,
+                ..Default::default()
+            };
+            let report = convert_to_overviews(tin.path(), tout.path(), &o).unwrap_or_else(|e| {
+                panic!("streaming={streaming} coalesce={coalesce}: failed: {e}")
+            });
+            assert!(
+                !report.levels.is_empty() && report.levels.len() <= 11,
+                "streaming={streaming} coalesce={coalesce}"
+            );
+            let vr = validate_file(tout.path()).unwrap();
+            assert!(
+                vr.is_valid(),
+                "streaming={streaming} coalesce={coalesce}: {:?}",
+                vr.failures().collect::<Vec<_>>()
+            );
+        }
+    }
+}
+
+#[test]
+fn empty_coarse_levels_omitted_with_clustering() {
+    // Same omission contract on the clustering route: a single point dataset
+    // over a wide zoom range keeps every level nonempty, while a clustered
+    // conversion of points that all defer still validates.
+    let tin = tempfile::NamedTempFile::new().unwrap();
+    let tout = tempfile::NamedTempFile::new().unwrap();
+    write_input(tin.path(), &spread_points(5), true, None);
+    let o = ConvertOptions {
+        cluster: true,
+        levels: LevelPlan::ZoomRange {
+            min_zoom: 0,
+            max_zoom: 10,
+        },
+        ..Default::default()
+    };
+    let report = convert_to_overviews(tin.path(), tout.path(), &o).unwrap();
+    assert_eq!(report.input_features, 5);
+    let vr = validate_file(tout.path()).unwrap();
+    assert!(
+        vr.is_valid(),
+        "failures: {:?}",
+        vr.failures().collect::<Vec<_>>()
+    );
+}
+
+// ============================================================================
+// Class 9: export-pmtiles hostile inputs
+// ============================================================================
+
+#[test]
+fn export_non_overview_parquet_errors() {
+    // A plain GeoParquet file (no `geo:overviews` key) is rejected with the
+    // typed reader error, not a panic.
+    let tin = tempfile::NamedTempFile::new().unwrap();
+    let tout = tempfile::NamedTempFile::new().unwrap();
+    write_input(tin.path(), &spread_points(3), true, None);
+    let err = export_pmtiles(tin.path(), tout.path(), &ExportOptions::default()).unwrap_err();
+    assert!(
+        matches!(err, ExportError::Reader(ReaderError::MissingOverviewsKey)),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn export_truncated_file_errors() {
+    let tovr = tempfile::NamedTempFile::new().unwrap();
+    make_valid_overview(tovr.path());
+    let len = std::fs::metadata(tovr.path()).unwrap().len();
+
+    let ttrunc = tempfile::NamedTempFile::new().unwrap();
+    let bytes = std::fs::read(tovr.path()).unwrap();
+    std::fs::write(ttrunc.path(), &bytes[..(len as usize) / 2]).unwrap();
+
+    let tout = tempfile::NamedTempFile::new().unwrap();
+    let err = export_pmtiles(ttrunc.path(), tout.path(), &ExportOptions::default()).unwrap_err();
+    assert!(matches!(err, ExportError::Reader(_)), "got: {err}");
+}
+
+#[test]
+fn export_footer_data_mismatch_errors() {
+    // Footer declares level bands that do not match the file's actual row
+    // groups: the reader must reject the file on open instead of reading
+    // wrong bands (or allocating from hostile row_group_end values).
+    let tovr = tempfile::NamedTempFile::new().unwrap();
+    make_valid_overview(tovr.path());
+
+    // Out-of-range row_group_end.
+    let tbad = tempfile::NamedTempFile::new().unwrap();
+    rewrite_with_tampered_footer(tovr.path(), tbad.path(), |v| {
+        let levels = v["levels"].as_array_mut().unwrap();
+        let last = levels.len() - 1;
+        levels[last]["row_group_end"] = serde_json::json!(999);
+    });
+    let tout = tempfile::NamedTempFile::new().unwrap();
+    let err = export_pmtiles(tbad.path(), tout.path(), &ExportOptions::default()).unwrap_err();
+    assert!(matches!(err, ExportError::Reader(_)), "got: {err}");
+}
+
+#[test]
+fn reader_rejects_negative_row_group_end() {
+    // A negative row_group_end would wrap through `as usize` into a huge band
+    // range; the reader must reject it at open.
+    let tovr = tempfile::NamedTempFile::new().unwrap();
+    make_valid_overview(tovr.path());
+
+    let tbad = tempfile::NamedTempFile::new().unwrap();
+    rewrite_with_tampered_footer(tovr.path(), tbad.path(), |v| {
+        v["levels"][0]["row_group_end"] = serde_json::json!(-1);
+    });
+    let err = OverviewReader::open(tbad.path()).unwrap_err();
+    assert!(
+        !matches!(err, ReaderError::MissingOverviewsKey),
+        "wrong rejection: {err}"
+    );
+}
+
+#[test]
+fn export_partitioning_mode_file_works() {
+    // Partitioning-mode overview files are a supported export source.
+    let tin = tempfile::NamedTempFile::new().unwrap();
+    let tovr = tempfile::NamedTempFile::new().unwrap();
+    let tout = tempfile::NamedTempFile::new().unwrap();
+    write_input(tin.path(), &spread_points(6), true, None);
+    let o = ConvertOptions {
+        mode: Mode::Partitioning,
+        ..opts(true)
+    };
+    convert_to_overviews(tin.path(), tovr.path(), &o).unwrap();
+    let report = export_pmtiles(tovr.path(), tout.path(), &ExportOptions::default()).unwrap();
+    assert!(report.total_tiles > 0);
+}

--- a/crates/core/src/overview/mod.rs
+++ b/crates/core/src/overview/mod.rs
@@ -14,6 +14,8 @@ pub mod cluster;
 pub mod coalesce;
 pub mod convert;
 pub mod export;
+#[cfg(test)]
+mod hostile;
 pub mod level;
 pub mod reader;
 pub mod simplify;

--- a/crates/core/src/overview/reader.rs
+++ b/crates/core/src/overview/reader.rs
@@ -46,6 +46,13 @@ pub enum ReaderError {
     /// The `geo:overviews` footer key is present but is not valid JSON per §3.
     #[error("invalid 'geo:overviews' JSON: {0}")]
     InvalidOverviewsJson(serde_json::Error),
+    /// The `geo:overviews` metadata parses but violates a §3.3/§3.4
+    /// structural invariant against the file's actual row groups (level band
+    /// out of range / non-monotonic / footer-data mismatch): the level bands
+    /// cannot be trusted, so the file is rejected at open (H4 hardening — a
+    /// hostile `row_group_end` would otherwise drive band arithmetic).
+    #[error("invalid 'geo:overviews' metadata: {0}")]
+    InvalidMetadata(#[from] super::level::OverviewValidationError),
     /// A level index was requested that does not exist in the file.
     #[error("level {level} out of range (file has {num_levels} levels)")]
     LevelOutOfRange {
@@ -89,6 +96,13 @@ impl OverviewReader {
             .ok_or(ReaderError::MissingOverviewsKey)?;
 
         let meta = OverviewsMeta::from_json(&json).map_err(ReaderError::InvalidOverviewsJson)?;
+
+        // Structural validation against the file's ACTUAL row groups (§3.3 /
+        // §3.4): every subsequent band computation trusts the footer's
+        // row_group_end values, so a corrupt or tampered footer must be
+        // rejected here rather than driving out-of-range (or, for negative
+        // values, usize-wrapped) row-group reads.
+        meta.validate(metadata.num_row_groups() as i64)?;
 
         Ok(Self {
             path,

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -59,7 +59,7 @@ use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::arrow::ProjectionMask;
 use rayon::prelude::*;
 
-use crate::batch_processor::extract_geometries_from_array;
+use crate::batch_processor::{extract_geometries_from_array, extract_geometries_opt_from_array};
 
 use super::assign::{apply_density_budget, assign_levels, AssignFeature, FeatureKind};
 use super::cluster::{build_cluster_tables, ClusterEntry, ClusterTables};
@@ -70,15 +70,21 @@ use super::convert::{
     build_source_schema, class_ranking_provenance, coalesce_effective, coalesce_level_chains,
     count_vertices, detect_crs, extract_class_ranks, extract_sort_keys, feature_kind,
     fill_level_bytes, find_geometry_column, geometry_bbox, mixed_geometry_field,
-    overture_road_ranking, validate_cluster_schema, validate_coalesce_schema, ClassRanking,
-    CoalesceTable, ConvertError, ConvertOptions, ConvertReport, GroupInterner, LevelReport,
-    KNOWN_ROAD_CLASSES, ROAD_VOCAB_MIN_DISTINCT,
+    overture_road_ranking, usable_geometry, validate_cluster_schema, validate_coalesce_schema,
+    ClassRanking, CoalesceTable, ConvertError, ConvertOptions, ConvertReport, GroupInterner,
+    LevelReport, KNOWN_ROAD_CLASSES, ROAD_VOCAB_MIN_DISTINCT,
 };
 use super::level::{Crs, Mode, RankingProvenance};
 use super::simplify::{
     full_resolution_fallback_count, simplify_for_level, Simplified, SimplifyOptions,
 };
 use super::writer::{LevelSpec, OverviewWriter, OverviewWriterOptions, LEVEL_COLUMN};
+
+/// Row-indexed winner-table sentinel for rows with no feature (null, empty,
+/// or non-finite geometry — skipped in pass 1). It matches no level in either
+/// mode: [`super::convert::MAX_LEVELS`] caps the plan at 255 levels, so the
+/// finest level index is at most 254.
+const UNASSIGNED_LEVEL: u8 = u8::MAX;
 
 /// A level actually emitted to the output (levels with zero winners are
 /// omitted and renumbered, spec §7.3, matching the in-memory path).
@@ -134,7 +140,15 @@ pub(super) fn convert_streaming(
         provenance: ranking_provenance,
         acc_values,
         coalesce: coalesce_scratch,
+        num_rows,
+        skipped_rows,
     } = run_pass1(input_path, &input_schema, geom_idx, options, &acc_cols)?;
+    if skipped_rows > 0 {
+        log::warn!(
+            "skipping {skipped_rows} of {num_rows} input rows with a null, \
+             empty, or non-finite geometry"
+        );
+    }
     let num_features = features.len();
     log::debug!(
         "[profile] pass1 stream+scan: {:.2}s",
@@ -164,23 +178,29 @@ pub(super) fn convert_streaming(
         t_assign.elapsed().as_secs_f64()
     );
 
-    // The winner table: per input row, the coarsest level it appears at.
-    // 1 byte per feature — the only O(N) state carried into pass 2.
-    let min_levels: Vec<u8> = assignment.assignments.iter().map(|a| a.min_level).collect();
+    // The feature-parallel winner table (coarsest level per FEATURE, in
+    // `features` order) feeds the cluster stage and the per-level counts.
+    let feat_min_levels: Vec<u8> = assignment.assignments.iter().map(|a| a.min_level).collect();
     drop(assignment);
 
     // Cluster tables (Q4): built from the pass-1 features + final winner
     // table, before the O(N) scratch is freed. Memory afterwards is
     // O(non-singleton clusters), carried into pass 2 alongside `min_levels`.
+    // Accumulate values are extracted per ROW; the cluster stage indexes them
+    // by feature position, so remap through each feature's row index.
     let cluster_tables: Option<ClusterTables> = if options.cluster {
         let ops: Vec<_> = options.accumulate.iter().map(|s| s.op).collect();
+        let acc_feat: Vec<Vec<Option<f64>>> = acc_values
+            .iter()
+            .map(|vals| features.iter().map(|f| vals[f.index]).collect())
+            .collect();
         Some(build_cluster_tables(
             &features,
-            &min_levels,
+            &feat_min_levels,
             &level_gsds,
             &options.assign,
             crs,
-            &acc_values,
+            &acc_feat,
             &ops,
         ))
     } else {
@@ -188,23 +208,34 @@ pub(super) fn convert_streaming(
     };
     drop(acc_values);
 
-    // Coalescing (Q3): keep the per-row kinds (1 byte/feature — line rows
-    // bypass the winner table at coalesced levels) and the pass-1 line
+    // Coalescing (Q3): keep the per-row kinds (1 byte/row — line rows bypass
+    // the winner table at coalesced levels; skipped-geometry rows default to
+    // Point, which never matches the Line bypass) and the pass-1 line
     // scratch; apply the memory guard.
     let coalesce_on = coalesce_effective(
         options,
         coalesce_scratch.as_ref().map_or(0, |s| s.rows.len()),
     );
-    let kinds: Option<Vec<FeatureKind>> = options
-        .coalesce_lines
-        .then(|| features.iter().map(|f| f.kind).collect());
+    let kinds: Option<Vec<FeatureKind>> = options.coalesce_lines.then(|| {
+        let mut k = vec![FeatureKind::Point; num_rows];
+        for f in &features {
+            k[f.index] = f.kind;
+        }
+        k
+    });
     let coalesce_scratch = coalesce_scratch.filter(|_| coalesce_on);
-
-    features.clear();
-    features.shrink_to_fit(); // free the pass-1 O(N)·48B scratch before pass 2
 
     let num_levels = level_gsds.len();
     let finest = num_levels.saturating_sub(1);
+
+    // The ROW-indexed winner table pass 2 addresses (`row_offset + i`), one
+    // byte per input row. Skipped-geometry rows keep the UNASSIGNED sentinel,
+    // which matches no level in either mode (the level plan is capped at
+    // [`super::convert::MAX_LEVELS`] levels, so `finest < u8::MAX`).
+    let mut min_levels = vec![UNASSIGNED_LEVEL; num_rows];
+    for (f, &ml) in features.iter().zip(&feat_min_levels) {
+        min_levels[f.index] = ml;
+    }
 
     // Per-level winner counts (exact row counts in partitioning mode; in
     // duplicating mode exact up to simplification drops — used as the writer's
@@ -215,13 +246,15 @@ pub(super) fn convert_streaming(
     // rebuilt, with simplification, per level in pass 2 rather than held for
     // every level at once).
     let mut hist = vec![0usize; num_levels];
-    for (pos, &ml) in min_levels.iter().enumerate() {
-        if coalesce_scratch.is_some() && kinds.as_ref().is_some_and(|k| k[pos] == FeatureKind::Line)
-        {
+    for (f, &ml) in features.iter().zip(&feat_min_levels) {
+        if coalesce_scratch.is_some() && f.kind == FeatureKind::Line {
             continue; // counted via the per-level chain stage below
         }
         hist[(ml as usize).min(finest)] += 1;
     }
+    drop(feat_min_levels);
+    features.clear();
+    features.shrink_to_fit(); // free the pass-1 O(N)·48B scratch before pass 2
     let mut counts: Vec<usize> = match options.mode {
         Mode::Duplicating => hist
             .iter()
@@ -580,6 +613,11 @@ struct Pass1Output {
     acc_values: Vec<Vec<Option<f64>>>,
     /// Line geometries + groups for coalescing (Q3); `None` unless enabled.
     coalesce: Option<CoalesceScratch>,
+    /// Total input rows streamed (INCLUDING skipped-geometry rows): the
+    /// domain of every row-indexed table pass 2 addresses.
+    num_rows: usize,
+    /// Rows skipped for a null, empty, or non-finite geometry (H4).
+    skipped_rows: usize,
 }
 
 /// Pass 1: stream the input (geometry + ranking/accumulate columns only) and
@@ -624,15 +662,20 @@ fn run_pass1(
         .build()?;
 
     let mut features: Vec<AssignFeature> = Vec::new();
+    let mut num_rows = 0usize;
+    let mut skipped_rows = 0usize;
     let mut point_count = 0usize;
     let mut explicit_keys: Vec<Option<f64>> = Vec::new();
     let mut confidence_keys: Vec<Option<f64>> = Vec::new();
     let mut acc_values: Vec<Vec<Option<f64>>> = vec![Vec::new(); acc_cols.len()];
-    let mut geoms_buf: Vec<Geometry<f64>> = Vec::new();
+    let mut geoms_buf: Vec<Option<Geometry<f64>>> = Vec::new();
     // Coalescing (Q3): line rows + geometries, and — for an explicit class
-    // ranking — the interned per-row class groups.
+    // ranking — the interned per-row class groups. `line_feat_pos` holds each
+    // line's position in `features` (NOT its row index: skipped-geometry rows
+    // make the two diverge).
     let collect_lines = options.coalesce_lines;
     let mut line_rows: Vec<usize> = Vec::new();
+    let mut line_feat_pos: Vec<usize> = Vec::new();
     let mut line_geoms: Vec<Geometry<f64>> = Vec::new();
     let mut explicit_groups: Vec<u32> = Vec::new();
     let mut explicit_interner = GroupInterner::default();
@@ -645,16 +688,26 @@ fn run_pass1(
         let garr = from_arrow_array(batch.column(gcol_idx).as_ref(), gfield)
             .map_err(|e| crate::Error::GeoParquetRead(format!("geometry decode: {e}")))?;
         geoms_buf.clear();
-        extract_geometries_from_array(garr.as_ref(), &mut geoms_buf)?;
+        extract_geometries_opt_from_array(garr.as_ref(), &mut geoms_buf)?;
 
-        let base = features.len();
-        for (i, g) in geoms_buf.iter().enumerate() {
+        // `AssignFeature::index` is the GLOBAL ROW index: pass 2 addresses the
+        // winner tables by raw row position. Rows with a null, empty, or
+        // non-finite geometry produce no feature but still advance the row
+        // index, so every row-keyed table stays aligned (H4 hardening; a
+        // skipped row must never shift attributes onto a neighbor's geometry).
+        let base = num_rows;
+        for (i, gopt) in geoms_buf.iter().enumerate() {
+            let Some(g) = gopt.as_ref().filter(|g| usable_geometry(g)) else {
+                skipped_rows += 1;
+                continue;
+            };
             let kind = feature_kind(g);
             if matches!(kind, FeatureKind::Point) {
                 point_count += 1;
             }
             if collect_lines && matches!(kind, FeatureKind::Line) {
                 line_rows.push(base + i);
+                line_feat_pos.push(features.len());
                 line_geoms.push(g.clone());
             }
             features.push(AssignFeature {
@@ -664,6 +717,7 @@ fn run_pass1(
                 sort_key: None, // filled below once the ranking tier resolves
             });
         }
+        num_rows += geoms_buf.len();
 
         match &mut plan {
             RankPlan::ExplicitSort { idx, .. } => {
@@ -784,15 +838,22 @@ fn run_pass1(
     };
 
     if let Some(keys) = keys {
-        debug_assert_eq!(keys.len(), features.len());
-        for (f, k) in features.iter_mut().zip(keys) {
-            f.sort_key = k;
+        // Keys are extracted per ROW (including skipped-geometry rows), so
+        // they are looked up by each feature's row index, not zipped
+        // positionally.
+        debug_assert_eq!(keys.len(), num_rows);
+        for f in features.iter_mut() {
+            f.sort_key = keys[f.index];
         }
     }
 
-    // Coalescing scratch (Q3): line sort keys + per-line groups.
+    // Coalescing scratch (Q3): line sort keys + per-line groups. `rows` and
+    // `groups` are row-indexed; sort keys live on the features.
     let coalesce = collect_lines.then(|| CoalesceScratch {
-        sort_keys: line_rows.iter().map(|&r| features[r].sort_key).collect(),
+        sort_keys: line_feat_pos
+            .iter()
+            .map(|&p| features[p].sort_key)
+            .collect(),
         groups: all_groups.map(|g| line_rows.iter().map(|&r| g[r]).collect()),
         rows: line_rows,
         geoms: line_geoms,
@@ -803,6 +864,8 @@ fn run_pass1(
         provenance,
         acc_values,
         coalesce,
+        num_rows,
+        skipped_rows,
     })
 }
 


### PR DESCRIPTION
Closes #173.

Systematically feeds garbage to the overview pipeline (convert / validate / export) per the H4 checklist. Every input class now either produces correct output or fails fast with a typed, actionable error — no panics, no silent wrong output. All fixtures are generated programmatically in a new test module, `crates/core/src/overview/hostile.rs` (27 tests); no binary fixtures checked in.

## Input classes

| Class | Behavior now | Tests |
|---|---|---|
| Empty file (0 rows) | `ConvertError::NoData` (both pipelines) | `empty_input_zero_rows_errors_nodata` |
| All-null geometry column | `ConvertError::NoData` | `all_null_geometry_errors_nodata` |
| **Interleaved null geometries** | **Fixed a real bug**: rows skipped with a warning, winner tables now row-aligned. Previously the streaming pass 2 panicked (index OOB at `stream.rs:971`) and the in-memory path silently paired attributes with a *neighboring row's geometry* | `partial_null_geometry_rows_skipped_with_aligned_attributes` |
| NaN/Inf coordinates | Rows skipped with a warning (previously silently collapsed into grid cell (0,0) and leaked NaN geometry into output) | `nonfinite_coordinate_rows_skipped` |
| Zero-coordinate (empty) geometries | Skipped with a warning (previously parked at a fabricated `[0,0,0,0]` bbox) | `empty_coordinate_geometries_skipped` |
| Empty/corrupt WKB value | Typed `GeoParquetRead` error, no panic | `empty_wkb_value_errors_typed` |
| Self-intersecting polygon | Carried through; output validates | `self_intersecting_polygon_converts` |
| Mixed geometry types | Already covered by existing `convert::tests` synthetics (points+lines+polygons) | existing suite |
| GeometryCollections | Pass through (treated as polygon-kind for thinning), survive to canonical | `geometry_collection_passes_through` |
| Antimeridian / pole-adjacent | Convert + validate cleanly | `antimeridian_and_pole_features_convert` |
| Degenerate extents (single point / all-identical / extent < finest GSD) | Correct output (1 winner per coarse level, all rows at canonical) | `single_point_dataset_converts`, `all_identical_geometries_convert`, `extent_smaller_than_finest_gsd_converts` |
| `min_zoom > max_zoom` | `ConvertError::InvalidLevels` (pre-existing; now covered by a test) | `min_zoom_greater_than_max_zoom_rejected` |
| 40+ zoom levels | Works; output validates | `forty_plus_zoom_levels_convert` |
| >255 levels | New: `InvalidLevels` (winner tables are u8-indexed; `u8::MAX` is now a reserved sentinel — previously wrapped silently) | `more_than_255_levels_rejected` |
| `gsd_base` 0/negative/NaN/Inf | New typed `ConvertError::InvalidConfig` (previously surfaced as a deep writer error, `levels[1].gsd = inf ...`) | `gsd_base_extremes_rejected` |
| Thinning 0/negative/NaN | New: `InvalidConfig` (previously silently degenerated the grid — everything fell to the canonical level, `Ok` with wrong output) | `thinning_zero_negative_nan_rejected` |
| Visibility negative/NaN | New: `InvalidConfig` | `visibility_negative_nan_rejected` |
| `coalesce_snap` / `coalesce_junction_angle` NaN | New: `InvalidConfig` (`<= 0` remains the documented OFF switch) | `coalesce_nan_knobs_rejected` |
| Reserved columns `LEVEL` / `Point_Count` / `COALESCED_COUNT` (any casing) | Verified: rejected case-insensitively (pre-existing behavior, now pinned by tests) | `reserved_columns_rejected_case_insensitive` |
| Zero-row levels after thinning | Verified across routes: empty levels omitted + renumbered on the plain, coalescing (on/off), and clustering routes, in both pipelines; residual simplify-degeneracy stays the documented typed `WriterError::EmptyLevel` fail-fast | `empty_coarse_levels_omitted_across_pipelines`, `empty_coarse_levels_omitted_with_clustering` |
| Non-4326/3857 CRS | Verified: existing typed `UnsupportedCrs` with actionable message (existing test `rejects_unsupported_crs`) | existing suite |
| export on non-overview parquet | `ExportError::Reader(MissingOverviewsKey)` | `export_non_overview_parquet_errors` |
| export on truncated file | Typed reader/parquet error, no panic | `export_truncated_file_errors` |
| export footer/data mismatch | **Fixed**: `OverviewReader::open` now runs `OverviewsMeta::validate(num_row_groups)` and rejects with new `ReaderError::InvalidMetadata`. Previously an out-of-range `row_group_end` panicked inside parquet's arrow_reader, and a negative one would wrap through `as usize` into a huge band range | `export_footer_data_mismatch_errors`, `reader_rejects_negative_row_group_end` |
| export on partitioning-mode file | Verified supported | `export_partitioning_mode_file_works` (+ existing export tests) |

## Core changes

- `batch_processor.rs`: new `extract_geometries_opt_from_array` (row-aligned, one `Option` per slot); `extract_geometries_from_array` delegates to it, unchanged behavior for existing callers.
- `overview/stream.rs`: pass 1 tracks a global row counter; skipped rows advance the row index without producing a feature; row-indexed winner/kind tables are scattered by feature row index with a `u8::MAX` "unassigned" sentinel; sort keys looked up by row index instead of positional zip; cluster accumulate values remapped row→feature order.
- `overview/convert.rs`: in-memory path filters the materialized batch and geometry vector together before any indexing; new `usable_geometry` gate (finite, non-empty); new `validate_options` + `ConvertError::InvalidConfig`; level plans capped at 255 levels (`MAX_LEVELS`).
- `overview/reader.rs`: footer structural validation on open + `ReaderError::InvalidMetadata`.

## Out of scope (explicit)

- **Fuzz/property test for the assign stage**: listed as a *stretch goal* in the issue; not included here. The deterministic hostile classes above cover the checklist proper.
- **Antimeridian geometry *splitting***: the pipeline stores geometries verbatim (spec: no reprojection/clipping at convert time); the H4 requirement is only that such inputs never crash or corrupt, which is what the test pins.

## Verification

- TDD: all 10 originally-failing tests verified red first (2 were library panics), then green per commit.
- `cargo test -p gpq-tiles-core --lib -- overview:: batch_processor::` → 234 passed, 0 failed.
- `cargo fmt --all` clean, `cargo clippy -p gpq-tiles-core --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)