### PR TITLE
feat(core): align output with spec v0.2.0 (provenance completeness, ranks map, strict cluster invariant)

### DIFF
--- a/crates/core/src/overview/check.rs
+++ b/crates/core/src/overview/check.rs
@@ -101,11 +101,18 @@ struct GeoDoc {
 }
 
 /// Validate an overview file at `path` against the §6.2 conformance checklist.
+///
+/// Runs every metadata-only check of [`validate_metadata`], plus the
+/// data-reading §12.1 cluster sum-invariant check (which needs the column
+/// values, not just row-group statistics).
 pub fn validate_file<P: AsRef<Path>>(path: P) -> Result<ValidationReport, CheckError> {
+    let path = path.as_ref();
     let file = File::open(path)?;
     let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
     let metadata = builder.metadata().clone();
-    Ok(validate_metadata(&metadata))
+    let mut report = validate_metadata(&metadata);
+    check_cluster_sum_invariant(path, &metadata, &mut report);
+    Ok(report)
 }
 
 /// Run the §6.2 checklist against already-parsed Parquet metadata.
@@ -569,6 +576,171 @@ fn check_coalescing(
     }
 }
 
+/// §12.1 strict cluster sum invariant (data-reading check, `validate_file`
+/// only): when clustering provenance is present and enabled on a structurally
+/// sound duplicating file, every level's `Σ point_count` over its **point**
+/// rows must equal the source point count exactly — taken as the number of
+/// point rows in the canonical band, which is the source data verbatim
+/// (§2.4). Implies the derived producer obligation: no clustered level may
+/// thin its points to zero while the source contains points.
+///
+/// Skipped (no report entry) when the prerequisites are missing — the
+/// structural checks of [`validate_metadata`] already fail those files.
+fn check_cluster_sum_invariant(
+    path: &Path,
+    metadata: &ParquetMetaData,
+    report: &mut ValidationReport,
+) {
+    // Prerequisites: parseable footer, enabled clustering, duplicating mode
+    // with a valid canonical level, the named INT64 count column, the level
+    // column, and a geometry column (needed to tell point rows apart).
+    let Some(meta) =
+        footer_value(metadata, OVERVIEWS_KEY).and_then(|j| OverviewsMeta::from_json(&j).ok())
+    else {
+        return;
+    };
+    let Some(clustering) = meta
+        .generalization
+        .as_ref()
+        .and_then(|g| g.clustering.as_ref())
+        .filter(|c| c.enabled)
+    else {
+        return;
+    };
+    if meta.mode != Some(Mode::Duplicating) {
+        return; // cluster_mode already failed
+    }
+    let Some(canonical) = meta.canonical_level.filter(|&c| c >= 0) else {
+        return; // mode_canonical already failed
+    };
+
+    match cluster_sum_by_level(path, &meta, clustering) {
+        Err(e) => report.fail(
+            "cluster_sum_invariant",
+            format!("could not read cluster columns: {e}"),
+        ),
+        Ok(None) => { /* prerequisite column absent: already failed elsewhere */ }
+        Ok(Some(per_level)) => {
+            let Some(&(_, expected)) = per_level.get(canonical as usize) else {
+                return; // canonical band outside levels: structure failed
+            };
+            let mut problems: Vec<String> = Vec::new();
+            for (level, &(point_rows, sum)) in per_level.iter().enumerate() {
+                if expected > 0 && point_rows == 0 {
+                    problems.push(format!(
+                        "level {level} has no point row to absorb {expected} \
+                         source points"
+                    ));
+                } else if sum != expected {
+                    problems.push(format!(
+                        "level {level}: sum(point_count) over point rows = \
+                         {sum}, expected source point count {expected}"
+                    ));
+                }
+            }
+            if problems.is_empty() {
+                report.pass(
+                    "cluster_sum_invariant",
+                    format!(
+                        "every level's point_count sums to the source point \
+                         count ({expected}) (§12.1)"
+                    ),
+                );
+            } else {
+                report.fail("cluster_sum_invariant", problems.join("; "));
+            }
+        }
+    }
+}
+
+/// Per level: `(point-row count, Σ point_count over point rows)`, read from
+/// the file with a projection over the geometry / `level` / count columns.
+/// `Ok(None)` when a prerequisite column is missing from the schema.
+#[allow(clippy::type_complexity)]
+fn cluster_sum_by_level(
+    path: &Path,
+    meta: &OverviewsMeta,
+    clustering: &crate::overview::level::ClusteringProvenance,
+) -> Result<Option<Vec<(usize, i64)>>, String> {
+    use arrow_array::cast::AsArray;
+    use arrow_array::types::{Int32Type, Int64Type};
+    use geoarrow::array::from_arrow_array;
+    use parquet::arrow::ProjectionMask;
+
+    use super::convert::{feature_kind, find_geometry_column};
+    use crate::batch_processor::extract_geometries_opt_from_array;
+
+    let file = File::open(path).map_err(|e| e.to_string())?;
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file).map_err(|e| e.to_string())?;
+    let schema = builder.schema().clone();
+
+    let Some(geom_idx) = find_geometry_column(&schema) else {
+        return Ok(None);
+    };
+    let Ok(pc_idx) = schema.index_of(&clustering.point_count_column) else {
+        return Ok(None);
+    };
+    let Ok(level_idx) = schema.index_of(LEVEL_COLUMN) else {
+        return Ok(None);
+    };
+    let geom_field = schema.field(geom_idx).clone();
+
+    let mask = ProjectionMask::roots(builder.parquet_schema(), [geom_idx, pc_idx, level_idx]);
+    let reader = builder
+        .with_projection(mask)
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let mut per_level: Vec<(usize, i64)> = vec![(0, 0); meta.levels.len()];
+    let mut geoms: Vec<Option<geo::Geometry<f64>>> = Vec::new();
+    for batch in reader {
+        let batch = batch.map_err(|e| e.to_string())?;
+        let bschema = batch.schema();
+        let g = batch.column(
+            bschema
+                .index_of(geom_field.name())
+                .map_err(|e| e.to_string())?,
+        );
+        let levels = batch
+            .column(bschema.index_of(LEVEL_COLUMN).map_err(|e| e.to_string())?)
+            .as_primitive::<Int32Type>()
+            .clone();
+        let counts = batch
+            .column(
+                bschema
+                    .index_of(&clustering.point_count_column)
+                    .map_err(|e| e.to_string())?,
+            )
+            .as_primitive::<Int64Type>()
+            .clone();
+
+        let garr = from_arrow_array(g.as_ref(), &geom_field)
+            .map_err(|e| format!("geometry decode: {e}"))?;
+        geoms.clear();
+        extract_geometries_opt_from_array(garr.as_ref(), &mut geoms)
+            .map_err(|e| format!("geometry decode: {e}"))?;
+
+        for (i, geom) in geoms.iter().enumerate() {
+            // Only point rows participate in the sum (§12.1); null geometry
+            // rows (foreign writers) cannot be classified and are skipped.
+            let is_point = geom
+                .as_ref()
+                .is_some_and(|g| feature_kind(g) == super::assign::FeatureKind::Point);
+            if !is_point {
+                continue;
+            }
+            let level = levels.value(i);
+            if level < 0 || level as usize >= per_level.len() {
+                return Err(format!("row carries out-of-range level {level}"));
+            }
+            let entry = &mut per_level[level as usize];
+            entry.0 += 1;
+            entry.1 += counts.value(i);
+        }
+    }
+    Ok(Some(per_level))
+}
+
 /// Per-RG `level` column statistics must be `min == max ==` the footer-implied
 /// level for that RG index (§4.1). Records one summarizing entry.
 fn check_level_footer_consistency(
@@ -940,11 +1112,14 @@ mod tests {
 
     #[test]
     fn clustering_good_file_passes() {
+        // Fixture geometry: even ids are points, odd ids polygons. Canonical
+        // level [0, 1, 2] has 2 source points (0, 2); the level-0 point row
+        // (id 0) must carry point_count 2 (§12.1 sum invariant).
         let tmp = tempfile::NamedTempFile::new().unwrap();
         write_cluster_fixture(
             tmp.path(),
             &[vec![0], vec![0, 1, 2]],
-            Some(&[vec![3], vec![1, 1, 1]]),
+            Some(&[vec![2], vec![1, 1, 1]]),
         );
         let report = validate_file(tmp.path()).unwrap();
         assert!(
@@ -960,6 +1135,53 @@ mod tests {
         assert_eq!(
             report.check_passed("cluster_point_count_values"),
             Some(true)
+        );
+        assert_eq!(report.check_passed("cluster_sum_invariant"), Some(true));
+    }
+
+    #[test]
+    fn clustering_sum_invariant_violation_fails() {
+        // Row-group statistics are conformant (min >= 1, canonical all 1),
+        // but the level-0 point sums to 3 while the source holds 2 points:
+        // an absorbed point was double counted (§12.1). Only the sum check
+        // catches this.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        write_cluster_fixture(
+            tmp.path(),
+            &[vec![0], vec![0, 1, 2]],
+            Some(&[vec![3], vec![1, 1, 1]]),
+        );
+        let report = validate_file(tmp.path()).unwrap();
+        assert!(!report.is_valid());
+        assert_eq!(
+            report.check_passed("cluster_point_count_values"),
+            Some(true),
+            "stats-level checks must stay green (the violation is data-level)"
+        );
+        assert_eq!(report.check_passed("cluster_sum_invariant"), Some(false));
+    }
+
+    #[test]
+    fn clustering_level_without_point_row_fails() {
+        // Level 0 holds only a polygon (id 1) while the source has 2 points:
+        // the derived producer obligation (§12.1) requires a surviving point
+        // row per clustered level to absorb the counts.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        write_cluster_fixture(
+            tmp.path(),
+            &[vec![1], vec![0, 1, 2]],
+            Some(&[vec![1], vec![1, 1, 1]]),
+        );
+        let report = validate_file(tmp.path()).unwrap();
+        assert!(!report.is_valid());
+        let failed = report
+            .failures()
+            .find(|c| c.name == "cluster_sum_invariant")
+            .expect("cluster_sum_invariant must fail");
+        assert!(
+            failed.message.contains("no point row"),
+            "unexpected message: {}",
+            failed.message
         );
     }
 

--- a/crates/core/src/overview/check.rs
+++ b/crates/core/src/overview/check.rs
@@ -1053,6 +1053,8 @@ mod tests {
             coalescing: Some(CoalescingProvenance {
                 enabled: true,
                 snap_tolerance_gsd_factor: 1.0,
+                junction_angle: Some(0.0),
+                max_level_rows: Some(2_000_000),
                 coalesced_count_column: "coalesced_count".to_string(),
             }),
         });

--- a/crates/core/src/overview/cluster.rs
+++ b/crates/core/src/overview/cluster.rs
@@ -324,6 +324,60 @@ pub fn build_cluster_tables(
     tables
 }
 
+/// Verify the strict §12.1 accounting / sum invariant over freshly built
+/// cluster tables: at every level, every source point feature is counted in
+/// exactly one point row of that level, so `Σ point_count` over a level's
+/// point rows equals the total source point count exactly — under any drop
+/// mechanism (cell-winner thinning, density budget, their interactions).
+///
+/// Also asserts the derived producer obligation: a clustered level MUST NOT
+/// thin its points to zero while the source contains points — there must be
+/// a surviving point row to absorb the re-assignments.
+///
+/// Inputs are the exact arguments/results of [`build_cluster_tables`]
+/// (`min_levels` parallel to `features`). Returns a human-readable violation
+/// description; callers surface it as a conversion error.
+pub fn verify_sum_invariant(
+    features: &[AssignFeature],
+    min_levels: &[u8],
+    tables: &ClusterTables,
+) -> Result<(), String> {
+    debug_assert_eq!(features.len(), min_levels.len());
+    let total: i64 = features
+        .iter()
+        .filter(|f| f.kind == FeatureKind::Point)
+        .count() as i64;
+    if total == 0 {
+        return Ok(()); // no source points: nothing to account for
+    }
+    for (level, table) in tables.iter().enumerate() {
+        let mut sum = 0i64;
+        let mut point_rows = 0usize;
+        for (f, &ml) in features.iter().zip(min_levels) {
+            if f.kind != FeatureKind::Point || ml as usize > level {
+                continue;
+            }
+            point_rows += 1;
+            sum += table.get(&f.index).map_or(1, |e| e.point_count);
+        }
+        if point_rows == 0 {
+            return Err(format!(
+                "clustered level {level} has no surviving point row to absorb \
+                 {total} source points (spec §12.1: a clustered level cannot \
+                 thin points to zero while the source contains points)"
+            ));
+        }
+        if sum != total {
+            return Err(format!(
+                "clustered level {level}: sum(point_count) over point rows = \
+                 {sum}, expected the source point count {total} (spec §12.1 \
+                 sum invariant)"
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Deterministic nearest present point feature to the center of `cell_key`,
 /// searched over expanding Chebyshev rings of the level grid. Among the
 /// candidates of the first non-empty ring, the one with the smallest squared
@@ -739,6 +793,65 @@ mod tests {
         };
         let t = build_cluster_tables(&[poly], &[0], &gsds, &cfg, Crs::Epsg3857, &[], &[]);
         assert!(t.iter().all(|m| m.is_empty()));
+    }
+
+    /// §12.1 verifier: a healthy table set (including a simulated
+    /// density-budget orphan) passes; the pathological zero-survivor level
+    /// (every point deferred past a level) is rejected with the derived
+    /// producer obligation, and a doctored table is rejected by the sum rule.
+    #[test]
+    fn verify_sum_invariant_pass_orphan_and_zero_survivor() {
+        let cell = 4.0 * gsd(2);
+        let feats = vec![
+            point(0, 0.5 * cell, 0.0),
+            point(1, 1.5 * cell, 0.0), // orphan cell (deferred winner)
+            point(2, 4.5 * cell, 0.0),
+        ];
+        let gsds = [gsd(2), gsd(10)];
+        let cfg = AssignConfig::default();
+
+        // Orphan absorbed by nearest survivor: invariant holds.
+        let min_levels = vec![0u8, 1, 0];
+        let tables =
+            build_cluster_tables(&feats, &min_levels, &gsds, &cfg, Crs::Epsg3857, &[], &[]);
+        verify_sum_invariant(&feats, &min_levels, &tables).unwrap();
+
+        // Zero survivors at level 0 (every point deferred): build silently
+        // skips the level, the verifier MUST reject it (spec §12.1).
+        let all_deferred = vec![1u8, 1, 1];
+        let tables =
+            build_cluster_tables(&feats, &all_deferred, &gsds, &cfg, Crs::Epsg3857, &[], &[]);
+        let err = verify_sum_invariant(&feats, &all_deferred, &tables).unwrap_err();
+        assert!(
+            err.contains("no surviving point row"),
+            "unexpected message: {err}"
+        );
+
+        // Doctored table (a lost absorption): sum rule rejects.
+        let min_levels = vec![0u8, 1, 0];
+        let mut tables =
+            build_cluster_tables(&feats, &min_levels, &gsds, &cfg, Crs::Epsg3857, &[], &[]);
+        tables[0].clear(); // drop the 2-point cluster entry → sum 2, not 3
+        let err = verify_sum_invariant(&feats, &min_levels, &tables).unwrap_err();
+        assert!(err.contains("sum invariant"), "unexpected message: {err}");
+    }
+
+    /// The verifier is a no-op for point-free inputs (lines/polygons only).
+    #[test]
+    fn verify_sum_invariant_no_points_is_ok() {
+        let poly = AssignFeature {
+            index: 0,
+            bbox: [0.0, 0.0, 50_000.0, 50_000.0],
+            kind: FeatureKind::Polygon,
+            sort_key: None,
+        };
+        let gsds = [gsd(2), gsd(6)];
+        let cfg = AssignConfig::default();
+        let feats = vec![poly];
+        let min_levels = vec![0u8];
+        let tables =
+            build_cluster_tables(&feats, &min_levels, &gsds, &cfg, Crs::Epsg3857, &[], &[]);
+        verify_sum_invariant(&feats, &min_levels, &tables).unwrap();
     }
 
     #[test]

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -1614,6 +1614,11 @@ pub(super) fn build_generalization(
             Some(CoalescingProvenance {
                 enabled: true,
                 snap_tolerance_gsd_factor: options.coalesce_snap,
+                // §13.4 (v0.2.0): the junction-continuation threshold and the
+                // per-level candidate ceiling are REQUIRED provenance so the
+                // generalization is reproducible from the file alone.
+                junction_angle: Some(options.coalesce_junction_angle),
+                max_level_rows: Some(options.coalesce_max_level_rows as u64),
                 coalesced_count_column: COALESCED_COUNT_COLUMN.to_string(),
             })
         } else {
@@ -1742,9 +1747,11 @@ fn resolve_ranking(
 }
 
 /// Provenance for a categorical class ranking, echoing the map when small.
+/// The footer shape is a JSON object map (spec §3.5 v0.2.0), so the ordered
+/// pair list collapses into a `BTreeMap` here.
 pub(super) fn class_ranking_provenance(mode: &str, cr: &ClassRanking) -> RankingProvenance {
     let ranks = if cr.ranks.len() <= MAX_PROVENANCE_RANKS {
-        Some(cr.ranks.clone())
+        Some(cr.ranks.iter().cloned().collect())
     } else {
         None
     };
@@ -2614,8 +2621,19 @@ mod tests {
             .unwrap();
         assert_eq!(r.mode, "class-ranking");
         assert_eq!(r.column.as_deref(), Some("road_class"));
-        assert_eq!(r.ranks.unwrap().len(), 2);
+        let ranks = r.ranks.unwrap();
+        assert_eq!(ranks.len(), 2);
+        assert_eq!(ranks.get("motorway"), Some(&5.0));
+        assert_eq!(ranks.get("footway"), Some(&1.0));
         assert_eq!(r.unknown_rank, Some(0.0));
+
+        // §3.5 (v0.2.0): the footer JSON carries ranks as an object map, not
+        // an array of pairs.
+        let json = overviews_footer_json(tout.path());
+        assert!(
+            json.contains(r#""ranks":{"footway":1.0,"motorway":5.0}"#),
+            "footer must serialize ranks as an object map, got {json}"
+        );
     }
 
     // --- Q1 regression: high class beats larger low class in a shared cell ---
@@ -3661,6 +3679,8 @@ mod tests {
         let opts = ConvertOptions {
             coalesce_lines: true,
             coalesce_snap: 1.5,
+            coalesce_junction_angle: 30.0,
+            coalesce_max_level_rows: 123_456,
             ..Default::default()
         };
         convert_to_overviews(tin.path(), tout.path(), &opts).unwrap();
@@ -3675,6 +3695,10 @@ mod tests {
             .expect("coalescing provenance recorded");
         assert!(c.enabled);
         assert_eq!(c.snap_tolerance_gsd_factor, 1.5);
+        // §13.4 (v0.2.0): junction angle + memory-guard ceiling recorded so
+        // the generalization is reproducible from the file alone.
+        assert_eq!(c.junction_angle, Some(30.0));
+        assert_eq!(c.max_level_rows, Some(123_456));
         assert_eq!(c.coalesced_count_column, "coalesced_count");
 
         // Opt-out (`--no-coalesce-lines`): no coalescing block recorded.

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -52,7 +52,9 @@ use super::assign::{
     apply_density_budget, assign_levels, AssignConfig, AssignFeature, DensityBudgetConfig,
     FeatureKind, SUPERCELL_GSD_FACTOR,
 };
-use super::cluster::{build_cluster_tables, AccumulateSpec, ClusterEntry, POINT_COUNT_COLUMN};
+use super::cluster::{
+    build_cluster_tables, verify_sum_invariant, AccumulateSpec, ClusterEntry, POINT_COUNT_COLUMN,
+};
 use super::coalesce::{
     coalesce_level_lines, CoalesceInput, CoalesceParams, COALESCED_COUNT_COLUMN,
     DEFAULT_COALESCE_MAX_LEVEL_ROWS, DEFAULT_JUNCTION_ANGLE_DEG, DEFAULT_SNAP_GSD_FACTOR,
@@ -531,6 +533,14 @@ pub enum ConvertError {
     /// The input has no features, or every feature was dropped from every level.
     #[error("no output rows produced (empty input or all features dropped)")]
     NoData,
+    /// The strict cluster accounting / sum invariant (spec §12.1) was
+    /// violated while building the per-level cluster tables: a level's
+    /// `point_count` values would not partition the source point set (or a
+    /// clustered level thinned its points to zero with source points left
+    /// to absorb). This is a producer bug guard — a conforming conversion
+    /// can never trip it.
+    #[error("cluster invariant violated (spec §12.1): {0}")]
+    ClusterInvariant(String),
 }
 
 /// Convert a GeoParquet file into a multi-resolution overview GeoParquet file.
@@ -773,7 +783,7 @@ pub fn convert_to_overviews(
         let min_levels: Vec<u8> = assignment.assignments.iter().map(|a| a.min_level).collect();
         let acc_values = extract_accumulate_values(&full, &acc_cols);
         let ops: Vec<_> = options.accumulate.iter().map(|s| s.op).collect();
-        Some(build_cluster_tables(
+        let tables = build_cluster_tables(
             &features,
             &min_levels,
             &level_gsds,
@@ -781,7 +791,12 @@ pub fn convert_to_overviews(
             crs,
             &acc_values,
             &ops,
-        ))
+        );
+        // Strict §12.1 accounting: Σ point_count per level == source point
+        // count, and no clustered level thins its points to zero.
+        verify_sum_invariant(&features, &min_levels, &tables)
+            .map_err(ConvertError::ClusterInvariant)?;
+        Some(tables)
     } else {
         None
     };
@@ -3108,6 +3123,76 @@ mod tests {
         assert!(coarse.iter().any(|&c| c > 1), "no clustering happened");
         assert!(coarse.len() < geoms.len());
         assert_eq!(report.levels.last().unwrap().feature_count, geoms.len());
+    }
+
+    /// §12.1 sum-invariant property across knob combinations: clustering
+    /// crossed with the density budget (on/off), point-thinning grid sizes,
+    /// and both pipelines (streaming / in-memory) — every produced file must
+    /// partition the source point set at every level, pass the
+    /// `cluster_sum_invariant` validator rule, and keep a singleton-only
+    /// canonical band. Coalescing stays at its default (on): it only touches
+    /// lines and must not interact with point accounting.
+    #[test]
+    fn cluster_sum_invariant_across_knob_combinations() {
+        let geoms = grid_points(300);
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        write_input(tin.path(), &geoms, false, None);
+
+        for streaming in [true, false] {
+            for density in [true, false] {
+                for thinning in [2.0, 8.0] {
+                    let tout = tempfile::NamedTempFile::new().unwrap();
+                    let mut opts = ConvertOptions {
+                        levels: LevelPlan::ZoomRange {
+                            min_zoom: 0,
+                            max_zoom: 6,
+                        },
+                        cluster: true,
+                        streaming,
+                        ..Default::default()
+                    };
+                    opts.density.enabled = density;
+                    opts.assign.point_thinning = thinning;
+                    let label =
+                        format!("streaming={streaming} density={density} thinning={thinning}");
+                    convert_to_overviews(tin.path(), tout.path(), &opts)
+                        .unwrap_or_else(|e| panic!("{label}: {e}"));
+
+                    let vr = validate_file(tout.path()).unwrap();
+                    assert!(
+                        vr.is_valid(),
+                        "{label}: failures: {:?}",
+                        vr.failures().collect::<Vec<_>>()
+                    );
+                    assert_eq!(
+                        vr.check_passed("cluster_sum_invariant"),
+                        Some(true),
+                        "{label}"
+                    );
+
+                    let reader = OverviewReader::open(tout.path()).unwrap();
+                    let canonical = reader.num_levels() - 1;
+                    for level in 0..reader.num_levels() {
+                        let counts = read_point_counts(&reader, level);
+                        assert!(
+                            !counts.is_empty(),
+                            "{label}: level {level} thinned points to zero"
+                        );
+                        assert_eq!(
+                            counts.iter().sum::<i64>(),
+                            geoms.len() as i64,
+                            "{label}: level {level} must partition the source set"
+                        );
+                    }
+                    assert!(
+                        read_point_counts(&reader, canonical)
+                            .iter()
+                            .all(|&c| c == 1),
+                        "{label}: canonical band must be singleton-only"
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/core/src/overview/level.rs
+++ b/crates/core/src/overview/level.rs
@@ -10,7 +10,9 @@
 //! files, behind an explicit writer flag — an optional COGP-compatible subset
 //! under [`COGP_KEY`].
 
-use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Deserializer, Serialize};
 
 /// Footer metadata key under which the overviews JSON object is stored.
 ///
@@ -175,6 +177,19 @@ pub struct CoalescingProvenance {
     /// Endpoint snap tolerance in GSD multiples (per level, the snap
     /// distance is `snap_tolerance_gsd_factor × gsd`).
     pub snap_tolerance_gsd_factor: f64,
+    /// Junction continuation threshold, degrees (`0` = strict degree-2
+    /// chaining; §13.4). REQUIRED on v0.2.0 writers; `None` only when
+    /// reading a file written before the member existed — readers MUST
+    /// treat absence as *unknown*, never as an implied default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub junction_angle: Option<f64>,
+    /// Per-level candidate-line ceiling (§13.4): levels whose candidate
+    /// line count exceeded it were written uncoalesced (memory guard).
+    /// REQUIRED on v0.2.0 writers; `None` only when reading a file written
+    /// before the member existed — readers MUST treat absence as
+    /// *unknown*, never as an implied default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_level_rows: Option<u64>,
     /// Name of the merged-segment-count column (this implementation:
     /// `coalesced_count`).
     pub coalesced_count_column: String,
@@ -242,12 +257,44 @@ pub struct RankingProvenance {
     pub column: Option<String>,
     /// The categorical value→priority map, when small enough to be useful
     /// (class-ranking tiers only). Higher priority wins the cell.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ranks: Option<Vec<(String, f64)>>,
+    ///
+    /// Serialized as a JSON object map (spec §3.5 v0.2.0), e.g.
+    /// `{"motorway": 5, "primary": 4}`. Deserialization additionally
+    /// accepts the legacy array-of-pairs shape (`[["motorway", 5.0], …]`)
+    /// emitted by gpq-tiles ≤ the 0.1.0/interim footers, so older files
+    /// keep reading; only the map shape is ever written.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_ranks"
+    )]
+    pub ranks: Option<BTreeMap<String, f64>>,
     /// Priority assigned to a present-but-unrecognized categorical value
     /// (class-ranking tiers only). Loses to every named rank, beats a null.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unknown_rank: Option<f64>,
+}
+
+/// Deserialize [`RankingProvenance::ranks`], accepting both the v0.2.0
+/// object-map shape (`{"motorway": 5.0}`) and the legacy array-of-pairs
+/// shape (`[["motorway", 5.0]]`) that pre-alignment gpq-tiles footers
+/// carry. Only the map shape is ever serialized.
+fn deserialize_ranks<'de, D>(deserializer: D) -> Result<Option<BTreeMap<String, f64>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum RanksShape {
+        Map(BTreeMap<String, f64>),
+        LegacyPairs(Vec<(String, f64)>),
+    }
+    Ok(
+        Option::<RanksShape>::deserialize(deserializer)?.map(|s| match s {
+            RanksShape::Map(m) => m,
+            RanksShape::LegacyPairs(pairs) => pairs.into_iter().collect(),
+        }),
+    )
 }
 
 /// One entry of the [`Generalization`] provenance block (§3.5).
@@ -849,10 +896,10 @@ mod tests {
             ranking: Some(RankingProvenance {
                 mode: "auto-overture-roads".to_string(),
                 column: Some("road_class".to_string()),
-                ranks: Some(vec![
+                ranks: Some(BTreeMap::from([
                     ("motorway".to_string(), 18.0),
                     ("service".to_string(), 11.0),
-                ]),
+                ])),
                 unknown_rank: Some(0.0),
             }),
             density_drop: None,
@@ -860,6 +907,11 @@ mod tests {
             coalescing: None,
         });
         let json = meta.to_json().unwrap();
+        // v0.2.0 (§3.5): ranks serialize as a JSON object map, NOT pairs.
+        assert!(
+            json.contains(r#""ranks":{"motorway":18.0,"service":11.0}"#),
+            "ranks must serialize as an object map, got {json}"
+        );
         let parsed = OverviewsMeta::from_json(&json).unwrap();
         assert_eq!(meta, parsed);
         let r = parsed.generalization.unwrap().ranking.unwrap();
@@ -867,6 +919,38 @@ mod tests {
         assert_eq!(r.column.as_deref(), Some("road_class"));
         assert_eq!(r.unknown_rank, Some(0.0));
         assert_eq!(r.ranks.unwrap().len(), 2);
+    }
+
+    #[test]
+    fn ranking_ranks_legacy_array_of_pairs_still_reads() {
+        // Files written before the v0.2.0 alignment carry ranks as an array
+        // of [value, priority] pairs; readers accept both shapes but only
+        // ever emit the map.
+        let src = r#"{
+            "version": "0.1.0", "mode": "duplicating", "canonical_level": 0,
+            "levels": [ { "row_group_end": 0, "gsd": 611.50, "zoom": 6 } ],
+            "generalization": {
+                "engine": "gpq-tiles 0.5.0",
+                "levels": [],
+                "ranking": {
+                    "mode": "class-ranking",
+                    "column": "road_class",
+                    "ranks": [["motorway", 5.0], ["primary", 4.0]],
+                    "unknown_rank": 0.0
+                }
+            }
+        }"#;
+        let meta = OverviewsMeta::from_json(src).unwrap();
+        let r = meta.generalization.clone().unwrap().ranking.unwrap();
+        let ranks = r.ranks.unwrap();
+        assert_eq!(ranks.get("motorway"), Some(&5.0));
+        assert_eq!(ranks.get("primary"), Some(&4.0));
+        // Re-serialization normalizes to the object-map shape.
+        let json = meta.to_json().unwrap();
+        assert!(
+            json.contains(r#""ranks":{"motorway":5.0,"primary":4.0}"#),
+            "re-emit must use the map shape, got {json}"
+        );
     }
 
     #[test]
@@ -922,15 +1006,29 @@ mod tests {
             coalescing: Some(CoalescingProvenance {
                 enabled: true,
                 snap_tolerance_gsd_factor: 1.0,
+                junction_angle: Some(0.0),
+                max_level_rows: Some(2_000_000),
                 coalesced_count_column: "coalesced_count".to_string(),
             }),
         });
         let json = meta.to_json().unwrap();
+        // §13.4 (v0.2.0): all five members present when emitted.
+        for key in [
+            r#""enabled":true"#,
+            r#""snap_tolerance_gsd_factor":1.0"#,
+            r#""junction_angle":0.0"#,
+            r#""max_level_rows":2000000"#,
+            r#""coalesced_count_column":"coalesced_count""#,
+        ] {
+            assert!(json.contains(key), "missing {key} in {json}");
+        }
         let parsed = OverviewsMeta::from_json(&json).unwrap();
         assert_eq!(meta, parsed);
         let c = parsed.generalization.unwrap().coalescing.unwrap();
         assert!(c.enabled);
         assert_eq!(c.snap_tolerance_gsd_factor, 1.0);
+        assert_eq!(c.junction_angle, Some(0.0));
+        assert_eq!(c.max_level_rows, Some(2_000_000));
         assert_eq!(c.coalesced_count_column, "coalesced_count");
 
         // Absent key → None (additive-field tolerance).
@@ -941,6 +1039,33 @@ mod tests {
         }"#;
         let m = OverviewsMeta::from_json(src).unwrap();
         assert!(m.generalization.unwrap().coalescing.is_none());
+    }
+
+    #[test]
+    fn coalescing_provenance_older_file_missing_new_members_reads_as_unknown() {
+        // A pre-v0.2.0-alignment footer records only the snap factor; the
+        // two new members MUST deserialize as None (unknown), never as an
+        // implied default (§13.4 read-compat).
+        let src = r#"{
+            "version": "0.1.0", "mode": "duplicating", "canonical_level": 0,
+            "levels": [ { "row_group_end": 0, "gsd": 611.50, "zoom": 6 } ],
+            "generalization": {
+                "engine": "gpq-tiles 0.5.0", "levels": [],
+                "coalescing": {
+                    "enabled": true,
+                    "snap_tolerance_gsd_factor": 1.0,
+                    "coalesced_count_column": "coalesced_count"
+                }
+            }
+        }"#;
+        let m = OverviewsMeta::from_json(src).unwrap();
+        let c = m.generalization.unwrap().coalescing.unwrap();
+        assert!(c.enabled);
+        assert_eq!(c.junction_angle, None, "absent means unknown, not 0");
+        assert_eq!(
+            c.max_level_rows, None,
+            "absent means unknown, not a default"
+        );
     }
 
     #[test]

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -62,7 +62,7 @@ use rayon::prelude::*;
 use crate::batch_processor::{extract_geometries_from_array, extract_geometries_opt_from_array};
 
 use super::assign::{apply_density_budget, assign_levels, AssignFeature, FeatureKind};
-use super::cluster::{build_cluster_tables, ClusterEntry, ClusterTables};
+use super::cluster::{build_cluster_tables, verify_sum_invariant, ClusterEntry, ClusterTables};
 use super::coalesce::CoalesceInput;
 use super::convert::{
     append_coalesced_count_field, append_point_count_field, apply_cluster_columns,
@@ -194,7 +194,7 @@ pub(super) fn convert_streaming(
             .iter()
             .map(|vals| features.iter().map(|f| vals[f.index]).collect())
             .collect();
-        Some(build_cluster_tables(
+        let tables = build_cluster_tables(
             &features,
             &feat_min_levels,
             &level_gsds,
@@ -202,7 +202,12 @@ pub(super) fn convert_streaming(
             crs,
             &acc_feat,
             &ops,
-        ))
+        );
+        // Strict §12.1 accounting: Σ point_count per level == source point
+        // count, and no clustered level thins its points to zero.
+        verify_sum_invariant(&features, &feat_min_levels, &tables)
+            .map_err(ConvertError::ClusterInvariant)?;
+        Some(tables)
     } else {
         None
     };


### PR DESCRIPTION
Code-alignment pass for spec v0.2.0 (draft #184, `docs/spec-v0.2.0-consolidation`): implements the three maintainer decisions recorded on #184 (flags 2, 3, 4) so gpq-tiles output conforms to the consolidated draft. Builds on #189 / the post-#181 `SPEC_VERSION = "0.2.0"` bump already on main.

## 1. Coalescing provenance completeness (§13.4, flag 2)

The `coalescing` footer object now emits **all** members — the junction-continuation threshold and the per-level memory-guard ceiling were previously unrecorded, so a junction-angle-30 file was indistinguishable from a default one.

Before:
```json
"coalescing": {
  "enabled": true,
  "snap_tolerance_gsd_factor": 1.0,
  "coalesced_count_column": "coalesced_count"
}
```

After:
```json
"coalescing": {
  "enabled": true,
  "snap_tolerance_gsd_factor": 1.0,
  "junction_angle": 0.0,
  "max_level_rows": 2000000,
  "coalesced_count_column": "coalesced_count"
}
```

**Read compat:** the two new members are `Option` with no implied default — absent on an older file deserializes as `None` (*unknown*, per §13.4's "readers MUST tolerate absence"), never as `0` / the engine default.

## 2. `ranking.ranks` as a JSON object map (§3.5, flag 3)

Before (array of pairs): `"ranks": [["motorway", 5.0], ["footway", 1.0]]`
After (object map): `"ranks": {"footway": 1.0, "motorway": 5.0}`

Semantics unchanged: **higher number wins** the cell; only the shape changed.

**Read compat decision:** reads accept **both** shapes — the map, and the legacy array-of-pairs emitted by our own 0.1.0/interim files (untagged serde fallback) — and only the map shape is ever emitted; re-serializing a legacy footer normalizes it to the map. Internal `ClassRanking.ranks` stays an ordered `Vec<(String, f64)>`; only the provenance echo collapses to a `BTreeMap` (deterministic key order in the footer).

## 3. Strict cluster sum invariant (§12.1, flag 4)

Per level, every source point is counted in exactly one point row: `Σ point_count` over a level's point rows MUST equal the exact source point count, under any drop mechanism. When a cluster winner is removed post-assignment (density budget), its accumulated count re-attaches to the nearest surviving point row — the existing absorption already guaranteed this in the budget/thinning paths (coalescing never touches points); this PR makes it *enforced* rather than incidental:

- **Producer guard:** `cluster::verify_sum_invariant` runs in both pipelines (streaming + in-memory) right after the cluster tables are built; a violation aborts with `ConvertError::ClusterInvariant` instead of writing a corrupt file. It also asserts the derived producer obligation from the #184 discussion: a clustered level cannot thin its points to **zero** while the source contains points (the one silent hole in `build_cluster_tables`, which skips a level with no present point rows).
- **Validator rule:** `validate_file` gains a data-reading `cluster_sum_invariant` check (row-group stats can't see sums): it sums `point_count` over each level's point rows and compares against the canonical band's point-row count (the source, verbatim per §2.4). `validate` now catches violating files.

## Tests

- Footer shape: coalescing five-member emission + JSON key assertions; older-footer absence → `None` (unknown); end-to-end knob round-trip (`junction_angle 30`, `max_level_rows 123456`).
- Ranks: map emission shape asserted in footer JSON; legacy array-of-pairs read + normalization test; end-to-end class-ranking provenance round-trip.
- Sum invariant: verifier unit tests (orphan absorption pass, zero-survivor rejection, doctored-table rejection); validator fixtures (pass / stats-clean-but-sum-violating / level-without-point-row); property test across knob combinations (streaming × density budget × point-thinning grid sizes), asserting per-level partition, singleton canonical band, and the validator rule.
- `cargo test -p gpq-tiles-core overview::` → **221 passed**; Python bindings rebuilt (`maturin develop`) + `pytest` → **70 passed** (no binding surface asserts the old shapes); `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` applied.

## Notes for #184

The informative notes in the draft spec that flag gpq-tiles' array-of-pairs `ranks` and missing coalescing members as pending alignment (§3.5, §13.4/§13.6) become satisfiable once this merges and can be dropped in the spec PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
