### PR TITLE
ci: pin action comments to immutable tags (fixes CI Lint drift)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Install cargo-machete
-        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2
+        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
           tool: cargo-machete
 
@@ -333,7 +333,7 @@ jobs:
       - name: Install tarpaulin
         # Prebuilt binary via install-action; `cargo install cargo-tarpaulin`
         # was several minutes of compile time on every run.
-        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2
+        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
           tool: cargo-tarpaulin
 
@@ -395,7 +395,7 @@ jobs:
           toolchain: stable
 
       - name: Install cargo-audit and cargo-deny
-        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2
+        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
           tool: cargo-audit,cargo-deny
 

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -65,7 +65,7 @@ jobs:
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Install cargo-mutants
-        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2
+        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
           tool: cargo-mutants
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,7 +41,7 @@ jobs:
           toolchain: stable
 
       - name: Install cargo-audit and cargo-deny
-        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2
+        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
           tool: cargo-audit,cargo-deny
 


### PR DESCRIPTION
zizmor's `ref-version-mismatch` audit is online and time-dependent: it verifies each SHA pin's comment against GitHub's live tags. Our `taiki-e/install-action` pins were commented `# v2` (a floating tag); when upstream released tonight, `v2` moved off our pinned SHA and CI Lint started failing on every PR (#195, #196) with no change on our side.

Fix: comment the pins with the immutable tag (`# v2.82.7`) that permanently points at the pinned commit — zizmor's own suggested auto-fix. Verified locally: `uvx zizmor==1.26.1 --min-severity low .github/workflows` → no findings. Dependabot's weekly actions group keeps these current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)