### PR TITLE
test: pin antimeridian downstream behavior + decision memo (#188)

### DIFF
--- a/context/ANTIMERIDIAN.md
+++ b/context/ANTIMERIDIAN.md
@@ -1,0 +1,157 @@
+# Antimeridian handling — decision memo (issue #188)
+
+**Status:** decided (research memo; pins in tree)
+**Date:** 2026-07-04
+**Follow-up to:** #173 / PR #186 (H4 hostile-input hardening)
+
+The convert pipeline stores geometries verbatim by design (spec: no
+reprojection or clipping at convert time). PR #186 pinned that
+antimeridian/polar inputs never crash. This memo answers the open
+questions from #188 empirically: what verbatim storage actually does
+downstream, whether splitting is warranted, and where it would belong.
+Every finding below is pinned by a test in the tree.
+
+## TL;DR
+
+Verbatim storage of an antimeridian-crossing geometry **does** degrade
+every downstream stage — level assignment, bbox pruning, and export —
+but by exactly the mechanism the spec already anticipates: §7.2 makes
+pre-splitting a **producer (input data) responsibility** and the
+validator SHOULD-warns on world-spanning bboxes. The failures are
+quality/size degradations, not crashes or corruption. **Recommendation:
+do not add splitting to the pipeline.** Keep the verbatim contract,
+rely on spec §7.2, and upgrade the user-facing surface (convert-time
+warning) rather than mutating geometry. Export-time splitting is the
+only defensible location if field evidence ever demands it.
+
+## Findings
+
+Test fixture throughout: a polygon whose author intends a 0.2° × 0.2°
+box straddling ±180° (vertices at lng −179.9 and +179.9), stored
+verbatim in EPSG:4326.
+
+### F1. Bboxes are inflated, never wrapped
+
+`geometry_bbox` (convert/stream) and `scan_level` (export) both use
+`geo::bounding_rect` — plain min/max. The fixture's bbox is
+`[-179.9, -0.1, 179.9, 0.1]`: 359.8° wide, `lng_min < lng_max` always.
+
+- A **wrapped** bbox (`lng_min > lng_max`) never arises anywhere in our
+  code paths. `tiles_for_bbox` has a correct wrapped-bbox branch
+  (tile.rs:191), but it is unreachable from the pipeline's own bboxes —
+  it can only trigger on caller-supplied bounds.
+- Pinned by: `overview::hostile::antimeridian_bbox_is_inflated_never_wrapped`,
+  `tile::tests::antimeridian_inflated_bbox_covers_full_world_row`.
+
+### F2. Level assignment: real degradation, two mechanisms
+
+Assignment consumes only the bbox (center + diagonal), so the inflated
+bbox distorts both:
+
+1. **GSD/visibility inflation.** The 0.2°-wide feature has a ~359.8°
+   bbox diagonal (~4.0e7 m), so it clears every visibility gate and is
+   promoted to the **coarsest** level (`min_level = 0`). At its true
+   extent it is gated to the **finest** level. Worst-case
+   miscategorization in both directions of the spec's intent: a
+   sliver-sized feature is rendered at global zooms, and its huge
+   `diag²` priority lets it out-compete genuinely large features.
+2. **Wrong-hemisphere representative point.** The bbox center is
+   lng ≈ 0 — the prime meridian, ~180° from the feature. It competes in
+   (and, with its inflated priority, **wins**) grid cells there,
+   displacing genuine prime-meridian features to finer levels.
+
+- Pinned by: `overview::assign::tests::antimeridian_inflated_bbox_assigned_to_coarsest_level`,
+  `overview::assign::tests::antimeridian_center_lands_on_prime_meridian_and_displaces_neighbor`.
+
+### F3. Export: full world-row smearing, not just seam artifacts
+
+The stored rectangle passes through lng 0 in coordinate space, so it
+genuinely intersects **every** tile column. End-to-end (convert at
+z2–z6, then `export_pmtiles`), the single 0.2°-wide polygon produces:
+
+| zoom | tiles written | wrap-aware expectation |
+|------|--------------:|-----------------------:|
+| z2   | 8             | ~2                      |
+| z3   | 16            | ~2–4                    |
+| z4   | 32            | ~2–4                    |
+| z5   | 64            | ~2–4                    |
+| z6   | 128           | ~2–4                    |
+
+That is `2^z × 2` tiles per zoom (full world row × two equator rows) —
+248 tiles total where a wrap-aware exporter would write ~15. Each tile
+carries a horizontal band polygon: the rendered output shows a
+world-wide smear at the feature's latitude. Tiles adjacent to ±180° do
+receive content (the geometry is present where the author intended it),
+but so does everything in between.
+
+- Pinned by: `overview::hostile::antimeridian_polygon_export_smears_world_row`,
+  `clip::tests::antimeridian_polygon_smears_into_prime_meridian_tile`,
+  `clip::tests::antimeridian_polygon_clips_at_edge_tile`.
+
+### F4. Reader-side bbox pruning is defeated (by inspection)
+
+The `bbox` covering column stores the same inflated bbox, so every
+viewport query at the feature's latitude fetches its row group — the
+exact failure mode spec §7.2 names ("a feature whose bbox spans ~360°
+of longitude defeats the covering index"). Consistent with F1–F3; no
+new pin needed beyond the bbox pin (F1).
+
+## Decision
+
+### (a) Is splitting warranted in gpq-tiles? **No.**
+
+- The degradations are real (F2/F3) but they are **input-data defects
+  under the spec's own contract**: §7.2 already says geometries MUST NOT
+  cross the antimeridian in a way that defeats bbox pruning and that
+  *producers SHOULD split before writing*. GeoParquet upstream takes the
+  same stance (RFC 7946 §3.1.9-style splitting is the data author's
+  job). Silently mutating geometry inside a converter whose core
+  contract is "verbatim" would be a bigger correctness risk than the
+  defect it fixes (splitting polygons correctly at ±180° — holes,
+  multi-part, winding — is a well-known bug farm; cf. the dedicated
+  `antimeridian` libraries).
+- No field evidence of real-world breakage has been presented; the
+  ticket's bar for reopening the verbatim contract ("evidence of a real
+  downstream failure") is met only by synthetic fixtures that are
+  already spec-non-conformant inputs.
+- The cheap, contract-preserving improvement instead: **warn at convert
+  time** when a feature bbox spans > 180° of longitude (the H4 warning
+  channel already exists for skipped rows), mirroring the validator's
+  SHOULD-warn. Tracked as follow-up; not part of this memo's pins.
+
+### (b) If splitting ever becomes necessary, export time only. **Yes.**
+
+Export already transforms geometry (tile clipping), already owns
+`tiles_for_bbox` with a working wrapped-bbox branch, and produces
+derived artifacts (PMTiles) rather than the stored format — so a future
+opt-in `ExportOptions` flag ("treat >180°-wide features as wrapped:
+split into two lobes before tile assignment") would leave the
+convert-time verbatim contract fully intact. Convert-time splitting is
+rejected outright: it mutates stored geometry, changes feature counts,
+and breaks round-trip fidelity with the source GeoParquet.
+
+### (c) Should the spec say more? **No — it already says the right thing.**
+
+`context/OVERVIEWS_SPEC.md` §7.2 (normative: inputs MUST NOT cross in a
+pruning-defeating way; producers SHOULD pre-split) plus the §6-family
+validator SHOULD-warn is exactly the "reader's/producer's problem"
+stance consistent with GeoParquet upstream. Adding converter-side
+normative text would contradict the verbatim contract. No spec change.
+
+## Test inventory (behavior pins, this memo)
+
+All pins document **current** behavior; if any starts failing, either a
+splitting feature landed (update this memo) or a regression changed
+bbox/assignment/clip semantics.
+
+- `overview::assign::tests::antimeridian_inflated_bbox_assigned_to_coarsest_level`
+- `overview::assign::tests::antimeridian_center_lands_on_prime_meridian_and_displaces_neighbor`
+- `clip::tests::antimeridian_polygon_smears_into_prime_meridian_tile`
+- `clip::tests::antimeridian_polygon_clips_at_edge_tile`
+- `tile::tests::antimeridian_inflated_bbox_covers_full_world_row`
+- `overview::hostile::antimeridian_bbox_is_inflated_never_wrapped`
+- `overview::hostile::antimeridian_polygon_export_smears_world_row`
+
+Pre-existing (PR #186): `overview::hostile::antimeridian_and_pole_features_convert`
+(no-crash pin); `tile::tests::test_tiles_for_bbox_antimeridian_crossing`
+(wrapped-bbox branch of `tiles_for_bbox`, caller-supplied bounds only).

--- a/context/ANTIMERIDIAN.md
+++ b/context/ANTIMERIDIAN.md
@@ -1,6 +1,7 @@
 # Antimeridian handling — decision memo (issue #188)
 
 **Status:** decided (research memo; pins in tree)
+**User-facing docs:** `docs/advanced-usage.md`, "Antimeridian-Crossing Geometry"
 **Date:** 2026-07-04
 **Follow-up to:** #173 / PR #186 (H4 hostile-input hardening)
 
@@ -115,9 +116,15 @@ new pin needed beyond the bbox pin (F1).
   downstream failure") is met only by synthetic fixtures that are
   already spec-non-conformant inputs.
 - The cheap, contract-preserving improvement instead: **warn at convert
-  time** when a feature bbox spans > 180° of longitude (the H4 warning
-  channel already exists for skipped rows), mirroring the validator's
-  SHOULD-warn. Tracked as follow-up; not part of this memo's pins.
+  time** when a feature bbox spans > 180° of longitude, mirroring the
+  validator's SHOULD-warn. **Implemented** alongside this memo:
+  `bbox_antimeridian_suspect` / `warn_antimeridian_suspects` in
+  `overview/convert.rs`, wired into both the in-memory and streaming
+  paths — one aggregate `log::warn!` per convert (surfaced by the CLI's
+  default `info` log filter), plus a
+  `ConvertReport::antimeridian_suspect_features` counter. Pure
+  detection; geometry is never mutated. User-facing explanation:
+  `docs/advanced-usage.md`, "Antimeridian-Crossing Geometry".
 
 ### (b) If splitting ever becomes necessary, export time only. **Yes.**
 
@@ -151,6 +158,8 @@ bbox/assignment/clip semantics.
 - `tile::tests::antimeridian_inflated_bbox_covers_full_world_row`
 - `overview::hostile::antimeridian_bbox_is_inflated_never_wrapped`
 - `overview::hostile::antimeridian_polygon_export_smears_world_row`
+- `overview::hostile::antimeridian_suspect_features_warned_normal_inputs_clean`
+  (convert-time detection counter, both streaming modes)
 
 Pre-existing (PR #186): `overview::hostile::antimeridian_and_pole_features_convert`
 (no-crash pin); `tile::tests::test_tiles_for_bbox_antimeridian_crossing`

--- a/crates/core/src/clip.rs
+++ b/crates/core/src/clip.rs
@@ -1072,6 +1072,62 @@ mod tests {
 
     // ========== Sutherland-Hodgman Clipping Unit Tests ==========
 
+    // ---- antimeridian-crossing geometries (issue #188 behavior pins) --------
+    //
+    // Geometries are stored verbatim, so a polygon whose vertices sit at
+    // lng ±179.9 is, in coordinate space, a near-world-wide rectangle passing
+    // through lng 0 — NOT two slivers at the antimeridian. These tests PIN
+    // what export-time clipping does with such a geometry: every tile in the
+    // world row intersects it ("smearing"). Documenting current behavior,
+    // not desired behavior. See `context/ANTIMERIDIAN.md`.
+
+    /// A polygon with vertices at lng ±179.9 — intended by the data author as
+    /// a 0.2°-wide feature crossing the antimeridian, but stored (verbatim)
+    /// as a 359.8°-wide rectangle.
+    fn antimeridian_polygon() -> Geometry<f64> {
+        Geometry::Polygon(Polygon::new(
+            LineString::from(vec![
+                Coord { x: -179.9, y: -0.1 },
+                Coord { x: 179.9, y: -0.1 },
+                Coord { x: 179.9, y: 0.1 },
+                Coord { x: -179.9, y: 0.1 },
+                Coord { x: -179.9, y: -0.1 },
+            ]),
+            vec![],
+        ))
+    }
+
+    #[test]
+    fn antimeridian_polygon_smears_into_prime_meridian_tile() {
+        // A tile at lng ≈ 0 is ~180° from either "true" half of the feature,
+        // yet clipping yields content there because the stored rectangle
+        // passes straight through it.
+        let tile = TileBounds::new(-1.0, -1.0, 1.0, 1.0);
+        let clipped = clip_geometry(&antimeridian_polygon(), &tile, 0.0);
+        let clipped = clipped.expect(
+            "PIN: prime-meridian tile receives geometry from an \
+             antimeridian-crossing polygon (smearing)",
+        );
+        // The smear fills the tile's full x-range.
+        let rect = clipped.bounding_rect().unwrap();
+        assert!(
+            (rect.min().x - (-1.0)).abs() < 1e-9 && (rect.max().x - 1.0).abs() < 1e-9,
+            "PIN: smear spans the entire tile width, got {rect:?}"
+        );
+    }
+
+    #[test]
+    fn antimeridian_polygon_clips_at_edge_tile() {
+        // A tile adjacent to +180° also intersects — the geometry is present
+        // where the author intended it, in addition to the world-row smear.
+        let tile = TileBounds::new(178.0, -1.0, 180.0, 1.0);
+        let clipped = clip_geometry(&antimeridian_polygon(), &tile, 0.0);
+        assert!(
+            clipped.is_some(),
+            "tile at the +180° edge intersects the stored rectangle"
+        );
+    }
+
     #[test]
     fn test_sutherland_hodgman_fully_inside() {
         // Polygon fully inside clip bounds -- should be unchanged

--- a/crates/core/src/overview/assign.rs
+++ b/crates/core/src/overview/assign.rs
@@ -1279,4 +1279,70 @@ mod tests {
             "disabled budget must be an identity"
         );
     }
+
+    // ---- antimeridian-crossing bboxes (issue #188 behavior pins) -------------
+    //
+    // The convert pipeline stores geometries verbatim and computes bboxes with
+    // `geo::bounding_rect` (plain min/max), so a feature straddling ±180° gets
+    // an *inflated* bbox spanning nearly the whole world (lng_min ≈ -179.9,
+    // lng_max ≈ +179.9) rather than a wrapped one (lng_min > lng_max never
+    // arises). These tests PIN the downstream consequences for level
+    // assignment — they document current behavior, not desired behavior. See
+    // `context/ANTIMERIDIAN.md`.
+
+    #[test]
+    fn antimeridian_inflated_bbox_assigned_to_coarsest_level() {
+        // A polygon whose true extent is 0.2° × 0.2° straddling the
+        // antimeridian. Our bbox math hands assignment the inflated bbox
+        // [-179.9, -0.1, 179.9, 0.1] (diag ≈ 359.8°), so the polygon clears
+        // every visibility gate and wins the coarsest level.
+        let inflated = poly(0, -179.9, -0.1, 179.9, 0.1);
+        // The same feature's *true* extent, expressed unwrapped past 180°
+        // (diag ≈ 0.28°): gated out of level 0 (gate = 4·gsd(2) ≈ 0.35°),
+        // eligible only at the finest level.
+        let true_extent = poly(1, 179.9, -0.1, 180.1, 0.1);
+        let gsds = [gsd(2), gsd(6)];
+        let out = assign_levels(
+            &[inflated, true_extent],
+            &gsds,
+            &AssignConfig::default(),
+            Crs::Epsg4326,
+        );
+        assert_eq!(
+            out.assignments[0].min_level, 0,
+            "PIN: inflated antimeridian bbox promotes a 0.2°-wide feature \
+             to the coarsest level"
+        );
+        assert_eq!(
+            out.assignments[1].min_level, 1,
+            "the same feature at its true extent is visibility-gated to the \
+             finest level"
+        );
+    }
+
+    #[test]
+    fn antimeridian_center_lands_on_prime_meridian_and_displaces_neighbor() {
+        // The bbox center of the inflated bbox is lng ≈ 0 — the wrong
+        // hemisphere. The feature therefore competes in a grid cell at the
+        // prime meridian, and its huge bbox diagonal out-ranks any genuine
+        // local feature sharing that cell.
+        let antimeridian = poly(0, -179.9, -0.1, 179.9, 0.1); // center (0, 0)
+        let local = poly(1, -0.5, -0.5, 0.5, 0.5); // genuinely at (0, 0)
+        let gsds = [gsd(2), gsd(6)];
+        let out = assign_levels(
+            &[antimeridian, local],
+            &gsds,
+            &AssignConfig::default(),
+            Crs::Epsg4326,
+        );
+        assert_eq!(
+            out.assignments[0].min_level, 0,
+            "PIN: antimeridian feature wins the prime-meridian cell"
+        );
+        assert_eq!(
+            out.assignments[1].min_level, 1,
+            "PIN: genuine prime-meridian feature is displaced to the finest \
+             level by the antimeridian feature's inflated priority"
+        );
+    }
 }

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -62,6 +62,7 @@ use super::coalesce::{
 use super::level::{
     gsd_with_base, AccumulatedColumn, ClusteringProvenance, CoalescingProvenance, Crs,
     DensityProvenance, Generalization, GeneralizationLevel, Mode, RankingProvenance, GSD_TILE_BASE,
+    METERS_PER_DEGREE,
 };
 use super::simplify::{simplify_for_level, Simplified, SimplifyOptions};
 use super::writer::{LevelSpec, OverviewWriter, OverviewWriterOptions, WriterError, LEVEL_COLUMN};
@@ -421,6 +422,11 @@ pub struct ConvertReport {
     pub total_vertices: usize,
     /// Total compressed output size (bytes) across all levels.
     pub total_compressed_bytes: i64,
+    /// Features whose bbox spans more than 180° of longitude — almost
+    /// certainly antimeridian-crossing geometry stored verbatim. Warned
+    /// about (one aggregate `log::warn!`), never mutated; see
+    /// `context/ANTIMERIDIAN.md` (issue #188).
+    pub antimeridian_suspect_features: usize,
     /// Wall-clock conversion duration in seconds.
     pub duration_secs: f64,
 }
@@ -758,6 +764,14 @@ pub fn convert_to_overviews(
             sort_key: sort_keys[i],
         })
         .collect();
+
+    // #188 follow-up: count antimeridian-suspect bboxes and warn once.
+    let antimeridian_suspect_features = features
+        .iter()
+        .filter(|f| bbox_antimeridian_suspect(&f.bbox, crs))
+        .count();
+    warn_antimeridian_suspects(antimeridian_suspect_features);
+
     let assignment = assign_levels(&features, &level_gsds, &options.assign, crs);
     // Q2: layer the per-level density budget on top of cell-winner thinning.
     // When disabled this is an identity, so `--no-density-drop` reproduces the
@@ -1002,6 +1016,7 @@ pub fn convert_to_overviews(
         total_rows,
         total_vertices,
         total_compressed_bytes,
+        antimeridian_suspect_features,
         duration_secs: start.elapsed().as_secs_f64(),
     })
 }
@@ -1051,6 +1066,29 @@ pub(super) fn geometry_bbox(g: &Geometry<f64>) -> [f64; 4] {
     match g.bounding_rect() {
         Some(r) => [r.min().x, r.min().y, r.max().x, r.max().y],
         None => [0.0, 0.0, 0.0, 0.0],
+    }
+}
+
+/// Whether a feature bbox is antimeridian-suspect: wider than 180° of
+/// longitude. A real feature that wide is essentially impossible; the near
+/// certain cause is an antimeridian-crossing geometry stored verbatim, whose
+/// min/max bbox inflates to ~360° (see `context/ANTIMERIDIAN.md`, #188).
+/// Detection only — geometry is never mutated.
+pub(super) fn bbox_antimeridian_suspect(bbox: &[f64; 4], crs: Crs) -> bool {
+    bbox[2] - bbox[0] > crs.meters_to_units(180.0 * METERS_PER_DEGREE)
+}
+
+/// Emit the single aggregate antimeridian warning (#188 follow-up). Called
+/// once per convert, from both the streaming and in-memory paths.
+pub(super) fn warn_antimeridian_suspects(count: usize) {
+    if count > 0 {
+        log::warn!(
+            "{count} feature(s) have bounding boxes wider than 180° of longitude — \
+             likely antimeridian-crossing geometry. These will be assigned to \
+             overly coarse levels and defeat bbox pruning; pre-split them at \
+             ±180° before converting (see docs/advanced-usage.md, \
+             \"Antimeridian-Crossing Geometry\")."
+        );
     }
 }
 

--- a/crates/core/src/overview/hostile.rs
+++ b/crates/core/src/overview/hostile.rs
@@ -889,3 +889,75 @@ fn export_partitioning_mode_file_works() {
     let report = export_pmtiles(tovr.path(), tout.path(), &ExportOptions::default()).unwrap();
     assert!(report.total_tiles > 0);
 }
+
+// ============================================================================
+// Issue #188: antimeridian downstream behavior pins
+// ============================================================================
+//
+// PR #186 (class 4 above) pinned that antimeridian/polar inputs never crash.
+// These tests pin what the verbatim contract does DOWNSTREAM: the bbox math
+// never produces a wrapped bbox, and export smears an antimeridian-crossing
+// polygon across the whole world row. They document current behavior, not
+// desired behavior. See `context/ANTIMERIDIAN.md`.
+
+#[test]
+fn antimeridian_bbox_is_inflated_never_wrapped() {
+    use super::convert::geometry_bbox;
+    // A 0.2°-wide polygon straddling ±180°, stored verbatim.
+    let poly = Geometry::Polygon(Polygon::new(
+        LineString::from(vec![
+            (-179.9, -0.1),
+            (179.9, -0.1),
+            (179.9, 0.1),
+            (-179.9, 0.1),
+            (-179.9, -0.1),
+        ]),
+        vec![],
+    ));
+    let [xmin, ymin, xmax, ymax] = geometry_bbox(&poly);
+    // Plain min/max: never a wrapped bbox (xmin > xmax cannot arise), so the
+    // wrapped-bbox branch in `tiles_for_bbox` is unreachable from this
+    // pipeline's own bboxes.
+    assert_eq!(
+        [xmin, ymin, xmax, ymax],
+        [-179.9, -0.1, 179.9, 0.1],
+        "PIN: bounding_rect yields the inflated (359.8°-wide) bbox"
+    );
+    assert!(xmin < xmax, "PIN: wrapped bboxes never arise");
+}
+
+#[test]
+fn antimeridian_polygon_export_smears_world_row() {
+    // End-to-end: one 0.2°-wide polygon straddling ±180° at the equator.
+    // A wrap-aware exporter would emit ~2 tile columns per zoom (one on each
+    // side of ±180°); the verbatim rectangle instead intersects EVERY column,
+    // so the finest zoom (z6, 64 columns × 2 equator rows) writes ~128 tiles.
+    let tin = tempfile::NamedTempFile::new().unwrap();
+    let tovr = tempfile::NamedTempFile::new().unwrap();
+    let tout = tempfile::NamedTempFile::new().unwrap();
+    let geoms: Vec<Option<Geometry<f64>>> = vec![Some(Geometry::Polygon(Polygon::new(
+        LineString::from(vec![
+            (-179.9, -0.1),
+            (179.9, -0.1),
+            (179.9, 0.1),
+            (-179.9, 0.1),
+            (-179.9, -0.1),
+        ]),
+        vec![],
+    )))];
+    write_input(tin.path(), &geoms, true, None);
+    convert_to_overviews(tin.path(), tovr.path(), &opts(true)).unwrap();
+    let report = export_pmtiles(tovr.path(), tout.path(), &ExportOptions::default()).unwrap();
+
+    for z in &report.zooms {
+        eprintln!("z{}: {} tiles", z.zoom, z.tile_count);
+    }
+    let finest = report.zooms.last().unwrap();
+    assert_eq!(finest.zoom, 6);
+    assert!(
+        finest.tile_count >= 64,
+        "PIN: export smears the polygon across the full world row at z6 \
+         (>= 64 tile columns), got {} tiles",
+        finest.tile_count
+    );
+}

--- a/crates/core/src/overview/hostile.rs
+++ b/crates/core/src/overview/hostile.rs
@@ -927,6 +927,59 @@ fn antimeridian_bbox_is_inflated_never_wrapped() {
 }
 
 #[test]
+fn antimeridian_suspect_features_warned_normal_inputs_clean() {
+    // Convert-time detection (#188 follow-up): a feature whose bbox spans
+    // more than 180° of longitude is counted as antimeridian-suspect and
+    // surfaced via `ConvertReport::antimeridian_suspect_features` plus ONE
+    // aggregate `log::warn!` at the end of convert. Detection only — the
+    // geometry itself is stored verbatim, never mutated.
+    let suspect = Geometry::Polygon(Polygon::new(
+        LineString::from(vec![
+            (-179.9, -0.1),
+            (179.9, -0.1),
+            (179.9, 0.1),
+            (-179.9, 0.1),
+            (-179.9, -0.1),
+        ]),
+        vec![],
+    ));
+    let geoms: Vec<Option<Geometry<f64>>> = vec![
+        Some(suspect),
+        Some(Geometry::Point(Point::new(10.0, 10.0))),
+        Some(Geometry::Point(Point::new(-170.0, 5.0))),
+    ];
+    for streaming in [true, false] {
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        write_input(tin.path(), &geoms, true, None);
+        let report = convert_to_overviews(tin.path(), tout.path(), &opts(streaming)).unwrap();
+        assert_eq!(
+            report.antimeridian_suspect_features, 1,
+            "streaming={streaming}: exactly the wide polygon is flagged"
+        );
+    }
+
+    // A normal (wide but < 180°) dataset triggers nothing.
+    let normal: Vec<Option<Geometry<f64>>> = vec![
+        Some(Geometry::LineString(LineString::from(vec![
+            (-80.0, 0.0),
+            (80.0, 10.0),
+        ]))),
+        Some(Geometry::Point(Point::new(0.0, 0.0))),
+    ];
+    for streaming in [true, false] {
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        write_input(tin.path(), &normal, true, None);
+        let report = convert_to_overviews(tin.path(), tout.path(), &opts(streaming)).unwrap();
+        assert_eq!(
+            report.antimeridian_suspect_features, 0,
+            "streaming={streaming}: sub-180° extents are not flagged"
+        );
+    }
+}
+
+#[test]
 fn antimeridian_polygon_export_smears_world_row() {
     // End-to-end: one 0.2°-wide polygon straddling ±180° at the equator.
     // A wrap-aware exporter would emit ~2 tile columns per zoom (one on each

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -150,6 +150,14 @@ pub(super) fn convert_streaming(
         );
     }
     let num_features = features.len();
+
+    // #188 follow-up: count antimeridian-suspect bboxes and warn once.
+    let antimeridian_suspect_features = features
+        .iter()
+        .filter(|f| super::convert::bbox_antimeridian_suspect(&f.bbox, crs))
+        .count();
+    super::convert::warn_antimeridian_suspects(antimeridian_suspect_features);
+
     log::debug!(
         "[profile] pass1 stream+scan: {:.2}s",
         t_pass1.elapsed().as_secs_f64()
@@ -429,6 +437,7 @@ pub(super) fn convert_streaming(
         total_rows,
         total_vertices,
         total_compressed_bytes,
+        antimeridian_suspect_features,
         duration_secs: start.elapsed().as_secs_f64(),
     })
 }

--- a/crates/core/src/tile.rs
+++ b/crates/core/src/tile.rs
@@ -372,6 +372,25 @@ mod tests {
     }
 
     #[test]
+    fn antimeridian_inflated_bbox_covers_full_world_row() {
+        // Issue #188 behavior pin. `tiles_for_bbox` supports wrapped bboxes
+        // (lng_min > lng_max, tested above), but the overview pipeline never
+        // produces one: bboxes come from `geo::bounding_rect` (plain min/max),
+        // so an antimeridian-crossing feature arrives as the INFLATED bbox
+        // [-179.9, .., 179.9]. That bbox enumerates every x column at the
+        // zoom — the full world row — not two columns at ±180°.
+        // See `context/ANTIMERIDIAN.md`.
+        let bbox = TileBounds::new(-179.9, -0.1, 179.9, 0.1);
+        let tiles: Vec<_> = tiles_for_bbox(&bbox, 4).collect();
+        let x_coords: std::collections::HashSet<_> = tiles.iter().map(|t| t.x).collect();
+        assert_eq!(
+            x_coords.len(),
+            16,
+            "PIN: inflated antimeridian bbox spans all 16 x columns at z4"
+        );
+    }
+
+    #[test]
     fn test_tiles_for_bbox_normal_still_works() {
         // Normal case: Europe (doesn't cross antimeridian)
         let bbox = TileBounds::new(-10.0, 40.0, 10.0, 50.0);

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -22,6 +22,59 @@ gpio convert reproject input.parquet prepared.parquet \
 
 Non-WGS84 input is rejected with the exact command to fix it.
 
+## Antimeridian-Crossing Geometry
+
+gpq-tiles stores your geometry exactly as written — it never reprojects,
+clips, or splits it. That is the right default, but it has one sharp
+edge: features that cross the antimeridian (the ±180° longitude line).
+
+Say you have a polygon around Fiji whose western edge is at longitude
++179.9 and whose eastern edge is at −179.9. On a globe that is a small
+polygon, about 0.2° wide. But written out as plain coordinates, its
+bounding box runs from −179.9 all the way to +179.9 — software that
+doesn't know about the antimeridian sees a polygon nearly 360° wide,
+wrapping the wrong way around the Earth through the prime meridian.
+
+If you convert such a file as-is, three things go wrong:
+
+- **Wrong overview levels.** Level assignment sizes features by their
+  bounding box, so your small Fiji polygon looks planet-sized and is
+  kept at the coarsest zoom levels, where it also crowds out genuinely
+  large features near longitude 0.
+- **Smeared tiles on export.** `export-pmtiles` clips the stored
+  coordinates verbatim, so the polygon renders as a horizontal band
+  across *every* tile at its latitude — a world-wide smear, not a small
+  shape near Fiji.
+- **Broken bbox pruning.** The bounding box stored in the overview file
+  spans nearly all longitudes, so every viewport query at that latitude
+  fetches the feature's row group. Spatial filtering stops helping.
+
+gpq-tiles detects this and warns — once per conversion, with a count of
+affected features — but deliberately does **not** modify your geometry:
+
+```text
+warning: 3 feature(s) have bounding boxes wider than 180° of
+longitude — likely antimeridian-crossing geometry. ...
+```
+
+**The fix is to split such features at ±180° before converting**, so
+the Fiji polygon becomes a MultiPolygon with one part on each side of
+the line. This matches GeoParquet upstream guidance (and the
+`geo:overviews` spec, §7.2): antimeridian handling is the data
+producer's job, done once at the source, rather than every downstream
+tool guessing. The Python [`antimeridian`](https://pypi.org/project/antimeridian/)
+package does exactly this split correctly (holes, multi-part geometry
+and all); many GIS pipelines also have a dateline-wrapping option.
+After splitting, re-run the gpio preparation step above and convert as
+usual — the warning disappears and levels, tiles, and pruning all
+behave.
+
+If you never see the warning, you have nothing to do: data that stays
+inside ±180° is unaffected.
+
+(Design background and the evidence behind this policy live in
+`context/ANTIMERIDIAN.md`.)
+
 ## Memory Control
 
 Conversion streams by default (two passes; peak memory


### PR DESCRIPTION
## Summary

Research deliverable for #188: empirically answers whether the verbatim-storage contract causes real downstream problems for antimeridian-crossing geometries, pins the current behavior with targeted tests, and records the decision in `context/ANTIMERIDIAN.md`.

Fixture throughout: a polygon the author intends as 0.2° × 0.2° straddling ±180° (vertices at lng −179.9 / +179.9), stored verbatim.

## Findings

- **Bboxes are inflated, never wrapped.** `geometry_bbox` / `scan_level` use `bounding_rect` (plain min/max) → bbox `[-179.9, -0.1, 179.9, 0.1]`, 359.8° wide. A wrapped bbox (`lng_min > lng_max`) never arises anywhere in our code paths; `tiles_for_bbox`'s wrapped branch is unreachable from pipeline-produced bboxes.
- **Level assignment degrades, two ways.** The inflated diagonal (~4.0e7 m) clears every visibility gate: the sliver is assigned `min_level = 0` (its true extent gates it to the finest level). And its bbox center lands at lng ≈ 0 — it wins the prime-meridian grid cell and displaces a genuine feature there to the finest level.
- **Export smears the world row.** End-to-end (convert z2–z6 → `export_pmtiles`), the single polygon writes `2^z × 2` tiles per zoom — z2: 8, z3: 16, z4: 32, z5: 64, z6: 128 (248 total) — vs ~2–4/zoom for a wrap-aware exporter. Middle-of-world tiles get a horizontal band; ±180°-edge tiles also get (correct) content.
- **Reader bbox pruning is defeated** (by inspection): the covering column stores the same inflated bbox — exactly the failure mode spec §7.2 names.

## Decision (see `context/ANTIMERIDIAN.md`)

- **(a) No splitting in gpq-tiles.** The degradations are real but are input-data defects under the spec's own contract: `OVERVIEWS_SPEC.md` §7.2 already says such inputs MUST NOT defeat bbox pruning and producers SHOULD pre-split (consistent with GeoParquet upstream). No field evidence of real-world breakage; the verbatim contract stands. Cheap follow-up **implemented in this PR** (maintainer-requested): convert-time warning when a feature bbox spans > 180° of longitude.
- **(b) If ever warranted, export-time only** — export already transforms geometry and owns a working wrapped-bbox `tiles_for_bbox` branch; an opt-in `ExportOptions` flag would preserve the verbatim contract.
- **(c) No spec change.** §7.2 + validator SHOULD-warn already say the right thing.

## Convert-time warning (new)

`bbox_antimeridian_suspect` + `warn_antimeridian_suspects` in `overview/convert.rs`, wired into both the streaming and in-memory paths. Detection only — geometry is never mutated. Features with a >180°-longitude bbox are counted and reported via a new `ConvertReport::antimeridian_suspect_features` field, plus ONE aggregate warning at convert (surfaced by the CLI's default `info` log filter):

> `N feature(s) have bounding boxes wider than 180° of longitude — likely antimeridian-crossing geometry. These will be assigned to overly coarse levels and defeat bbox pruning; pre-split them at ±180° before converting (see docs/advanced-usage.md, "Antimeridian-Crossing Geometry").`

## User docs (new)

`docs/advanced-usage.md` gains an **"Antimeridian-Crossing Geometry"** section (plain-English Fiji example: wrong levels, world-row tile smearing, broken bbox pruning; gpq-tiles warns but does not split; pre-split at ±180° per spec §7.2 / GeoParquet upstream guidance). `context/ANTIMERIDIAN.md` stays the decision memo and now points at it.

## Tests added (behavior pins — document current behavior, not a fix)

- `overview::assign::tests::antimeridian_inflated_bbox_assigned_to_coarsest_level`
- `overview::assign::tests::antimeridian_center_lands_on_prime_meridian_and_displaces_neighbor`
- `clip::tests::antimeridian_polygon_smears_into_prime_meridian_tile`
- `clip::tests::antimeridian_polygon_clips_at_edge_tile`
- `tile::tests::antimeridian_inflated_bbox_covers_full_world_row`
- `overview::hostile::antimeridian_bbox_is_inflated_never_wrapped`
- `overview::hostile::antimeridian_polygon_export_smears_world_row`
- `overview::hostile::antimeridian_suspect_features_warned_normal_inputs_clean` (warning counter: fires for the antimeridian fixture, silent for a sub-180° control; both streaming modes)

All run green via targeted `cargo test --package gpq-tiles-core antimeridian` (12 passed incl. the pre-existing #186 pins).

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)
