### PR TITLE
feat: PMTiles → GeoParquet decode (#112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Fast GeoParquet → PMTiles converter in Rust.
 - Quality ladder tuned against tippecanoe: class ranking (Overture auto-detect), visibility gates, density budget, point clustering, line coalescing
 - Memory-bounded streaming conversion (632k-polygon / 38M-vertex file: ~55 s, ~320 MB peak RSS)
 - Spec validation (`gpq-tiles validate`)
+- PMTiles → GeoParquet decoding (`gpq-tiles decode`) — tippecanoe-decode
+  semantics, any PMTiles v3 MVT archive
 
 > **⚠️ Work in Progress**:
 > Code is generated with Claude; take it with a grain of salt.
@@ -53,6 +55,18 @@ All tuning knobs live on `overview` / `export-pmtiles` — see
 [Overview Tuning](docs/OVERVIEW_TUNING.md). Defaults are calibrated on
 rendered corpus sweeps and are meant to look right out of the box.
 
+### Decoding PMTiles back to GeoParquet
+
+```bash
+# Extract one zoom of any PMTiles v3 vector archive as GeoParquet
+gpq-tiles decode input.pmtiles output.parquet --zoom 14
+```
+
+The output is the **tiled representation** (simplified, clipped, duplicated
+across tiles and zooms — no round-trip guarantee), with `zoom`/`layer`/
+`mvt_id` provenance columns for filtering. See
+[Decoding PMTiles](docs/decode.md).
+
 ### Input Preparation
 
 Inputs must be WGS84 (EPSG:4326), and should be Hilbert-sorted with sane
@@ -81,6 +95,7 @@ convert("input.parquet", "output.pmtiles", min_zoom=0, max_zoom=14)
 
 - **[Getting Started](docs/getting-started.md)** — Installation, basic usage, the two-step workflow
 - **[Overview Tuning](docs/OVERVIEW_TUNING.md)** — Every generalization knob explained
+- **[Decoding PMTiles](docs/decode.md)** — PMTiles → GeoParquet, limitations included
 - **[API Reference](docs/api-reference.md)** — CLI flags, Python API, Rust API
 - **[Advanced Usage](docs/advanced-usage.md)** — Input optimization, memory, remote reads, CI/CD
 - **[Format Spec (draft)](context/OVERVIEWS_SPEC.md)** — The `geo:overviews` format contract

--- a/context/ARCHITECTURE.md
+++ b/context/ARCHITECTURE.md
@@ -125,6 +125,28 @@ banding/row-group alignment, canonical fidelity, monotonicity, cluster
 | Tile-size control (export) | Single non-iterative drop pass (`--tile-size-limit`) | Iterative threshold retry loop | Overview levels are already budgeted; the valve is a backstop, not the mechanism |
 | Polygon clipping (export) | Sutherland–Hodgman f64 + i_overlay fallback | Sutherland–Hodgman integer tile coords | Same algorithm family, different coordinate space (below) |
 
+## Decision Record: MVT Winding Fix + PMTiles Decode (#112, 2026-07-04)
+
+While building the PMTiles → GeoParquet decoder (`decode.rs`), its
+spec-strict ring classifier exposed an encoder bug: `orient_polygon_for_mvt`
+used geo's `Direction::Default` (exterior CCW in geographic coordinates),
+reasoning visually that "geographic CCW appears clockwise after the Y-flip".
+Visually true — but MVT spec 4.3.3.3 defines exterior rings by a POSITIVE
+surveyor's-formula area on the stored tile coordinates, and a Y-flip NEGATES
+that sign. Our exteriors therefore carried negative area (holes positive) —
+inverted relative to the spec and to tippecanoe. Fixed to
+`Direction::Reversed`; `mvt::tests::test_encoded_exterior_ring_has_positive_tile_area`
+pins the convention at the command-stream level. Archives written by older
+releases have inverted windings; winding-agnostic renderers (even-odd fill)
+draw them correctly, but spec-strict consumers (including our own decoder)
+classify their holes as exteriors — re-export to fix.
+
+The decoder itself follows tippecanoe-decode's model: no deduplication
+(every feature from every selected tile, with `zoom`/`layer`/`mvt_id`
+provenance columns for filtering), coordinates lifted through tippecanoe's
+32-bit world-coordinate transform (write_json.cpp), degenerate MVT content
+(zero-area rings, one-point linestrings, leading interior rings) dropped.
+
 ## Polygon Clipping: Sutherland-Hodgman
 
 **DIVERGENCE**: Tippecanoe uses Sutherland-Hodgman in integer tile
@@ -203,6 +225,7 @@ crates/core/src/
 ├── tile.rs             # TileCoord, TileBounds
 ├── world_coord.rs      # Integer world-coordinate space
 ├── mvt.rs              # MVT encoding
+├── decode.rs           # PMTiles → GeoParquet decoding (#112)
 ├── pmtiles_writer.rs   # PMTiles v3 writer (StreamingPmtilesWriter)
 ├── compression.rs      # gzip/brotli/zstd compression
 ├── dedup.rs            # Tile deduplication (XXH3)

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -68,6 +68,60 @@ enum Command {
     Validate(ValidateArgs),
     /// Export a PMTiles archive from an overview GeoParquet file (Plan E0).
     ExportPmtiles(ExportPmtilesArgs),
+    /// Decode a PMTiles vector-tile archive back to GeoParquet.
+    Decode(DecodeArgs),
+}
+
+/// Arguments for `gpq-tiles decode`.
+///
+/// The output is the TILED representation, not the original source data:
+/// geometries are simplified per zoom, clipped to (buffered) tile bounds,
+/// duplicated across neighboring tiles and zoom levels, and only the
+/// properties that survived tiling are present. There is no round-trip
+/// guarantee. Matching tippecanoe-decode, nothing is deduplicated; use
+/// `--zoom` (or filter the output's `zoom` column) for a single
+/// representation, and prefer the maximum zoom for the best detail.
+#[derive(Parser, Debug)]
+#[command(after_help = "\
+The output is the tiled representation, not the original source:
+  - simplified: vertices were removed during tiling at lower zooms
+    (extract the max zoom for best detail)
+  - clipped: features are cut at (buffered) tile boundaries
+  - duplicated: a feature appears once per neighboring tile and per
+    zoom level; nothing is deduplicated (matches tippecanoe-decode) -
+    filter with --zoom or the output's `zoom` column
+  - lossy properties: attributes dropped during tiling cannot be
+    recovered
+There is no round-trip guarantee: A.parquet -> B.pmtiles -> C.parquet
+does not reproduce A. See docs/decode.md for details.")]
+struct DecodeArgs {
+    /// Input PMTiles archive (vector tiles).
+    #[arg(value_name = "INPUT")]
+    input: PathBuf,
+
+    /// Output GeoParquet file.
+    #[arg(value_name = "OUTPUT")]
+    output: PathBuf,
+
+    /// Decode a single zoom level (recommended for most uses).
+    #[arg(long, conflicts_with_all = ["min_zoom", "max_zoom"])]
+    zoom: Option<u8>,
+
+    /// Minimum zoom level to decode.
+    #[arg(long)]
+    min_zoom: Option<u8>,
+
+    /// Maximum zoom level to decode.
+    #[arg(long)]
+    max_zoom: Option<u8>,
+
+    /// Only decode features from this MVT layer.
+    #[arg(long, value_name = "NAME")]
+    layer: Option<String>,
+
+    /// Write the JSON decode report to this path.
+    #[arg(long, value_name = "PATH")]
+    report: Option<PathBuf>,
 }
 
 /// Arguments for `gpq-tiles export-pmtiles`.
@@ -481,6 +535,7 @@ fn main() -> Result<()> {
         Command::Overview(args) => run_overview(*args),
         Command::Validate(args) => run_validate(args),
         Command::ExportPmtiles(args) => run_export_pmtiles(args),
+        Command::Decode(args) => run_decode(args),
         Command::Tiles(args) => run_tiles(args),
     }
 }
@@ -494,7 +549,14 @@ fn rewrite_bare_args<I>(args: I) -> Vec<std::ffi::OsString>
 where
     I: IntoIterator<Item = std::ffi::OsString>,
 {
-    const SUBCOMMANDS: [&str; 5] = ["tiles", "overview", "validate", "export-pmtiles", "help"];
+    const SUBCOMMANDS: [&str; 6] = [
+        "tiles",
+        "overview",
+        "validate",
+        "export-pmtiles",
+        "decode",
+        "help",
+    ];
     let argv: Vec<std::ffi::OsString> = args.into_iter().collect();
 
     // Nothing to rewrite for a bare `gpq-tiles` (clap prints help/usage).
@@ -927,6 +989,64 @@ fn run_export_pmtiles(args: ExportPmtilesArgs) -> Result<()> {
         report.total_tile_features,
         report.oversized_tiles,
         report.duration_secs
+    );
+
+    if let Some(path) = &args.report {
+        let json = serde_json::to_string_pretty(&report)
+            .map_err(|e| anyhow::anyhow!("serialize report: {e}"))?;
+        std::fs::write(path, json)
+            .map_err(|e| anyhow::anyhow!("write report {}: {e}", path.display()))?;
+        println!("  report → {}", path.display());
+    }
+    Ok(())
+}
+
+/// Run `gpq-tiles decode`: PMTiles → GeoParquet (thin facade over
+/// `gpq_tiles_core::decode::decode_pmtiles`).
+fn run_decode(args: DecodeArgs) -> Result<()> {
+    use gpq_tiles_core::decode::{decode_pmtiles, DecodeOptions};
+
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    // `--zoom N` is shorthand for `--min-zoom N --max-zoom N` (clap already
+    // rejects combining them).
+    let (min_zoom, max_zoom) = match args.zoom {
+        Some(z) => (Some(z), Some(z)),
+        None => (args.min_zoom, args.max_zoom),
+    };
+    if let (Some(lo), Some(hi)) = (min_zoom, max_zoom) {
+        if lo > hi {
+            anyhow::bail!("--min-zoom {lo} exceeds --max-zoom {hi}");
+        }
+    }
+    let options = DecodeOptions {
+        min_zoom,
+        max_zoom,
+        layer: args.layer,
+    };
+
+    println!(
+        "Decoding {} → {}",
+        args.input.display(),
+        args.output.display()
+    );
+    let report = decode_pmtiles(&args.input, &args.output, &options)
+        .with_context(|| format!("decode failed for {}", args.input.display()))?;
+
+    match report.zoom_range {
+        Some((lo, hi)) => println!("  zooms z{lo}..z{hi}, layers: {}", report.layers.join(", ")),
+        None => println!("  no features matched the filters"),
+    }
+    println!(
+        "\n✓ {} features from {} tiles ({} skipped as degenerate) in {:.2}s",
+        format_number(report.features_written),
+        format_number(report.tiles_read),
+        report.features_skipped,
+        report.elapsed_secs
+    );
+    println!(
+        "  note: output is the tiled representation (simplified, clipped, \
+         duplicated across zooms); see `gpq-tiles decode --help`"
     );
 
     if let Some(path) = &args.report {

--- a/crates/core/src/compression.rs
+++ b/crates/core/src/compression.rs
@@ -49,6 +49,21 @@ impl Compression {
         *self as u8
     }
 
+    /// Parse a PMTiles spec byte code back into a compression type.
+    ///
+    /// Inverse of [`Compression::code`]. Returns `None` for codes outside the
+    /// PMTiles v3 spec (0-4).
+    pub fn from_code(code: u8) -> Option<Self> {
+        match code {
+            0 => Some(Compression::Unknown),
+            1 => Some(Compression::None),
+            2 => Some(Compression::Gzip),
+            3 => Some(Compression::Brotli),
+            4 => Some(Compression::Zstd),
+            _ => Option::None,
+        }
+    }
+
     /// Get a human-readable name for this compression type.
     pub fn name(&self) -> &'static str {
         match self {
@@ -80,6 +95,52 @@ pub fn compress(data: &[u8], compression: Compression) -> io::Result<Vec<u8>> {
         Compression::Brotli => compress_brotli(data),
         Compression::Zstd => compress_zstd(data),
     }
+}
+
+/// Decompress data using the specified algorithm.
+///
+/// Inverse of [`compress`]: the read side of the PMTiles pipeline (issue
+/// #112) uses this for directories, JSON metadata, and tile data, honoring
+/// the compression codes declared in the archive header.
+///
+/// # Arguments
+/// * `data` - Compressed input data
+/// * `compression` - Compression algorithm the data was compressed with
+///
+/// # Returns
+/// Decompressed data, or a copy of the input if compression is None.
+pub fn decompress(data: &[u8], compression: Compression) -> io::Result<Vec<u8>> {
+    match compression {
+        Compression::Unknown => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Cannot decompress with unknown compression type",
+        )),
+        Compression::None => Ok(data.to_vec()),
+        Compression::Gzip => decompress_gzip(data),
+        Compression::Brotli => decompress_brotli(data),
+        Compression::Zstd => decompress_zstd(data),
+    }
+}
+
+/// Decompress gzip data.
+fn decompress_gzip(data: &[u8]) -> io::Result<Vec<u8>> {
+    use std::io::Read;
+    let mut out = Vec::new();
+    flate2::read::GzDecoder::new(data).read_to_end(&mut out)?;
+    Ok(out)
+}
+
+/// Decompress brotli data.
+fn decompress_brotli(data: &[u8]) -> io::Result<Vec<u8>> {
+    use std::io::Read;
+    let mut out = Vec::new();
+    brotli::Decompressor::new(data, 4096).read_to_end(&mut out)?;
+    Ok(out)
+}
+
+/// Decompress zstd data.
+fn decompress_zstd(data: &[u8]) -> io::Result<Vec<u8>> {
+    zstd::decode_all(data)
 }
 
 /// Compress data with gzip.
@@ -305,5 +366,71 @@ mod tests {
                 compression.name()
             );
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // Decompression (read side, issue #112)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_from_code_inverts_code() {
+        for compression in [
+            Compression::Unknown,
+            Compression::None,
+            Compression::Gzip,
+            Compression::Brotli,
+            Compression::Zstd,
+        ] {
+            assert_eq!(
+                Compression::from_code(compression.code()),
+                Some(compression)
+            );
+        }
+        assert_eq!(Compression::from_code(5), None);
+        assert_eq!(Compression::from_code(255), None);
+    }
+
+    #[test]
+    fn test_decompress_roundtrips_every_codec() {
+        let original = b"PMTiles round-trip payload \x00\x01\x02 with some repetition repetition";
+        for compression in [
+            Compression::None,
+            Compression::Gzip,
+            Compression::Brotli,
+            Compression::Zstd,
+        ] {
+            let compressed = compress(original, compression).unwrap();
+            let decompressed = decompress(&compressed, compression).unwrap();
+            assert_eq!(
+                decompressed,
+                original.to_vec(),
+                "{} round-trip",
+                compression.name()
+            );
+        }
+    }
+
+    #[test]
+    fn test_decompress_empty_payload() {
+        for compression in [
+            Compression::None,
+            Compression::Gzip,
+            Compression::Brotli,
+            Compression::Zstd,
+        ] {
+            let compressed = compress(&[], compression).unwrap();
+            let decompressed = decompress(&compressed, compression).unwrap();
+            assert!(decompressed.is_empty(), "{}", compression.name());
+        }
+    }
+
+    #[test]
+    fn test_decompress_unknown_is_error() {
+        assert!(decompress(b"anything", Compression::Unknown).is_err());
+    }
+
+    #[test]
+    fn test_decompress_corrupt_gzip_is_error() {
+        assert!(decompress(b"not gzip at all", Compression::Gzip).is_err());
     }
 }

--- a/crates/core/src/decode.rs
+++ b/crates/core/src/decode.rs
@@ -1,0 +1,1300 @@
+//! PMTiles → GeoParquet decoding (issue #112).
+//!
+//! Decodes a PMTiles v3 vector-tile archive back into a GeoParquet file,
+//! following the model of `tippecanoe-decode` (decode.cpp / write_json.cpp):
+//!
+//! - **Every feature from every selected tile is emitted — no deduplication.**
+//!   A feature near a tile seam appears once per neighboring tile (buffer
+//!   copies), and once per zoom level of its band. This matches
+//!   tippecanoe-decode; filter by the `zoom` column (or `--zoom` in the CLI)
+//!   for a single representation.
+//! - The output is the **tiled representation**, not the original source:
+//!   geometries are simplified per zoom, clipped to (buffered) tile bounds,
+//!   and properties are whatever survived tiling. There is no round-trip
+//!   guarantee. Extract the maximum zoom for the best available detail.
+//!
+//! # Coordinate transform
+//!
+//! Tile-local integer coordinates are lifted to WGS84 through tippecanoe's
+//! 32-bit Web Mercator world coordinate space (write_json.cpp /
+//! projection.cpp):
+//!
+//! ```text
+//! wscale = 2^(32 - z)
+//! wx = wscale * tile_x + (wscale / extent) * px
+//! lon = wx / 2^32 * 360 - 180
+//! lat = atan(sinh(pi - 2*pi * wy / 2^32)) in degrees
+//! ```
+//!
+//! Computed in f64, which reproduces tippecanoe's integer arithmetic exactly
+//! for power-of-two extents up to `z + log2(extent) <= 52` (i.e. everywhere
+//! in practice; MVT extents are powers of two and z <= 31).
+//!
+//! # Output schema
+//!
+//! Three provenance columns are always present so users can filter the
+//! duplicated representation: `zoom` (UInt8), `layer` (Utf8), and `mvt_id`
+//! (UInt64, nullable — the raw MVT feature id, if any). They are followed by
+//! the union of all property columns seen across tiles/layers (alphabetical,
+//! all nullable; a feature lacking a property gets null), then `geometry`.
+//! A property named like a provenance column is rejected with
+//! [`DecodeError::ReservedColumn`].
+//!
+//! Property types are unified across features: `int`/`sint`/`uint` → Int64
+//! (a `uint` above `i64::MAX` degrades to Float64, like JSON consumers),
+//! `float`/`double` → Float64, Int64 ∪ Float64 → Float64, and any other
+//! mixture (e.g. bool vs string) degrades to Utf8 with values stringified.
+//!
+//! # Divergences from tippecanoe
+//!
+//! - DIVERGENCE FROM TIPPECANOE: tippecanoe-decode emits GeoJSON text; we
+//!   emit GeoParquet through the existing GeoArrow writer stack, which is
+//!   the point of the feature.
+//! - Degenerate MVT content (zero-area rings, one-point linestrings,
+//!   interior rings before any exterior ring) is dropped rather than
+//!   emitted; the MVT spec leaves decoder behavior for these undefined.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Instant;
+
+use arrow_array::builder::{
+    BooleanBuilder, Float64Builder, Int64Builder, StringBuilder, UInt64Builder, UInt8Builder,
+};
+use arrow_array::{ArrayRef, RecordBatch};
+use arrow_schema::{DataType, Field, Schema};
+use geo::{Geometry, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon};
+use geoarrow::array::GeometryBuilder;
+use geoarrow::datatypes::GeometryType;
+use geoarrow_array::GeoArrowArray;
+use geoparquet::writer::{
+    GeoParquetRecordBatchEncoder, GeoParquetWriterEncoding, GeoParquetWriterOptionsBuilder,
+};
+use parquet::arrow::ArrowWriter;
+use prost::Message;
+use serde::Serialize;
+use thiserror::Error;
+
+use crate::compression::decompress;
+use crate::mvt::{command_decode, zigzag_decode};
+use crate::pmtiles_writer::{decode_directory, tile_id_to_zxy, Header, TileType};
+use crate::vector_tile::tile::GeomType;
+use crate::vector_tile::Tile;
+
+/// Rows per output batch (bounds decoder memory to O(batch), matching the
+/// export pipeline's streaming ethos).
+const BATCH_SIZE: usize = 8192;
+
+/// Provenance / structural column names reserved by the decoder.
+const RESERVED_COLUMNS: [&str; 4] = ["zoom", "layer", "mvt_id", "geometry"];
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/// Options for [`decode_pmtiles`].
+#[derive(Debug, Clone, Default)]
+pub struct DecodeOptions {
+    /// Only decode tiles with `zoom >= min_zoom`.
+    pub min_zoom: Option<u8>,
+    /// Only decode tiles with `zoom <= max_zoom`.
+    pub max_zoom: Option<u8>,
+    /// Only decode features from this MVT layer.
+    pub layer: Option<String>,
+}
+
+/// Summary of a completed decode.
+#[derive(Debug, Clone, Serialize)]
+pub struct DecodeReport {
+    /// Tiles read (after zoom filtering).
+    pub tiles_read: u64,
+    /// Feature rows written to the output.
+    pub features_written: u64,
+    /// Features skipped because their geometry decoded to nothing
+    /// (empty / fully degenerate per the module docs).
+    pub features_skipped: u64,
+    /// MVT layers encountered (after layer filtering), sorted.
+    pub layers: Vec<String>,
+    /// Min/max zoom actually written (None when no features were written).
+    pub zoom_range: Option<(u8, u8)>,
+    /// Wall-clock seconds.
+    pub elapsed_secs: f64,
+}
+
+/// Errors from [`decode_pmtiles`].
+#[derive(Debug, Error)]
+pub enum DecodeError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    Archive(#[from] crate::Error),
+
+    #[error("invalid PMTiles archive: {0}")]
+    InvalidArchive(String),
+
+    #[error("archive does not contain vector tiles (tile type {0:?})")]
+    NotVectorTiles(TileType),
+
+    #[error("MVT protobuf decode failed for tile z{z}/{x}/{y}: {source}")]
+    Mvt {
+        z: u8,
+        x: u32,
+        y: u32,
+        source: prost::DecodeError,
+    },
+
+    #[error("invalid MVT geometry in tile z{z}/{x}/{y}: {reason}")]
+    Geometry {
+        z: u8,
+        x: u32,
+        y: u32,
+        reason: String,
+    },
+
+    #[error(
+        "property column {0:?} collides with a decoder provenance column; \
+         rename it in the source data or decode with a layer filter"
+    )]
+    ReservedColumn(String),
+
+    #[error("Arrow error: {0}")]
+    Arrow(#[from] arrow_schema::ArrowError),
+
+    #[error("Parquet error: {0}")]
+    Parquet(#[from] parquet::errors::ParquetError),
+
+    #[error("GeoParquet write failed: {0}")]
+    Write(String),
+}
+
+/// Decode a PMTiles archive into a GeoParquet file.
+///
+/// See the module docs for output semantics (no deduplication, tiled
+/// representation, provenance columns, property type unification).
+pub fn decode_pmtiles(
+    input_path: impl AsRef<Path>,
+    output_path: impl AsRef<Path>,
+    options: &DecodeOptions,
+) -> Result<DecodeReport, DecodeError> {
+    let start = Instant::now();
+    let bytes = std::fs::read(input_path.as_ref())?;
+    let header = Header::from_bytes(&bytes)?;
+    if header.tile_type != TileType::Mvt {
+        return Err(DecodeError::NotVectorTiles(header.tile_type));
+    }
+
+    let tiles = collect_tile_refs(&bytes, &header, options)?;
+
+    // ---- Pass A: property schema union + layer inventory. -----------------
+    // Tiles are decoded twice (schema first, rows second) so peak memory
+    // stays O(one tile + one batch) instead of O(all features).
+    let mut col_types: BTreeMap<String, ColType> = BTreeMap::new();
+    let mut layers: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for tile in &tiles {
+        for (layer_name, feature) in decode_tile_features(&bytes, &header, tile, options)? {
+            layers.insert(layer_name);
+            for (key, value) in &feature.props {
+                if RESERVED_COLUMNS.contains(&key.as_str()) {
+                    return Err(DecodeError::ReservedColumn(key.clone()));
+                }
+                let t = ColType::of(value);
+                col_types
+                    .entry(key.clone())
+                    .and_modify(|e| *e = e.unify(t))
+                    .or_insert(t);
+            }
+        }
+    }
+
+    // ---- Output schema: zoom, layer, mvt_id, properties (sorted), geometry.
+    let geom_field = GeometryBuilder::new(GeometryType::new(Default::default()))
+        .finish()
+        .data_type()
+        .to_field("geometry", true);
+    let mut fields: Vec<Arc<Field>> = vec![
+        Arc::new(Field::new("zoom", DataType::UInt8, false)),
+        Arc::new(Field::new("layer", DataType::Utf8, false)),
+        Arc::new(Field::new("mvt_id", DataType::UInt64, true)),
+    ];
+    for (name, t) in &col_types {
+        fields.push(Arc::new(Field::new(name, t.arrow_type(), true)));
+    }
+    fields.push(Arc::new(geom_field));
+    let schema = Arc::new(Schema::new(fields));
+
+    let gpq_options = GeoParquetWriterOptionsBuilder::default()
+        .set_encoding(GeoParquetWriterEncoding::WKB)
+        .set_generate_covering(true)
+        .build();
+    let mut encoder = GeoParquetRecordBatchEncoder::try_new(&schema, &gpq_options)
+        .map_err(|e| DecodeError::Write(e.to_string()))?;
+    let file = std::fs::File::create(output_path.as_ref())?;
+    let mut writer = ArrowWriter::try_new(file, encoder.target_schema(), None)?;
+
+    // ---- Pass B: decode again, batch rows, stream to the writer. ----------
+    let mut report = DecodeReport {
+        tiles_read: tiles.len() as u64,
+        features_written: 0,
+        features_skipped: 0,
+        layers: layers.into_iter().collect(),
+        zoom_range: None,
+        elapsed_secs: 0.0,
+    };
+    let mut batch = RowBatch::new(&col_types);
+    for tile in &tiles {
+        for (layer_name, feature) in decode_tile_features(&bytes, &header, tile, options)? {
+            match feature.geometry {
+                Some(geometry) => {
+                    batch.push(
+                        tile.z,
+                        &layer_name,
+                        feature.mvt_id,
+                        &feature.props,
+                        geometry,
+                    );
+                    report.features_written += 1;
+                    report.zoom_range = Some(match report.zoom_range {
+                        Some((lo, hi)) => (lo.min(tile.z), hi.max(tile.z)),
+                        None => (tile.z, tile.z),
+                    });
+                    if batch.len() >= BATCH_SIZE {
+                        flush_batch(&mut batch, &schema, &mut encoder, &mut writer, &col_types)?;
+                    }
+                }
+                None => report.features_skipped += 1,
+            }
+        }
+    }
+    if batch.len() > 0 {
+        flush_batch(&mut batch, &schema, &mut encoder, &mut writer, &col_types)?;
+    }
+
+    writer.append_key_value_metadata(
+        encoder
+            .into_keyvalue()
+            .map_err(|e| DecodeError::Write(e.to_string()))?,
+    );
+    writer.close()?;
+
+    report.elapsed_secs = start.elapsed().as_secs_f64();
+    Ok(report)
+}
+
+// ============================================================================
+// Archive walking
+// ============================================================================
+
+/// A located tile: coordinates plus the byte range of its (compressed) data.
+struct TileRef {
+    z: u8,
+    x: u32,
+    y: u32,
+    start: usize,
+    len: usize,
+}
+
+/// Walk the root (and any leaf) directories, expand run-length entries, and
+/// apply the zoom filter. Entries arrive in ascending tile-id order (the
+/// writer emits clustered archives), which the output preserves.
+fn collect_tile_refs(
+    bytes: &[u8],
+    header: &Header,
+    options: &DecodeOptions,
+) -> Result<Vec<TileRef>, DecodeError> {
+    let section = |offset: u64, length: u64, what: &str| -> Result<&[u8], DecodeError> {
+        let start = usize::try_from(offset)
+            .map_err(|_| DecodeError::InvalidArchive(format!("{what} offset overflow")))?;
+        let end = start
+            .checked_add(
+                usize::try_from(length)
+                    .map_err(|_| DecodeError::InvalidArchive(format!("{what} length overflow")))?,
+            )
+            .filter(|&e| e <= bytes.len())
+            .ok_or_else(|| {
+                DecodeError::InvalidArchive(format!("{what} extends past end of file"))
+            })?;
+        Ok(&bytes[start..end])
+    };
+
+    let decode_dir = |raw: &[u8], what: &str| -> Result<Vec<_>, DecodeError> {
+        let plain = decompress(raw, header.internal_compression)?;
+        decode_directory(&plain)
+            .ok_or_else(|| DecodeError::InvalidArchive(format!("undecodable {what}")))
+    };
+
+    let root_raw = section(
+        header.root_dir_offset,
+        header.root_dir_length,
+        "root directory",
+    )?;
+    let root = decode_dir(root_raw, "root directory")?;
+
+    let mut entries = Vec::new();
+    for entry in root {
+        if entry.run_length == 0 {
+            // Leaf directory: offset is relative to the leaf-dirs section.
+            let leaf_raw = section(
+                header.leaf_dirs_offset + entry.offset,
+                u64::from(entry.length),
+                "leaf directory",
+            )?;
+            entries.extend(decode_dir(leaf_raw, "leaf directory")?);
+        } else {
+            entries.push(entry);
+        }
+    }
+
+    let mut tiles = Vec::new();
+    for entry in &entries {
+        for i in 0..u64::from(entry.run_length.max(1)) {
+            let (z, x, y) = tile_id_to_zxy(entry.tile_id + i)?;
+            if options.min_zoom.is_some_and(|mz| z < mz)
+                || options.max_zoom.is_some_and(|mz| z > mz)
+            {
+                continue;
+            }
+            // Validate the range now so pass B can slice without checks.
+            section(
+                header.tile_data_offset + entry.offset,
+                u64::from(entry.length),
+                "tile data",
+            )?;
+            tiles.push(TileRef {
+                z,
+                x,
+                y,
+                start: (header.tile_data_offset + entry.offset) as usize,
+                len: entry.length as usize,
+            });
+        }
+    }
+    Ok(tiles)
+}
+
+// ============================================================================
+// Tile decoding: MVT bytes -> features
+// ============================================================================
+
+/// One decoded feature. `geometry` is `None` when the MVT geometry decoded
+/// to nothing (empty command stream / fully degenerate content).
+struct DecodedFeature {
+    geometry: Option<Geometry<f64>>,
+    mvt_id: Option<u64>,
+    props: Vec<(String, PropValue)>,
+}
+
+/// Decompress and decode one tile into `(layer_name, feature)` pairs,
+/// applying the layer filter and the coordinate transform.
+fn decode_tile_features(
+    bytes: &[u8],
+    header: &Header,
+    tile: &TileRef,
+    options: &DecodeOptions,
+) -> Result<Vec<(String, DecodedFeature)>, DecodeError> {
+    let raw = &bytes[tile.start..tile.start + tile.len];
+    let plain = decompress(raw, header.tile_compression)?;
+    let decoded = Tile::decode(plain.as_slice()).map_err(|source| DecodeError::Mvt {
+        z: tile.z,
+        x: tile.x,
+        y: tile.y,
+        source,
+    })?;
+
+    let mut out = Vec::new();
+    for layer in &decoded.layers {
+        if options.layer.as_ref().is_some_and(|l| *l != layer.name) {
+            continue;
+        }
+        let extent = layer.extent.unwrap_or(4096);
+        for feature in &layer.features {
+            let parts = parse_command_stream(&feature.geometry).map_err(|reason| {
+                DecodeError::Geometry {
+                    z: tile.z,
+                    x: tile.x,
+                    y: tile.y,
+                    reason,
+                }
+            })?;
+            let geometry = assemble_geometry(feature.r#type(), &parts, |px, py| {
+                tile_local_to_lonlat(tile.z, tile.x, tile.y, extent, px, py)
+            });
+
+            let mut props = Vec::new();
+            for pair in feature.tags.chunks(2) {
+                if pair.len() != 2 {
+                    return Err(DecodeError::Geometry {
+                        z: tile.z,
+                        x: tile.x,
+                        y: tile.y,
+                        reason: "odd-length tag list".to_string(),
+                    });
+                }
+                let key =
+                    layer
+                        .keys
+                        .get(pair[0] as usize)
+                        .ok_or_else(|| DecodeError::Geometry {
+                            z: tile.z,
+                            x: tile.x,
+                            y: tile.y,
+                            reason: format!("tag key index {} out of range", pair[0]),
+                        })?;
+                let value =
+                    layer
+                        .values
+                        .get(pair[1] as usize)
+                        .ok_or_else(|| DecodeError::Geometry {
+                            z: tile.z,
+                            x: tile.x,
+                            y: tile.y,
+                            reason: format!("tag value index {} out of range", pair[1]),
+                        })?;
+                if let Some(v) = PropValue::from_mvt(value) {
+                    props.push((key.clone(), v));
+                }
+            }
+
+            out.push((
+                layer.name.clone(),
+                DecodedFeature {
+                    geometry,
+                    mvt_id: feature.id,
+                    props,
+                },
+            ));
+        }
+    }
+    Ok(out)
+}
+
+// ============================================================================
+// MVT geometry command stream -> parts -> geo::Geometry
+// ============================================================================
+
+/// One MoveTo-initiated run of vertices in tile-local coordinates.
+struct Part {
+    /// Vertices, without the implicit ClosePath closing vertex.
+    pts: Vec<(i64, i64)>,
+    /// Whether the part was terminated by ClosePath (i.e. it is a ring).
+    closed: bool,
+}
+
+impl Part {
+    /// Twice the signed area by the surveyor's formula on raw tile coords.
+    /// Per the MVT spec, positive ⇒ exterior ring, negative ⇒ interior ring
+    /// (Y axis points down in tile space).
+    fn area2(&self) -> i64 {
+        let n = self.pts.len();
+        let mut sum = 0i64;
+        for i in 0..n {
+            let (x0, y0) = self.pts[i];
+            let (x1, y1) = self.pts[(i + 1) % n];
+            sum += x0 * y1 - x1 * y0;
+        }
+        sum
+    }
+}
+
+/// Parse an MVT geometry command stream (MoveTo/LineTo/ClosePath with
+/// zigzag-encoded deltas) into parts. Each MoveTo coordinate starts a new
+/// part, so multipoints come out as one single-vertex part per point.
+fn parse_command_stream(geom: &[u32]) -> Result<Vec<Part>, String> {
+    const CMD_MOVE_TO: u32 = 1;
+    const CMD_LINE_TO: u32 = 2;
+    const CMD_CLOSE_PATH: u32 = 7;
+
+    let mut parts: Vec<Part> = Vec::new();
+    let mut cur: Vec<(i64, i64)> = Vec::new();
+    let (mut cx, mut cy) = (0i64, 0i64);
+    let mut i = 0usize;
+
+    let take_pair = |i: &mut usize, cx: &mut i64, cy: &mut i64| -> Result<(), String> {
+        if *i + 1 >= geom.len() {
+            return Err("truncated coordinate pair".to_string());
+        }
+        *cx += i64::from(zigzag_decode(geom[*i]));
+        *cy += i64::from(zigzag_decode(geom[*i + 1]));
+        *i += 2;
+        Ok(())
+    };
+
+    while i < geom.len() {
+        let (cmd, count) = command_decode(geom[i]);
+        i += 1;
+        match cmd {
+            CMD_MOVE_TO => {
+                for _ in 0..count {
+                    take_pair(&mut i, &mut cx, &mut cy)?;
+                    if !cur.is_empty() {
+                        parts.push(Part {
+                            pts: std::mem::take(&mut cur),
+                            closed: false,
+                        });
+                    }
+                    cur.push((cx, cy));
+                }
+            }
+            CMD_LINE_TO => {
+                for _ in 0..count {
+                    take_pair(&mut i, &mut cx, &mut cy)?;
+                    cur.push((cx, cy));
+                }
+            }
+            CMD_CLOSE_PATH => {
+                if !cur.is_empty() {
+                    parts.push(Part {
+                        pts: std::mem::take(&mut cur),
+                        closed: true,
+                    });
+                }
+            }
+            other => return Err(format!("unknown MVT command id {other}")),
+        }
+    }
+    if !cur.is_empty() {
+        parts.push(Part {
+            pts: cur,
+            closed: false,
+        });
+    }
+    Ok(parts)
+}
+
+/// Assemble parsed parts into a `geo::Geometry` in WGS84, per the MVT spec
+/// rules for each geometry type. Returns `None` when nothing valid remains
+/// (see module docs for the degenerate cases that are dropped).
+fn assemble_geometry(
+    geom_type: GeomType,
+    parts: &[Part],
+    tf: impl Fn(i64, i64) -> (f64, f64),
+) -> Option<Geometry<f64>> {
+    match geom_type {
+        GeomType::Point => {
+            let pts: Vec<Point<f64>> = parts
+                .iter()
+                .flat_map(|p| p.pts.iter())
+                .map(|&(x, y)| Point::from(tf(x, y)))
+                .collect();
+            match pts.len() {
+                0 => None,
+                1 => Some(Geometry::Point(pts.into_iter().next().expect("len 1"))),
+                _ => Some(Geometry::MultiPoint(MultiPoint::new(pts))),
+            }
+        }
+        GeomType::Linestring => {
+            let lines: Vec<LineString<f64>> = parts
+                .iter()
+                .filter(|p| p.pts.len() >= 2)
+                .map(|p| LineString::from(p.pts.iter().map(|&(x, y)| tf(x, y)).collect::<Vec<_>>()))
+                .collect();
+            match lines.len() {
+                0 => None,
+                1 => Some(Geometry::LineString(
+                    lines.into_iter().next().expect("len 1"),
+                )),
+                _ => Some(Geometry::MultiLineString(MultiLineString::new(lines))),
+            }
+        }
+        GeomType::Polygon => {
+            let mut polys: Vec<(LineString<f64>, Vec<LineString<f64>>)> = Vec::new();
+            for part in parts {
+                // Rings must be closed and have >= 3 vertices; zero-area
+                // rings carry no winding information. Drop degenerates.
+                if !part.closed || part.pts.len() < 3 {
+                    continue;
+                }
+                let area2 = part.area2();
+                if area2 == 0 {
+                    continue;
+                }
+                let ring =
+                    LineString::from(part.pts.iter().map(|&(x, y)| tf(x, y)).collect::<Vec<_>>());
+                if area2 > 0 {
+                    polys.push((ring, Vec::new()));
+                } else if let Some(last) = polys.last_mut() {
+                    last.1.push(ring);
+                }
+                // Interior ring before any exterior: dropped (undefined per
+                // MVT spec; see module docs).
+            }
+            let polys: Vec<Polygon<f64>> = polys
+                .into_iter()
+                .map(|(ext, holes)| Polygon::new(ext, holes))
+                .collect();
+            match polys.len() {
+                0 => None,
+                1 => Some(Geometry::Polygon(polys.into_iter().next().expect("len 1"))),
+                _ => Some(Geometry::MultiPolygon(MultiPolygon::new(polys))),
+            }
+        }
+        GeomType::Unknown => None,
+    }
+}
+
+// ============================================================================
+// Coordinate transform (tippecanoe write_json.cpp / projection.cpp)
+// ============================================================================
+
+/// Transform tile-local coordinates to WGS84 lon/lat.
+///
+/// See the module docs for the formula and its exactness envelope. Buffered
+/// coordinates (px/py outside `0..extent`) transform fine — they simply land
+/// outside the tile's geographic bounds, exactly as tippecanoe-decode emits
+/// them.
+pub fn tile_local_to_lonlat(z: u8, tx: u32, ty: u32, extent: u32, px: i64, py: i64) -> (f64, f64) {
+    const WORLD: f64 = 4_294_967_296.0; // 2^32
+    let wscale = 2f64.powi(32 - i32::from(z));
+    let wx = wscale * f64::from(tx) + (wscale / f64::from(extent)) * px as f64;
+    let wy = wscale * f64::from(ty) + (wscale / f64::from(extent)) * py as f64;
+    let lon = wx / WORLD * 360.0 - 180.0;
+    let n = std::f64::consts::PI - 2.0 * std::f64::consts::PI * wy / WORLD;
+    let lat = n.sinh().atan().to_degrees();
+    (lon, lat)
+}
+
+// ============================================================================
+// Properties: MVT Value -> unified Arrow columns
+// ============================================================================
+
+/// A decoded MVT property value (already normalized: uint that fits i64 is
+/// Int, larger uints degrade to Float — see module docs).
+#[derive(Debug, Clone, PartialEq)]
+enum PropValue {
+    Bool(bool),
+    Int(i64),
+    Float(f64),
+    Str(String),
+}
+
+impl PropValue {
+    /// Decode an MVT `Value`. Returns `None` for a value with no field set
+    /// (invalid per spec; skipped rather than fatal).
+    fn from_mvt(v: &crate::vector_tile::tile::Value) -> Option<Self> {
+        if let Some(s) = &v.string_value {
+            Some(PropValue::Str(s.clone()))
+        } else if let Some(f) = v.float_value {
+            Some(PropValue::Float(f64::from(f)))
+        } else if let Some(d) = v.double_value {
+            Some(PropValue::Float(d))
+        } else if let Some(i) = v.int_value {
+            Some(PropValue::Int(i))
+        } else if let Some(u) = v.uint_value {
+            match i64::try_from(u) {
+                Ok(i) => Some(PropValue::Int(i)),
+                Err(_) => Some(PropValue::Float(u as f64)),
+            }
+        } else if let Some(i) = v.sint_value {
+            Some(PropValue::Int(i))
+        } else {
+            v.bool_value.map(PropValue::Bool)
+        }
+    }
+
+    /// Stringified form, used when a column degrades to Utf8.
+    fn to_string_lossy(&self) -> String {
+        match self {
+            PropValue::Bool(b) => b.to_string(),
+            PropValue::Int(i) => i.to_string(),
+            PropValue::Float(f) => f.to_string(),
+            PropValue::Str(s) => s.clone(),
+        }
+    }
+}
+
+/// Unified Arrow column type for a property across all features.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ColType {
+    Bool,
+    Int,
+    Float,
+    Str,
+}
+
+impl ColType {
+    fn of(v: &PropValue) -> Self {
+        match v {
+            PropValue::Bool(_) => ColType::Bool,
+            PropValue::Int(_) => ColType::Int,
+            PropValue::Float(_) => ColType::Float,
+            PropValue::Str(_) => ColType::Str,
+        }
+    }
+
+    /// Promotion lattice: identical stays; Int ∪ Float = Float; everything
+    /// else (bool vs number, anything vs string) degrades to Utf8.
+    fn unify(self, other: Self) -> Self {
+        use ColType::*;
+        match (self, other) {
+            (a, b) if a == b => a,
+            (Int, Float) | (Float, Int) => Float,
+            _ => Str,
+        }
+    }
+
+    fn arrow_type(self) -> DataType {
+        match self {
+            ColType::Bool => DataType::Boolean,
+            ColType::Int => DataType::Int64,
+            ColType::Float => DataType::Float64,
+            ColType::Str => DataType::Utf8,
+        }
+    }
+}
+
+// ============================================================================
+// Row batching -> Arrow -> GeoParquet
+// ============================================================================
+
+/// Column-oriented buffer for one output batch.
+struct RowBatch {
+    zoom: UInt8Builder,
+    layer: StringBuilder,
+    mvt_id: UInt64Builder,
+    props: BTreeMap<String, PropColumn>,
+    geoms: Vec<Geometry<f64>>,
+}
+
+enum PropColumn {
+    Bool(BooleanBuilder),
+    Int(Int64Builder),
+    Float(Float64Builder),
+    Str(StringBuilder),
+}
+
+impl PropColumn {
+    fn for_type(t: ColType) -> Self {
+        match t {
+            ColType::Bool => PropColumn::Bool(BooleanBuilder::new()),
+            ColType::Int => PropColumn::Int(Int64Builder::new()),
+            ColType::Float => PropColumn::Float(Float64Builder::new()),
+            ColType::Str => PropColumn::Str(StringBuilder::new()),
+        }
+    }
+
+    /// Append a value, coercing per the promotion lattice (a column typed
+    /// Float may receive Int values; a column typed Str may receive any).
+    fn append(&mut self, v: Option<&PropValue>) {
+        match (self, v) {
+            (PropColumn::Bool(b), Some(PropValue::Bool(x))) => b.append_value(*x),
+            (PropColumn::Int(b), Some(PropValue::Int(x))) => b.append_value(*x),
+            (PropColumn::Float(b), Some(PropValue::Float(x))) => b.append_value(*x),
+            (PropColumn::Float(b), Some(PropValue::Int(x))) => b.append_value(*x as f64),
+            (PropColumn::Str(b), Some(x)) => b.append_value(x.to_string_lossy()),
+            (PropColumn::Bool(b), None) => b.append_null(),
+            (PropColumn::Int(b), None) => b.append_null(),
+            (PropColumn::Float(b), None) => b.append_null(),
+            (PropColumn::Str(b), None) => b.append_null(),
+            // Unreachable by construction: pass A fixed the column type as
+            // the unified supertype of every value.
+            (col, Some(other)) => {
+                unreachable!(
+                    "value {other:?} does not fit unified column {:?}",
+                    col.kind()
+                )
+            }
+        }
+    }
+
+    fn kind(&self) -> ColType {
+        match self {
+            PropColumn::Bool(_) => ColType::Bool,
+            PropColumn::Int(_) => ColType::Int,
+            PropColumn::Float(_) => ColType::Float,
+            PropColumn::Str(_) => ColType::Str,
+        }
+    }
+
+    fn finish(&mut self) -> ArrayRef {
+        match self {
+            PropColumn::Bool(b) => Arc::new(b.finish()),
+            PropColumn::Int(b) => Arc::new(b.finish()),
+            PropColumn::Float(b) => Arc::new(b.finish()),
+            PropColumn::Str(b) => Arc::new(b.finish()),
+        }
+    }
+}
+
+impl RowBatch {
+    fn new(col_types: &BTreeMap<String, ColType>) -> Self {
+        RowBatch {
+            zoom: UInt8Builder::new(),
+            layer: StringBuilder::new(),
+            mvt_id: UInt64Builder::new(),
+            props: col_types
+                .iter()
+                .map(|(k, t)| (k.clone(), PropColumn::for_type(*t)))
+                .collect(),
+            geoms: Vec::new(),
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.geoms.len()
+    }
+
+    fn push(
+        &mut self,
+        zoom: u8,
+        layer: &str,
+        mvt_id: Option<u64>,
+        props: &[(String, PropValue)],
+        geometry: Geometry<f64>,
+    ) {
+        self.zoom.append_value(zoom);
+        self.layer.append_value(layer);
+        match mvt_id {
+            Some(id) => self.mvt_id.append_value(id),
+            None => self.mvt_id.append_null(),
+        }
+        for (name, col) in self.props.iter_mut() {
+            // Last occurrence wins if a tag key repeats within one feature.
+            let v = props.iter().rev().find(|(k, _)| k == name).map(|(_, v)| v);
+            col.append(v);
+        }
+        self.geoms.push(geometry);
+    }
+}
+
+/// Convert the buffered rows into a RecordBatch, encode, and write it.
+fn flush_batch(
+    batch: &mut RowBatch,
+    schema: &Arc<Schema>,
+    encoder: &mut GeoParquetRecordBatchEncoder,
+    writer: &mut ArrowWriter<std::fs::File>,
+    col_types: &BTreeMap<String, ColType>,
+) -> Result<(), DecodeError> {
+    let mut geom_builder = GeometryBuilder::new(GeometryType::new(Default::default()));
+    geom_builder.extend_from_iter(batch.geoms.iter().map(Some));
+    let geom_arr = geom_builder.finish();
+
+    let mut columns: Vec<ArrayRef> = vec![
+        Arc::new(batch.zoom.finish()),
+        Arc::new(batch.layer.finish()),
+        Arc::new(batch.mvt_id.finish()),
+    ];
+    for col in batch.props.values_mut() {
+        columns.push(col.finish());
+    }
+    columns.push(geom_arr.to_array_ref());
+
+    let record = RecordBatch::try_new(schema.clone(), columns)?;
+    let encoded = encoder
+        .encode_record_batch(&record)
+        .map_err(|e| DecodeError::Write(e.to_string()))?;
+    writer.write(&encoded)?;
+
+    *batch = RowBatch::new(col_types);
+    Ok(())
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mvt::{command_encode, encode_geometry, zigzag_encode};
+    use crate::tile::{tile_bounds, TileBounds};
+    use geo::{MultiLineString, MultiPoint, MultiPolygon};
+
+    // ---- Coordinate transform ---------------------------------------------
+
+    /// One tile-local unit in degrees of longitude at (z, extent).
+    fn lon_unit(z: u8, extent: u32) -> f64 {
+        360.0 / ((1u64 << z) as f64 * f64::from(extent))
+    }
+
+    #[test]
+    fn transform_tile_origin_of_world_tile_is_northwest_corner() {
+        let (lon, lat) = tile_local_to_lonlat(0, 0, 0, 4096, 0, 0);
+        assert!((lon - (-180.0)).abs() < 1e-9);
+        assert!((lat - 85.051_128_779_806_59).abs() < 1e-6); // top of Mercator
+    }
+
+    #[test]
+    fn transform_tile_center_of_world_tile_is_null_island() {
+        let (lon, lat) = tile_local_to_lonlat(0, 0, 0, 4096, 2048, 2048);
+        assert!(lon.abs() < 1e-9, "{lon}");
+        assert!(lat.abs() < 1e-9, "{lat}");
+    }
+
+    #[test]
+    fn transform_matches_tile_bounds_corners() {
+        // The tile's (0,0) and (extent,extent) corners must land on the
+        // geographic bounds our own tiler computes for that tile.
+        for (z, x, y) in [(1u8, 1u32, 0u32), (5, 17, 11), (14, 4823, 6160)] {
+            let b = tile_bounds(x, y, z);
+            let (lon0, lat0) = tile_local_to_lonlat(z, x, y, 4096, 0, 0);
+            let (lon1, lat1) = tile_local_to_lonlat(z, x, y, 4096, 4096, 4096);
+            assert!((lon0 - b.lng_min).abs() < 1e-9, "z{z} lng_min");
+            assert!((lat0 - b.lat_max).abs() < 1e-6, "z{z} lat_max");
+            assert!((lon1 - b.lng_max).abs() < 1e-9, "z{z} lng_max");
+            assert!((lat1 - b.lat_min).abs() < 1e-6, "z{z} lat_min");
+        }
+    }
+
+    #[test]
+    fn transform_handles_buffered_coordinates_outside_tile() {
+        // Buffer pixels land monotonically outside the tile bounds.
+        let b = tile_bounds(100, 200, 9);
+        let (lon, lat) = tile_local_to_lonlat(9, 100, 200, 4096, -64, -64);
+        assert!(lon < b.lng_min);
+        assert!(lat > b.lat_max);
+    }
+
+    // ---- Command stream parsing -------------------------------------------
+
+    #[test]
+    fn parse_rejects_truncated_stream() {
+        // MoveTo count=1 but only one parameter integer.
+        let geom = vec![command_encode(1, 1), zigzag_encode(5)];
+        assert!(parse_command_stream(&geom).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_unknown_command() {
+        let geom = vec![command_encode(5, 1), 0, 0];
+        assert!(parse_command_stream(&geom).is_err());
+    }
+
+    #[test]
+    fn parse_empty_stream_is_empty() {
+        assert!(parse_command_stream(&[]).unwrap().is_empty());
+    }
+
+    // ---- Geometry assembly: round-trip against our own MVT encoder --------
+
+    /// Encode a geometry with the production encoder for the given tile,
+    /// then parse + assemble it back and return the decoded geometry.
+    fn roundtrip(geom: &Geometry<f64>, z: u8, x: u32, y: u32) -> Option<Geometry<f64>> {
+        let bounds: TileBounds = tile_bounds(x, y, z);
+        // encode_geometry returns the MVT GeomType alongside the commands;
+        // feed both straight into the decoder, mirroring decode_tile_features.
+        let (commands, geom_type) = encode_geometry(geom, &bounds, 4096);
+        let parts = parse_command_stream(&commands).unwrap();
+        assemble_geometry(geom_type, &parts, |px, py| {
+            tile_local_to_lonlat(z, x, y, 4096, px, py)
+        })
+    }
+
+    /// Assert two coordinates match within n tile-local quantization units.
+    fn assert_close(got: (f64, f64), want: (f64, f64), z: u8, what: &str) {
+        let tol = lon_unit(z, 4096);
+        assert!(
+            (got.0 - want.0).abs() <= tol && (got.1 - want.1).abs() <= tol,
+            "{what}: got {got:?}, want {want:?}, tol {tol}"
+        );
+    }
+
+    #[test]
+    fn assemble_point_roundtrip() {
+        let z = 10;
+        let b = tile_bounds(301, 385, z); // contains (-74.xx, 40.xx)
+        let p = Point::new((b.lng_min + b.lng_max) / 2.0, (b.lat_min + b.lat_max) / 2.0);
+        let got = roundtrip(&Geometry::Point(p), z, 301, 385).unwrap();
+        match got {
+            Geometry::Point(q) => assert_close((q.x(), q.y()), (p.x(), p.y()), z, "point"),
+            other => panic!("expected Point, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn assemble_multipoint_roundtrip() {
+        let z = 10;
+        let (x, y) = (301, 385);
+        let b = tile_bounds(x, y, z);
+        let w = b.lng_max - b.lng_min;
+        let h = b.lat_max - b.lat_min;
+        let pts = vec![
+            Point::new(b.lng_min + 0.25 * w, b.lat_min + 0.25 * h),
+            Point::new(b.lng_min + 0.50 * w, b.lat_min + 0.50 * h),
+            Point::new(b.lng_min + 0.75 * w, b.lat_min + 0.75 * h),
+        ];
+        let got = roundtrip(&Geometry::MultiPoint(MultiPoint::new(pts.clone())), z, x, y).unwrap();
+        match got {
+            Geometry::MultiPoint(mp) => {
+                assert_eq!(mp.0.len(), 3);
+                for (q, p) in mp.0.iter().zip(&pts) {
+                    assert_close((q.x(), q.y()), (p.x(), p.y()), z, "multipoint vertex");
+                }
+            }
+            other => panic!("expected MultiPoint, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn assemble_linestring_roundtrip() {
+        let z = 12;
+        let (x, y) = (1205, 1539);
+        let b = tile_bounds(x, y, z);
+        let w = b.lng_max - b.lng_min;
+        let h = b.lat_max - b.lat_min;
+        let line = LineString::from(vec![
+            (b.lng_min + 0.1 * w, b.lat_min + 0.1 * h),
+            (b.lng_min + 0.5 * w, b.lat_min + 0.7 * h),
+            (b.lng_min + 0.9 * w, b.lat_min + 0.2 * h),
+        ]);
+        let got = roundtrip(&Geometry::LineString(line.clone()), z, x, y).unwrap();
+        match got {
+            Geometry::LineString(l) => {
+                assert_eq!(l.0.len(), 3);
+                for (q, p) in l.0.iter().zip(line.0.iter()) {
+                    assert_close((q.x, q.y), (p.x, p.y), z, "linestring vertex");
+                }
+            }
+            other => panic!("expected LineString, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn assemble_multilinestring_roundtrip() {
+        let z = 12;
+        let (x, y) = (1205, 1539);
+        let b = tile_bounds(x, y, z);
+        let w = b.lng_max - b.lng_min;
+        let h = b.lat_max - b.lat_min;
+        let mls = MultiLineString::new(vec![
+            LineString::from(vec![
+                (b.lng_min + 0.1 * w, b.lat_min + 0.1 * h),
+                (b.lng_min + 0.3 * w, b.lat_min + 0.3 * h),
+            ]),
+            LineString::from(vec![
+                (b.lng_min + 0.6 * w, b.lat_min + 0.6 * h),
+                (b.lng_min + 0.9 * w, b.lat_min + 0.8 * h),
+                (b.lng_min + 0.9 * w, b.lat_min + 0.9 * h),
+            ]),
+        ]);
+        let got = roundtrip(&Geometry::MultiLineString(mls.clone()), z, x, y).unwrap();
+        match got {
+            Geometry::MultiLineString(l) => {
+                assert_eq!(l.0.len(), 2);
+                assert_eq!(l.0[0].0.len(), 2);
+                assert_eq!(l.0[1].0.len(), 3);
+            }
+            other => panic!("expected MultiLineString, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn assemble_polygon_with_hole_roundtrip() {
+        let z = 12;
+        let (x, y) = (1205, 1539);
+        let b = tile_bounds(x, y, z);
+        let w = b.lng_max - b.lng_min;
+        let h = b.lat_max - b.lat_min;
+        let sq = |x0: f64, y0: f64, x1: f64, y1: f64| {
+            LineString::from(vec![
+                (b.lng_min + x0 * w, b.lat_min + y0 * h),
+                (b.lng_min + x1 * w, b.lat_min + y0 * h),
+                (b.lng_min + x1 * w, b.lat_min + y1 * h),
+                (b.lng_min + x0 * w, b.lat_min + y1 * h),
+                (b.lng_min + x0 * w, b.lat_min + y0 * h),
+            ])
+        };
+        let poly = Polygon::new(sq(0.1, 0.1, 0.9, 0.9), vec![sq(0.4, 0.4, 0.6, 0.6)]);
+        let got = roundtrip(&Geometry::Polygon(poly), z, x, y).unwrap();
+        match got {
+            Geometry::Polygon(p) => {
+                assert_eq!(p.exterior().0.len(), 5, "exterior ring closed, 4 corners");
+                assert_eq!(p.interiors().len(), 1, "hole preserved");
+                assert_eq!(p.interiors()[0].0.len(), 5);
+                // Spot-check one corner within tolerance.
+                let want = (b.lng_min + 0.1 * w, b.lat_min + 0.1 * h);
+                let found = p
+                    .exterior()
+                    .0
+                    .iter()
+                    .map(|c| (c.x - want.0).abs().max((c.y - want.1).abs()))
+                    .fold(f64::INFINITY, f64::min);
+                assert!(found <= lon_unit(z, 4096), "corner error {found}");
+            }
+            other => panic!("expected Polygon, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn assemble_multipolygon_roundtrip() {
+        let z = 12;
+        let (x, y) = (1205, 1539);
+        let b = tile_bounds(x, y, z);
+        let w = b.lng_max - b.lng_min;
+        let h = b.lat_max - b.lat_min;
+        let sq = |x0: f64, y0: f64, x1: f64, y1: f64| {
+            Polygon::new(
+                LineString::from(vec![
+                    (b.lng_min + x0 * w, b.lat_min + y0 * h),
+                    (b.lng_min + x1 * w, b.lat_min + y0 * h),
+                    (b.lng_min + x1 * w, b.lat_min + y1 * h),
+                    (b.lng_min + x0 * w, b.lat_min + y1 * h),
+                    (b.lng_min + x0 * w, b.lat_min + y0 * h),
+                ]),
+                vec![],
+            )
+        };
+        let mp = MultiPolygon::new(vec![sq(0.1, 0.1, 0.3, 0.3), sq(0.6, 0.6, 0.9, 0.9)]);
+        let got = roundtrip(&Geometry::MultiPolygon(mp), z, x, y).unwrap();
+        match got {
+            Geometry::MultiPolygon(m) => assert_eq!(m.0.len(), 2),
+            other => panic!("expected MultiPolygon, got {other:?}"),
+        }
+    }
+
+    // ---- Degenerate content -----------------------------------------------
+
+    #[test]
+    fn assemble_empty_stream_is_none() {
+        for gt in [GeomType::Point, GeomType::Linestring, GeomType::Polygon] {
+            assert!(assemble_geometry(gt, &[], |x, y| (x as f64, y as f64)).is_none());
+        }
+    }
+
+    #[test]
+    fn assemble_unknown_type_is_none() {
+        let parts = parse_command_stream(&[command_encode(1, 1), 0, 0]).unwrap();
+        assert!(
+            assemble_geometry(GeomType::Unknown, &parts, |x, y| (x as f64, y as f64)).is_none()
+        );
+    }
+
+    #[test]
+    fn assemble_single_vertex_linestring_is_dropped() {
+        // MoveTo(1) with no LineTo: not a valid linestring part.
+        let parts =
+            parse_command_stream(&[command_encode(1, 1), zigzag_encode(10), zigzag_encode(10)])
+                .unwrap();
+        assert!(
+            assemble_geometry(GeomType::Linestring, &parts, |x, y| (x as f64, y as f64)).is_none()
+        );
+    }
+
+    #[test]
+    fn assemble_unclosed_ring_is_dropped() {
+        // A polygon "ring" without ClosePath is degenerate content.
+        let geom = [
+            command_encode(1, 1),
+            zigzag_encode(0),
+            zigzag_encode(0),
+            command_encode(2, 2),
+            zigzag_encode(10),
+            zigzag_encode(0),
+            zigzag_encode(0),
+            zigzag_encode(10),
+            // no ClosePath
+        ];
+        let parts = parse_command_stream(&geom).unwrap();
+        assert!(
+            assemble_geometry(GeomType::Polygon, &parts, |x, y| (x as f64, y as f64)).is_none()
+        );
+    }
+
+    #[test]
+    fn assemble_zero_area_ring_is_dropped() {
+        // Three collinear points closed into a "ring": area 0.
+        let geom = [
+            command_encode(1, 1),
+            zigzag_encode(0),
+            zigzag_encode(0),
+            command_encode(2, 2),
+            zigzag_encode(5),
+            zigzag_encode(0),
+            zigzag_encode(5),
+            zigzag_encode(0),
+            command_encode(7, 1),
+        ];
+        let parts = parse_command_stream(&geom).unwrap();
+        assert!(
+            assemble_geometry(GeomType::Polygon, &parts, |x, y| (x as f64, y as f64)).is_none()
+        );
+    }
+
+    #[test]
+    fn assemble_leading_interior_ring_is_dropped() {
+        // A CCW-in-tile-space (negative-area) ring with no preceding
+        // exterior: dropped, not promoted.
+        let geom = [
+            command_encode(1, 1),
+            zigzag_encode(0),
+            zigzag_encode(0),
+            command_encode(2, 3),
+            // (0,0) -> (0,10) -> (10,10) -> (10,0): negative surveyor area
+            zigzag_encode(0),
+            zigzag_encode(10),
+            zigzag_encode(10),
+            zigzag_encode(0),
+            zigzag_encode(0),
+            zigzag_encode(-10),
+            command_encode(7, 1),
+        ];
+        let parts = parse_command_stream(&geom).unwrap();
+        assert!(parts[0].area2() < 0, "test ring must be interior-wound");
+        assert!(
+            assemble_geometry(GeomType::Polygon, &parts, |x, y| (x as f64, y as f64)).is_none()
+        );
+    }
+
+    // ---- Property decode + type unification --------------------------------
+
+    fn mvt_value() -> crate::vector_tile::tile::Value {
+        crate::vector_tile::tile::Value::default()
+    }
+
+    #[test]
+    fn prop_value_decodes_every_mvt_variant() {
+        let mut v = mvt_value();
+        v.string_value = Some("hi".into());
+        assert_eq!(PropValue::from_mvt(&v), Some(PropValue::Str("hi".into())));
+
+        let mut v = mvt_value();
+        v.float_value = Some(1.5);
+        assert_eq!(PropValue::from_mvt(&v), Some(PropValue::Float(1.5)));
+
+        let mut v = mvt_value();
+        v.double_value = Some(2.5);
+        assert_eq!(PropValue::from_mvt(&v), Some(PropValue::Float(2.5)));
+
+        let mut v = mvt_value();
+        v.int_value = Some(-7);
+        assert_eq!(PropValue::from_mvt(&v), Some(PropValue::Int(-7)));
+
+        let mut v = mvt_value();
+        v.sint_value = Some(-9);
+        assert_eq!(PropValue::from_mvt(&v), Some(PropValue::Int(-9)));
+
+        let mut v = mvt_value();
+        v.uint_value = Some(42);
+        assert_eq!(PropValue::from_mvt(&v), Some(PropValue::Int(42)));
+
+        // uint that does not fit i64 degrades to float.
+        let mut v = mvt_value();
+        v.uint_value = Some(u64::MAX);
+        assert_eq!(
+            PropValue::from_mvt(&v),
+            Some(PropValue::Float(u64::MAX as f64))
+        );
+
+        let mut v = mvt_value();
+        v.bool_value = Some(true);
+        assert_eq!(PropValue::from_mvt(&v), Some(PropValue::Bool(true)));
+
+        // No field set: invalid, skipped.
+        assert_eq!(PropValue::from_mvt(&mvt_value()), None);
+    }
+
+    #[test]
+    fn coltype_unify_lattice() {
+        use ColType::*;
+        assert_eq!(Int.unify(Int), Int);
+        assert_eq!(Int.unify(Float), Float);
+        assert_eq!(Float.unify(Int), Float);
+        assert_eq!(Bool.unify(Bool), Bool);
+        assert_eq!(Str.unify(Str), Str);
+        // Any other mixture degrades to string.
+        assert_eq!(Bool.unify(Int), Str);
+        assert_eq!(Int.unify(Str), Str);
+        assert_eq!(Str.unify(Float), Str);
+        assert_eq!(Bool.unify(Str), Str);
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -42,6 +42,7 @@ pub mod batch_processor;
 pub mod clip;
 pub mod compression;
 pub mod covering;
+pub mod decode;
 pub mod dedup;
 pub mod ioverlay_clip;
 pub mod mvt;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -69,6 +69,9 @@ pub enum Error {
     #[error("Failed to write PMTiles: {0}")]
     PMTilesWrite(String),
 
+    #[error("Failed to read PMTiles: {0}")]
+    PMTilesRead(String),
+
     #[error("Invalid geometry at feature {feature_id}: {reason}")]
     InvalidGeometry { feature_id: usize, reason: String },
 

--- a/crates/core/src/mvt.rs
+++ b/crates/core/src/mvt.rs
@@ -80,17 +80,23 @@ pub fn command_decode(command: u32) -> (u32, u32) {
 
 /// Orient a polygon for MVT encoding.
 ///
-/// MVT specification requires:
-/// - Exterior rings: clockwise in screen/tile coordinates (positive area)
-/// - Interior rings: counter-clockwise in screen/tile coordinates (negative area)
+/// MVT spec 4.3.3.3 defines ring roles by the sign of the surveyor's-formula
+/// (shoelace) area computed on the stored tile coordinates:
+/// - Exterior rings: POSITIVE area (appears clockwise with Y pointing down)
+/// - Interior rings: NEGATIVE area (appears counter-clockwise with Y down)
 ///
-/// Since tile coordinates have Y increasing downward (opposite to geographic coords),
-/// and our coordinate transform flips Y, we need polygons in geographic coordinates
-/// to have:
-/// - Exterior rings: counter-clockwise (becomes CW after Y-flip)
-/// - Interior rings: clockwise (becomes CCW after Y-flip)
+/// Our coordinate transform flips Y (geographic latitude up → tile Y down),
+/// and a Y-flip NEGATES the shoelace sign. So to end up positive in tile
+/// coordinates, exterior rings must be NEGATIVE (clockwise) in geographic
+/// coordinates — geo's `Direction::Reversed` convention:
+/// - Exterior rings: clockwise in geo coords (positive area after Y-flip)
+/// - Interior rings: counter-clockwise in geo coords (negative after Y-flip)
 ///
-/// This matches geo's `Direction::Default` convention.
+/// (An earlier version used `Direction::Default`, reasoning visually that
+/// "geographic CCW appears CW after the Y-flip" — true on screen, but the
+/// spec's definition is the algebraic sign on the stored coordinates, which
+/// the flip negates. That emitted spec-inverted windings; fixed as part of
+/// issue #112, whose decoder follows the spec sign.)
 ///
 /// # Arguments
 /// * `polygon` - The polygon to orient
@@ -98,7 +104,7 @@ pub fn command_decode(command: u32) -> (u32, u32) {
 /// # Returns
 /// A new polygon with correctly oriented rings for MVT encoding
 pub fn orient_polygon_for_mvt(polygon: &Polygon) -> Polygon {
-    polygon.orient(Direction::Default)
+    polygon.orient(Direction::Reversed)
 }
 
 /// Orient a multi-polygon for MVT encoding.
@@ -111,7 +117,7 @@ pub fn orient_polygon_for_mvt(polygon: &Polygon) -> Polygon {
 /// # Returns
 /// A new multi-polygon with correctly oriented rings for MVT encoding
 pub fn orient_multi_polygon_for_mvt(multi: &MultiPolygon) -> MultiPolygon {
-    multi.orient(Direction::Default)
+    multi.orient(Direction::Reversed)
 }
 
 // ============================================================================
@@ -1121,18 +1127,17 @@ mod tests {
 
     #[test]
     fn test_polygon_correct_winding_unchanged() {
-        // A polygon with correct MVT winding (CCW exterior in geographic coords,
-        // which becomes CW exterior in tile coords after Y-flip) should pass through unchanged.
-        //
-        // MVT requires: exterior rings CW, interior rings CCW (in tile/screen coords)
-        // Geographic CCW -> Tile CW (after Y-flip), so geo::Direction::Default is correct.
+        // A polygon with correct MVT winding (CW exterior in geographic
+        // coords: the Y-flip negates the shoelace sign, yielding the
+        // POSITIVE tile-space area the spec requires for exterior rings)
+        // should pass through unchanged.
 
-        // CCW polygon in geographic coords (correct for MVT after Y-flip)
+        // CW polygon in geographic coords (correct for MVT after Y-flip)
         let poly = polygon![
             (x: 0.0, y: 0.0),
-            (x: 1.0, y: 0.0),
-            (x: 1.0, y: 1.0),
             (x: 0.0, y: 1.0),
+            (x: 1.0, y: 1.0),
+            (x: 1.0, y: 0.0),
             (x: 0.0, y: 0.0),
         ];
 
@@ -1144,47 +1149,119 @@ mod tests {
 
     #[test]
     fn test_polygon_incorrect_winding_gets_corrected() {
-        // A polygon with incorrect winding (CW exterior in geographic coords)
-        // should be corrected to CCW exterior.
+        // A polygon with incorrect winding (CCW exterior in geographic
+        // coords, which would flip to NEGATIVE tile-space area) should be
+        // corrected to CW exterior.
 
-        // CW polygon in geographic coords (incorrect - needs correction)
+        // CCW polygon in geographic coords (incorrect - needs correction)
         let poly = polygon![
             (x: 0.0, y: 0.0),
-            (x: 0.0, y: 1.0),
-            (x: 1.0, y: 1.0),
             (x: 1.0, y: 0.0),
+            (x: 1.0, y: 1.0),
+            (x: 0.0, y: 1.0),
             (x: 0.0, y: 0.0),
         ];
 
         let oriented = orient_polygon_for_mvt(&poly);
 
-        // Should now be CCW (reversed from input)
+        // Should now be CW (reversed from input)
         // The first and last points stay the same, but the middle points should be reversed
         assert_ne!(poly.exterior().0[1], oriented.exterior().0[1]);
     }
 
     #[test]
+    fn test_encoded_exterior_ring_has_positive_tile_area() {
+        // MVT spec 4.3.3.3: exterior rings must have POSITIVE area by the
+        // surveyor's formula on tile coordinates; interior rings NEGATIVE.
+        // This pins the winding fix (issue #112) at the command-stream level.
+        let bounds = test_bounds();
+        let poly = polygon![
+            exterior: [
+                (x: 0.1, y: 0.1),
+                (x: 0.9, y: 0.1),
+                (x: 0.9, y: 0.9),
+                (x: 0.1, y: 0.9),
+                (x: 0.1, y: 0.1),
+            ],
+            interiors: [
+                [
+                    (x: 0.4, y: 0.4),
+                    (x: 0.6, y: 0.4),
+                    (x: 0.6, y: 0.6),
+                    (x: 0.4, y: 0.6),
+                    (x: 0.4, y: 0.4),
+                ],
+            ],
+        ];
+        let commands = encode_polygon(&poly, &bounds, 4096);
+
+        // Decode the command stream into rings of absolute tile coords.
+        let mut rings: Vec<Vec<(i64, i64)>> = Vec::new();
+        let mut cur: Vec<(i64, i64)> = Vec::new();
+        let (mut cx, mut cy) = (0i64, 0i64);
+        let mut i = 0;
+        while i < commands.len() {
+            let (cmd, count) = command_decode(commands[i]);
+            i += 1;
+            match cmd {
+                CMD_MOVE_TO | CMD_LINE_TO => {
+                    for _ in 0..count {
+                        cx += i64::from(zigzag_decode(commands[i]));
+                        cy += i64::from(zigzag_decode(commands[i + 1]));
+                        i += 2;
+                        cur.push((cx, cy));
+                    }
+                }
+                CMD_CLOSE_PATH => rings.push(std::mem::take(&mut cur)),
+                _ => panic!("unexpected command"),
+            }
+        }
+        assert_eq!(rings.len(), 2, "exterior + hole");
+
+        let area2 = |ring: &[(i64, i64)]| -> i64 {
+            let n = ring.len();
+            (0..n)
+                .map(|j| {
+                    let (x0, y0) = ring[j];
+                    let (x1, y1) = ring[(j + 1) % n];
+                    x0 * y1 - x1 * y0
+                })
+                .sum()
+        };
+        assert!(
+            area2(&rings[0]) > 0,
+            "exterior ring must have positive tile-space area, got {}",
+            area2(&rings[0])
+        );
+        assert!(
+            area2(&rings[1]) < 0,
+            "interior ring must have negative tile-space area, got {}",
+            area2(&rings[1])
+        );
+    }
+
+    #[test]
     fn test_polygon_with_hole_correct_winding() {
         // A polygon with a hole should have:
-        // - CCW exterior in geographic coords (becomes CW in tile coords)
-        // - CW interior in geographic coords (becomes CCW in tile coords)
+        // - CW exterior in geographic coords (positive tile-space area)
+        // - CCW interior in geographic coords (negative tile-space area)
 
-        // Exterior: CCW in geo coords
-        // Interior: CW in geo coords (correct for a hole)
+        // Exterior: CW in geo coords (correct)
+        // Interior: CCW in geo coords (correct for a hole)
         let poly = polygon![
             exterior: [
                 (x: 0.0, y: 0.0),
-                (x: 10.0, y: 0.0),
-                (x: 10.0, y: 10.0),
                 (x: 0.0, y: 10.0),
+                (x: 10.0, y: 10.0),
+                (x: 10.0, y: 0.0),
                 (x: 0.0, y: 0.0),
             ],
             interiors: [
                 [
                     (x: 2.0, y: 2.0),
-                    (x: 2.0, y: 8.0),
-                    (x: 8.0, y: 8.0),
                     (x: 8.0, y: 2.0),
+                    (x: 8.0, y: 8.0),
+                    (x: 2.0, y: 8.0),
                     (x: 2.0, y: 2.0),
                 ],
             ],
@@ -1192,31 +1269,33 @@ mod tests {
 
         let oriented = orient_polygon_for_mvt(&poly);
 
-        // After orientation, exterior should be CCW and interior should be CW
-        // (in geographic coordinates, which becomes CW exterior / CCW interior in tile coords)
+        // After orientation, exterior stays CW and interior stays CCW
+        // (in geographic coordinates: positive/negative tile-space area).
         assert_eq!(oriented.interiors().len(), 1);
+        assert_eq!(poly.exterior().0, oriented.exterior().0);
+        assert_eq!(poly.interiors()[0].0, oriented.interiors()[0].0);
     }
 
     #[test]
     fn test_polygon_with_hole_incorrect_winding_gets_corrected() {
         // A polygon where both exterior and interior have wrong winding
 
-        // Exterior: CW in geo coords (wrong)
-        // Interior: CCW in geo coords (wrong for a hole)
+        // Exterior: CCW in geo coords (wrong)
+        // Interior: CW in geo coords (wrong for a hole)
         let poly = polygon![
             exterior: [
                 (x: 0.0, y: 0.0),
-                (x: 0.0, y: 10.0),
-                (x: 10.0, y: 10.0),
                 (x: 10.0, y: 0.0),
+                (x: 10.0, y: 10.0),
+                (x: 0.0, y: 10.0),
                 (x: 0.0, y: 0.0),
             ],
             interiors: [
                 [
                     (x: 2.0, y: 2.0),
-                    (x: 8.0, y: 2.0),
-                    (x: 8.0, y: 8.0),
                     (x: 2.0, y: 8.0),
+                    (x: 8.0, y: 8.0),
+                    (x: 8.0, y: 2.0),
                     (x: 2.0, y: 2.0),
                 ],
             ],

--- a/crates/core/src/overview/export.rs
+++ b/crates/core/src/overview/export.rs
@@ -1206,6 +1206,12 @@ mod tests {
     /// produced by the pre-refactor per-zoom BTreeMap implementation. The
     /// reference hash was captured from that implementation (commit b8a1635)
     /// on this exact fixture before the partitioned-streaming rewrite.
+    ///
+    /// REPIN (issue #112): the MVT winding fix (orient_polygon_for_mvt now
+    /// emits spec-compliant positive-area exterior rings) intentionally
+    /// changed polygon command bytes; the hash was re-captured from the
+    /// fixed encoder. The anchor still guards the export restructure — the
+    /// partition-invariance test alongside it is unchanged.
     #[test]
     fn export_archive_matches_pre_refactor_reference() {
         let tin = tempfile::NamedTempFile::new().unwrap();
@@ -1220,7 +1226,7 @@ mod tests {
         let bytes = std::fs::read(tout.path()).unwrap();
         assert_eq!(
             format!("{:016x}", crate::dedup::TileHasher::hash(&bytes)),
-            "58d90ae6c69d16f6",
+            "a108f1607d994a92",
             "archive bytes diverged from the pre-refactor reference"
         );
     }

--- a/crates/core/src/pmtiles_writer.rs
+++ b/crates/core/src/pmtiles_writer.rs
@@ -159,6 +159,92 @@ impl Header {
     }
 }
 
+impl TileType {
+    /// Parse a PMTiles spec byte code back into a tile type (byte 99).
+    ///
+    /// Returns `None` for codes outside the PMTiles v3 spec (0-5).
+    pub fn from_code(code: u8) -> Option<Self> {
+        match code {
+            0 => Some(TileType::Unknown),
+            1 => Some(TileType::Mvt),
+            2 => Some(TileType::Png),
+            3 => Some(TileType::Jpeg),
+            4 => Some(TileType::Webp),
+            5 => Some(TileType::Avif),
+            _ => None,
+        }
+    }
+}
+
+impl Header {
+    /// Parse a PMTiles v3 header from the first 127 bytes of an archive.
+    ///
+    /// Inverse of [`Header::to_bytes`]; the read side of the pipeline (issue
+    /// #112) uses this to locate directories and tile data. Fails on short
+    /// input, bad magic, unsupported version, or out-of-spec compression /
+    /// tile-type codes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Header> {
+        let err = |msg: String| Error::PMTilesRead(msg);
+        if bytes.len() < 127 {
+            return Err(err(format!(
+                "file too short for PMTiles header: {} bytes (need 127)",
+                bytes.len()
+            )));
+        }
+        if &bytes[0..7] != PMTILES_MAGIC {
+            return Err(err("bad magic: not a PMTiles archive".to_string()));
+        }
+        if bytes[7] != PMTILES_VERSION {
+            return Err(err(format!(
+                "unsupported PMTiles version {} (only v3 is supported)",
+                bytes[7]
+            )));
+        }
+
+        let read_u64 =
+            |at: usize| u64::from_le_bytes(bytes[at..at + 8].try_into().expect("8-byte slice"));
+        let read_coord = |at: usize| {
+            f64::from(i32::from_le_bytes(
+                bytes[at..at + 4].try_into().expect("4-byte slice"),
+            )) / 10_000_000.0
+        };
+
+        let internal_compression = Compression::from_code(bytes[97])
+            .ok_or_else(|| err(format!("invalid internal compression code {}", bytes[97])))?;
+        let tile_compression = Compression::from_code(bytes[98])
+            .ok_or_else(|| err(format!("invalid tile compression code {}", bytes[98])))?;
+        let tile_type = TileType::from_code(bytes[99])
+            .ok_or_else(|| err(format!("invalid tile type code {}", bytes[99])))?;
+
+        Ok(Header {
+            root_dir_offset: read_u64(8),
+            root_dir_length: read_u64(16),
+            json_metadata_offset: read_u64(24),
+            json_metadata_length: read_u64(32),
+            leaf_dirs_offset: read_u64(40),
+            leaf_dirs_length: read_u64(48),
+            tile_data_offset: read_u64(56),
+            tile_data_length: read_u64(64),
+            addressed_tiles_count: read_u64(72),
+            tile_entries_count: read_u64(80),
+            tile_contents_count: read_u64(88),
+            clustered: bytes[96] == 1,
+            internal_compression,
+            tile_compression,
+            tile_type,
+            min_zoom: bytes[100],
+            max_zoom: bytes[101],
+            min_lon: read_coord(102),
+            min_lat: read_coord(106),
+            max_lon: read_coord(110),
+            max_lat: read_coord(114),
+            center_zoom: bytes[118],
+            center_lon: read_coord(119),
+            center_lat: read_coord(123),
+        })
+    }
+}
+
 /// Convert tile coordinates (z, x, y) to a TileID for PMTiles
 ///
 /// Uses Hilbert curve ordering for spatial locality. The tile ID is a cumulative
@@ -213,6 +299,54 @@ fn xy_to_hilbert(z: u8, x: u32, y: u32) -> u64 {
         s /= 2;
     }
     d
+}
+
+/// Convert a PMTiles TileID back to tile coordinates (z, x, y).
+///
+/// Inverse of [`tile_id`]. Supports zoom levels 0-31 (the range a u64
+/// cumulative Hilbert ID can address); returns an error for IDs beyond z31.
+pub fn tile_id_to_zxy(id: u64) -> Result<(u8, u32, u32)> {
+    let mut acc: u64 = 0;
+    for z in 0u8..=31 {
+        let num = 1u64 << (2 * u64::from(z));
+        if id - acc < num {
+            let (x, y) = hilbert_d2xy(z, id - acc);
+            return Ok((z, x, y));
+        }
+        acc += num;
+    }
+    Err(Error::PMTilesRead(format!(
+        "tile id {id} exceeds the zoom 31 address space"
+    )))
+}
+
+/// Convert a Hilbert curve index back to x,y coordinates at zoom level z
+///
+/// Standard inverse Hilbert algorithm (d2xy), mirroring [`xy_to_hilbert`]:
+/// https://en.wikipedia.org/wiki/Hilbert_curve
+fn hilbert_d2xy(z: u8, d: u64) -> (u32, u32) {
+    let n = 1u64 << z;
+    let (mut x, mut y) = (0u64, 0u64);
+    let mut t = d;
+    let mut s = 1u64;
+    while s < n {
+        let rx = 1 & (t / 2);
+        let ry = 1 & (t ^ rx);
+        // Rotate quadrant - the inverse uses s-1 (current block size - 1),
+        // where the forward transform uses n-1 (see xy_to_hilbert).
+        if ry == 0 {
+            if rx == 1 {
+                x = s - 1 - x;
+                y = s - 1 - y;
+            }
+            std::mem::swap(&mut x, &mut y);
+        }
+        x += s * rx;
+        y += s * ry;
+        t /= 4;
+        s *= 2;
+    }
+    (x as u32, y as u32)
 }
 
 // ============================================================================
@@ -1563,6 +1697,134 @@ mod tests {
                 z
             );
         }
+    }
+
+    #[test]
+    fn test_tile_id_to_zxy_matches_spec_examples() {
+        assert_eq!(tile_id_to_zxy(0).unwrap(), (0, 0, 0));
+        assert_eq!(tile_id_to_zxy(1).unwrap(), (1, 0, 0));
+        assert_eq!(tile_id_to_zxy(2).unwrap(), (1, 0, 1));
+        assert_eq!(tile_id_to_zxy(3).unwrap(), (1, 1, 1));
+        assert_eq!(tile_id_to_zxy(4).unwrap(), (1, 1, 0));
+        assert_eq!(tile_id_to_zxy(5).unwrap(), (2, 0, 0));
+    }
+
+    #[test]
+    fn test_tile_id_to_zxy_inverts_tile_id_exhaustively() {
+        // Exhaustive round-trip at low zooms...
+        for z in 0..=5u8 {
+            let n = 1u32 << z;
+            for y in 0..n {
+                for x in 0..n {
+                    assert_eq!(
+                        tile_id_to_zxy(tile_id(z, x, y)).unwrap(),
+                        (z, x, y),
+                        "round-trip z={z} x={x} y={y}"
+                    );
+                }
+            }
+        }
+        // ...and spot checks at high zooms, including corners.
+        for (z, x, y) in [
+            (14u8, 4823u32, 6160u32),
+            (14, 0, 0),
+            (14, (1 << 14) - 1, (1 << 14) - 1),
+            (20, 123_456, 654_321),
+            (31, (1u32 << 31) - 1, 0),
+        ] {
+            assert_eq!(tile_id_to_zxy(tile_id(z, x, y)).unwrap(), (z, x, y));
+        }
+    }
+
+    #[test]
+    fn test_tile_id_to_zxy_rejects_out_of_range() {
+        // One past the last z31 ID must error rather than wrap.
+        let past_z31 = (0..=31u8).map(|z| 1u64 << (2 * u64::from(z))).sum::<u64>();
+        assert!(tile_id_to_zxy(past_z31).is_err());
+        assert!(tile_id_to_zxy(u64::MAX).is_err());
+    }
+
+    #[test]
+    fn test_header_from_bytes_roundtrips_to_bytes() {
+        let header = Header {
+            root_dir_offset: 127,
+            root_dir_length: 421,
+            json_metadata_offset: 548,
+            json_metadata_length: 33,
+            leaf_dirs_offset: 581,
+            leaf_dirs_length: 1290,
+            tile_data_offset: 1871,
+            tile_data_length: 999_999,
+            addressed_tiles_count: 42,
+            tile_entries_count: 40,
+            tile_contents_count: 39,
+            clustered: true,
+            internal_compression: Compression::Gzip,
+            tile_compression: Compression::Zstd,
+            tile_type: TileType::Mvt,
+            min_zoom: 3,
+            max_zoom: 14,
+            min_lon: -75.1652,
+            min_lat: -33.8688,
+            max_lon: 151.2093,
+            max_lat: 48.8566,
+            center_zoom: 8,
+            center_lon: 2.3522,
+            center_lat: 39.9526,
+        };
+        let parsed = Header::from_bytes(&header.to_bytes()).unwrap();
+
+        assert_eq!(parsed.root_dir_offset, header.root_dir_offset);
+        assert_eq!(parsed.root_dir_length, header.root_dir_length);
+        assert_eq!(parsed.json_metadata_offset, header.json_metadata_offset);
+        assert_eq!(parsed.json_metadata_length, header.json_metadata_length);
+        assert_eq!(parsed.leaf_dirs_offset, header.leaf_dirs_offset);
+        assert_eq!(parsed.leaf_dirs_length, header.leaf_dirs_length);
+        assert_eq!(parsed.tile_data_offset, header.tile_data_offset);
+        assert_eq!(parsed.tile_data_length, header.tile_data_length);
+        assert_eq!(parsed.addressed_tiles_count, header.addressed_tiles_count);
+        assert_eq!(parsed.tile_entries_count, header.tile_entries_count);
+        assert_eq!(parsed.tile_contents_count, header.tile_contents_count);
+        assert_eq!(parsed.clustered, header.clustered);
+        assert_eq!(parsed.internal_compression, header.internal_compression);
+        assert_eq!(parsed.tile_compression, header.tile_compression);
+        assert_eq!(parsed.tile_type, header.tile_type);
+        assert_eq!(parsed.min_zoom, header.min_zoom);
+        assert_eq!(parsed.max_zoom, header.max_zoom);
+        // Coordinates go through the i32 * 1e7 spec encoding: 1e-7 precision.
+        for (got, want) in [
+            (parsed.min_lon, header.min_lon),
+            (parsed.min_lat, header.min_lat),
+            (parsed.max_lon, header.max_lon),
+            (parsed.max_lat, header.max_lat),
+            (parsed.center_lon, header.center_lon),
+            (parsed.center_lat, header.center_lat),
+        ] {
+            assert!((got - want).abs() < 1e-6, "{got} vs {want}");
+        }
+        assert_eq!(parsed.center_zoom, header.center_zoom);
+    }
+
+    #[test]
+    fn test_header_from_bytes_rejects_garbage() {
+        // Too short.
+        assert!(Header::from_bytes(&[0u8; 50]).is_err());
+        // Bad magic.
+        let mut bytes = Header::default().to_bytes();
+        bytes[0] = b'X';
+        assert!(Header::from_bytes(&bytes).is_err());
+        // Bad version.
+        let mut bytes = Header::default().to_bytes();
+        bytes[7] = 2;
+        assert!(Header::from_bytes(&bytes).is_err());
+        // Out-of-spec compression code.
+        let mut bytes = Header::default().to_bytes();
+        bytes[97] = 9;
+        assert!(Header::from_bytes(&bytes).is_err());
+        // Out-of-spec tile type code.
+        let mut bytes = Header::default().to_bytes();
+        bytes[99] = 9;
+        assert!(Header::from_bytes(&bytes).is_err());
     }
 
     #[test]

--- a/crates/core/tests/decode_roundtrip.rs
+++ b/crates/core/tests/decode_roundtrip.rs
@@ -1,0 +1,540 @@
+//! Integration tests for PMTiles → GeoParquet decoding (issue #112).
+//!
+//! Round-trips through the real production pipeline: fixture GeoParquet →
+//! `convert_to_overviews` → `export_pmtiles` → `decode_pmtiles` → read the
+//! output GeoParquet and verify coordinates, provenance columns, properties
+//! and filters. Plus a golden comparison against `tippecanoe-decode` when
+//! that binary is available (skipped gracefully otherwise).
+//!
+//! Run with:
+//!   cargo test --package gpq-tiles-core --test decode_roundtrip -- --nocapture
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+
+use arrow_array::cast::AsArray;
+use arrow_array::types::{Int64Type, UInt64Type, UInt8Type};
+use arrow_array::{Array, Int64Array, RecordBatch, StringArray};
+use arrow_schema::{DataType, Field, Schema};
+use geo::{Geometry, LineString, Point, Polygon};
+use geoarrow::array::{from_arrow_array, GeometryBuilder};
+use geoarrow::datatypes::GeometryType;
+use geoarrow_array::GeoArrowArray;
+use geoparquet::writer::{
+    GeoParquetRecordBatchEncoder, GeoParquetWriterEncoding, GeoParquetWriterOptionsBuilder,
+};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::arrow::ArrowWriter;
+
+use gpq_tiles_core::batch_processor::extract_geometries_from_array;
+use gpq_tiles_core::decode::{decode_pmtiles, DecodeError, DecodeOptions};
+use gpq_tiles_core::overview::convert::{convert_to_overviews, ConvertOptions, LevelPlan};
+use gpq_tiles_core::overview::export::{export_pmtiles, ExportOptions};
+
+const MIN_ZOOM: u8 = 4;
+const MAX_ZOOM: u8 = 14;
+
+/// Quantization tolerance in degrees at (zoom, extent 4096): one tile-local
+/// unit of longitude. Encoding rounds to the nearest unit (<= 0.5 units);
+/// latitude error in degrees never exceeds longitude error at the same
+/// world position.
+fn tol_deg(zoom: u8) -> f64 {
+    360.0 / ((1u64 << zoom) as f64 * 4096.0)
+}
+
+/// Source geometries with hand-picked coordinates (mid-tile at z14, so
+/// clipping introduces no extra vertices in what we assert on).
+fn fixture_geometries() -> Vec<Geometry<f64>> {
+    vec![
+        Geometry::Point(Point::new(-75.1652, 39.9526)), // Philadelphia
+        Geometry::Point(Point::new(2.3522, 48.8566)),   // Paris
+        Geometry::Point(Point::new(151.2093, -33.8688)), // Sydney
+        Geometry::LineString(LineString::from(vec![
+            (10.0030, 50.0030),
+            (10.0040, 50.0035),
+            (10.0050, 50.0030),
+        ])),
+        Geometry::Polygon(Polygon::new(
+            LineString::from(vec![
+                (-45.0030, -20.0030),
+                (-45.0020, -20.0030),
+                (-45.0020, -20.0020),
+                (-45.0030, -20.0020),
+                (-45.0030, -20.0030),
+            ]),
+            vec![],
+        )),
+    ]
+}
+
+/// Write a GeoParquet fixture with `id` (Int64) and `name` (Utf8) properties,
+/// plus an optional extra Int64 column (reserved-name collision tests).
+fn write_fixture(path: &Path, geoms: &[Geometry<f64>], extra_col: Option<&str>) {
+    let n = geoms.len();
+    let id = Int64Array::from((0..n as i64).collect::<Vec<_>>());
+    let name = StringArray::from((0..n).map(|i| format!("f{i}")).collect::<Vec<_>>());
+
+    let typ = GeometryType::new(Default::default());
+    let mut b = GeometryBuilder::new(typ).with_prefer_multi(false);
+    b.extend_from_iter(geoms.iter().map(Some));
+    let geom_arr = b.finish();
+    let geom_field = geom_arr.data_type().to_field("geometry", true);
+
+    let mut fields = vec![
+        Arc::new(Field::new("id", DataType::Int64, false)),
+        Arc::new(Field::new("name", DataType::Utf8, false)),
+    ];
+    let mut columns: Vec<Arc<dyn Array>> = vec![Arc::new(id), Arc::new(name)];
+    if let Some(col) = extra_col {
+        fields.push(Arc::new(Field::new(col, DataType::Int64, false)));
+        columns.push(Arc::new(Int64Array::from(vec![7i64; n])));
+    }
+    fields.push(Arc::new(geom_field));
+    columns.push(geom_arr.to_array_ref());
+
+    let schema = Arc::new(Schema::new(fields));
+    let batch = RecordBatch::try_new(schema.clone(), columns).unwrap();
+
+    let gpq_options = GeoParquetWriterOptionsBuilder::default()
+        .set_encoding(GeoParquetWriterEncoding::WKB)
+        .set_generate_covering(true)
+        .build();
+    let mut encoder = GeoParquetRecordBatchEncoder::try_new(&schema, &gpq_options).unwrap();
+    let target_schema = encoder.target_schema();
+
+    let file = std::fs::File::create(path).unwrap();
+    let mut writer = ArrowWriter::try_new(file, target_schema, None).unwrap();
+    writer
+        .write(&encoder.encode_record_batch(&batch).unwrap())
+        .unwrap();
+    writer.append_key_value_metadata(encoder.into_keyvalue().unwrap());
+    writer.close().unwrap();
+}
+
+/// Run the production pipeline (convert + export) over the fixture and
+/// return the PMTiles path (tempdir keeps everything alive).
+fn build_archive(dir: &tempfile::TempDir, extra_col: Option<&str>) -> PathBuf {
+    let input = dir.path().join("fixture.parquet");
+    let overviews = dir.path().join("fixture-overviews.parquet");
+    let pmtiles = dir.path().join("fixture.pmtiles");
+
+    write_fixture(&input, &fixture_geometries(), extra_col);
+    let convert_opts = ConvertOptions {
+        levels: LevelPlan::ZoomRange {
+            min_zoom: MIN_ZOOM,
+            max_zoom: MAX_ZOOM,
+        },
+        ..Default::default()
+    };
+    convert_to_overviews(&input, &overviews, &convert_opts).unwrap();
+    export_pmtiles(&overviews, &pmtiles, &ExportOptions::default()).unwrap();
+    pmtiles
+}
+
+/// A decoded output row: provenance + properties + geometry.
+struct Row {
+    zoom: u8,
+    layer: String,
+    mvt_id: Option<u64>,
+    id: Option<i64>,
+    name: Option<String>,
+    geometry: Geometry<f64>,
+}
+
+/// Read every row of a decoded GeoParquet file.
+fn read_rows(path: &Path) -> Vec<Row> {
+    let file = std::fs::File::open(path).unwrap();
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
+    let mut rows = Vec::new();
+    for batch in builder.build().unwrap() {
+        let batch = batch.unwrap();
+        let schema = batch.schema();
+        let zoom = batch
+            .column(schema.index_of("zoom").unwrap())
+            .as_primitive::<UInt8Type>()
+            .clone();
+        let layer = batch
+            .column(schema.index_of("layer").unwrap())
+            .as_string::<i32>()
+            .clone();
+        let mvt_id = batch
+            .column(schema.index_of("mvt_id").unwrap())
+            .as_primitive::<UInt64Type>()
+            .clone();
+        let id = batch
+            .column(schema.index_of("id").unwrap())
+            .as_primitive::<Int64Type>()
+            .clone();
+        let name = batch
+            .column(schema.index_of("name").unwrap())
+            .as_string::<i32>()
+            .clone();
+        let gidx = schema.index_of("geometry").unwrap();
+        let garr = from_arrow_array(batch.column(gidx).as_ref(), schema.field(gidx)).unwrap();
+        let mut geoms = Vec::new();
+        extract_geometries_from_array(garr.as_ref(), &mut geoms).unwrap();
+        assert_eq!(geoms.len(), batch.num_rows(), "no null geometry rows");
+        for (i, geometry) in geoms.into_iter().enumerate() {
+            rows.push(Row {
+                zoom: zoom.value(i),
+                layer: layer.value(i).to_string(),
+                mvt_id: (!mvt_id.is_null(i)).then(|| mvt_id.value(i)),
+                id: (!id.is_null(i)).then(|| id.value(i)),
+                name: (!name.is_null(i)).then(|| name.value(i).to_string()),
+                geometry,
+            });
+        }
+    }
+    rows
+}
+
+/// All vertices of a geometry as (lon, lat) pairs.
+fn vertices(geom: &Geometry<f64>) -> Vec<(f64, f64)> {
+    use geo::CoordsIter;
+    geom.coords_iter().map(|c| (c.x, c.y)).collect()
+}
+
+// ============================================================================
+// Round-trip
+// ============================================================================
+
+#[test]
+fn decode_roundtrip_full_archive() {
+    let dir = tempfile::tempdir().unwrap();
+    let pmtiles = build_archive(&dir, None);
+    let output = dir.path().join("decoded.parquet");
+
+    let report = decode_pmtiles(&pmtiles, &output, &DecodeOptions::default()).unwrap();
+    println!("report: {report:?}");
+
+    let rows = read_rows(&output);
+    assert_eq!(rows.len() as u64, report.features_written);
+    assert!(report.features_written > 0);
+    assert_eq!(report.layers, vec!["overview".to_string()]);
+    assert_eq!(report.zoom_range, Some((MIN_ZOOM, MAX_ZOOM)));
+
+    // Provenance columns.
+    let zooms: BTreeSet<u8> = rows.iter().map(|r| r.zoom).collect();
+    assert!(zooms.contains(&MAX_ZOOM), "max-zoom rows present");
+    assert!(*zooms.iter().min().unwrap() >= MIN_ZOOM);
+    assert!(rows.iter().all(|r| r.layer == "overview"));
+    // Our export writes per-tile sequential MVT feature ids.
+    assert!(rows.iter().all(|r| r.mvt_id.is_some()));
+
+    // Properties survive: id and name paired as in the source.
+    for row in &rows {
+        let id = row.id.expect("id property present");
+        assert_eq!(row.name.as_deref(), Some(format!("f{id}").as_str()));
+    }
+
+    // Coordinate accuracy at max zoom: every source vertex must have a
+    // decoded counterpart within quantization tolerance.
+    let tol = tol_deg(MAX_ZOOM);
+    let mut worst = 0.0f64;
+    for (source_id, geom) in fixture_geometries().iter().enumerate() {
+        let instances: Vec<&Row> = rows
+            .iter()
+            .filter(|r| r.zoom == MAX_ZOOM && r.id == Some(source_id as i64))
+            .collect();
+        assert!(!instances.is_empty(), "feature {source_id} at max zoom");
+        for (sx, sy) in vertices(geom) {
+            let err = instances
+                .iter()
+                .flat_map(|r| vertices(&r.geometry))
+                .map(|(dx, dy)| (dx - sx).abs().max((dy - sy).abs()))
+                .fold(f64::INFINITY, f64::min);
+            assert!(
+                err <= tol,
+                "feature {source_id} vertex ({sx}, {sy}): error {err} > tol {tol}"
+            );
+            worst = worst.max(err);
+        }
+    }
+    println!(
+        "round-trip OK: worst vertex error {worst:.9} deg (~{:.3} m) vs tol {tol:.9} deg",
+        worst * 111_320.0
+    );
+
+    // Geometry types survive at max zoom (no simplification at the finest
+    // level; polygons stay polygons, lines stay lines).
+    for row in rows.iter().filter(|r| r.zoom == MAX_ZOOM) {
+        match row.id.unwrap() {
+            0..=2 => assert!(matches!(row.geometry, Geometry::Point(_))),
+            3 => assert!(matches!(
+                row.geometry,
+                Geometry::LineString(_) | Geometry::MultiLineString(_)
+            )),
+            4 => assert!(matches!(
+                row.geometry,
+                Geometry::Polygon(_) | Geometry::MultiPolygon(_)
+            )),
+            other => panic!("unexpected id {other}"),
+        }
+    }
+}
+
+// ============================================================================
+// Filters
+// ============================================================================
+
+#[test]
+fn decode_single_zoom_filter() {
+    let dir = tempfile::tempdir().unwrap();
+    let pmtiles = build_archive(&dir, None);
+    let output = dir.path().join("decoded-z8.parquet");
+
+    let options = DecodeOptions {
+        min_zoom: Some(8),
+        max_zoom: Some(8),
+        layer: None,
+    };
+    let report = decode_pmtiles(&pmtiles, &output, &options).unwrap();
+    let rows = read_rows(&output);
+
+    assert_eq!(rows.len() as u64, report.features_written);
+    assert!(!rows.is_empty());
+    assert!(rows.iter().all(|r| r.zoom == 8), "only z8 rows");
+    assert_eq!(report.zoom_range, Some((8, 8)));
+}
+
+#[test]
+fn decode_zoom_range_filter() {
+    let dir = tempfile::tempdir().unwrap();
+    let pmtiles = build_archive(&dir, None);
+    let output = dir.path().join("decoded-z10-12.parquet");
+
+    let options = DecodeOptions {
+        min_zoom: Some(10),
+        max_zoom: Some(12),
+        layer: None,
+    };
+    decode_pmtiles(&pmtiles, &output, &options).unwrap();
+    let rows = read_rows(&output);
+    assert!(!rows.is_empty());
+    assert!(rows.iter().all(|r| (10..=12).contains(&r.zoom)));
+}
+
+#[test]
+fn decode_layer_filter_matching_and_not() {
+    let dir = tempfile::tempdir().unwrap();
+    let pmtiles = build_archive(&dir, None);
+
+    // Matching layer: same rows as unfiltered.
+    let out_match = dir.path().join("decoded-layer.parquet");
+    let report = decode_pmtiles(
+        &pmtiles,
+        &out_match,
+        &DecodeOptions {
+            layer: Some("overview".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert!(report.features_written > 0);
+
+    // Non-matching layer: empty (but valid) output.
+    let out_none = dir.path().join("decoded-nolayer.parquet");
+    let report = decode_pmtiles(
+        &pmtiles,
+        &out_none,
+        &DecodeOptions {
+            layer: Some("does-not-exist".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(report.features_written, 0);
+    assert!(report.layers.is_empty());
+    assert_eq!(report.zoom_range, None);
+
+    // The empty file must still be readable parquet with the provenance
+    // schema (zero rows).
+    let file = std::fs::File::open(&out_none).unwrap();
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
+    let names: Vec<String> = builder
+        .schema()
+        .fields()
+        .iter()
+        .map(|f| f.name().clone())
+        .collect();
+    assert!(names.contains(&"zoom".to_string()));
+    assert!(names.contains(&"layer".to_string()));
+    assert!(names.contains(&"mvt_id".to_string()));
+    assert!(names.contains(&"geometry".to_string()));
+    assert_eq!(builder.build().unwrap().count(), 0);
+}
+
+// ============================================================================
+// Errors
+// ============================================================================
+
+#[test]
+fn decode_rejects_reserved_property_name() {
+    // A source property named `mvt_id` collides with the decoder's
+    // provenance column and must be rejected, not silently clobbered.
+    let dir = tempfile::tempdir().unwrap();
+    let pmtiles = build_archive(&dir, Some("mvt_id"));
+    let output = dir.path().join("decoded.parquet");
+
+    let err = decode_pmtiles(&pmtiles, &output, &DecodeOptions::default()).unwrap_err();
+    assert!(
+        matches!(err, DecodeError::ReservedColumn(ref c) if c == "mvt_id"),
+        "expected ReservedColumn(mvt_id), got {err:?}"
+    );
+}
+
+#[test]
+fn decode_rejects_non_pmtiles_input() {
+    let dir = tempfile::tempdir().unwrap();
+    let garbage = dir.path().join("garbage.pmtiles");
+    std::fs::write(
+        &garbage,
+        b"definitely not a pmtiles archive, but long enough to parse",
+    )
+    .unwrap();
+    let output = dir.path().join("decoded.parquet");
+    assert!(decode_pmtiles(&garbage, &output, &DecodeOptions::default()).is_err());
+}
+
+#[test]
+fn decode_rejects_missing_input() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = dir.path().join("decoded.parquet");
+    assert!(decode_pmtiles(
+        dir.path().join("nope.pmtiles"),
+        &output,
+        &DecodeOptions::default()
+    )
+    .is_err());
+}
+
+// ============================================================================
+// Golden comparison against tippecanoe-decode
+// ============================================================================
+
+/// Recursively collect `(geometry-type, [vertices])` for every Feature in a
+/// tippecanoe-decode GeoJSON document.
+fn collect_tippecanoe_features(
+    value: &serde_json::Value,
+    out: &mut Vec<(String, Vec<(f64, f64)>)>,
+) {
+    match value {
+        serde_json::Value::Object(obj) => {
+            if obj.get("type").and_then(|t| t.as_str()) == Some("Feature") {
+                if let Some(geom) = obj.get("geometry") {
+                    let gtype = geom
+                        .get("type")
+                        .and_then(|t| t.as_str())
+                        .unwrap_or_default()
+                        .to_string();
+                    let mut verts = Vec::new();
+                    collect_positions(
+                        geom.get("coordinates").unwrap_or(&serde_json::Value::Null),
+                        &mut verts,
+                    );
+                    out.push((gtype, verts));
+                }
+            }
+            for v in obj.values() {
+                collect_tippecanoe_features(v, out);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for v in arr {
+                collect_tippecanoe_features(v, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Flatten arbitrarily nested GeoJSON coordinates into (lon, lat) pairs.
+fn collect_positions(value: &serde_json::Value, out: &mut Vec<(f64, f64)>) {
+    if let serde_json::Value::Array(arr) = value {
+        if arr.len() >= 2 && arr[0].is_number() && arr[1].is_number() {
+            out.push((arr[0].as_f64().expect("lon"), arr[1].as_f64().expect("lat")));
+        } else {
+            for v in arr {
+                collect_positions(v, out);
+            }
+        }
+    }
+}
+
+#[test]
+fn decode_golden_against_tippecanoe_decode() {
+    // Skip gracefully when the reference binary is unavailable.
+    if Command::new("tippecanoe-decode")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!("tippecanoe-decode not available, skipping golden comparison");
+        return;
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let pmtiles = build_archive(&dir, None);
+    let output = dir.path().join("decoded.parquet");
+
+    // Ours, max zoom only.
+    let options = DecodeOptions {
+        min_zoom: Some(MAX_ZOOM),
+        max_zoom: Some(MAX_ZOOM),
+        layer: None,
+    };
+    decode_pmtiles(&pmtiles, &output, &options).unwrap();
+    let ours = read_rows(&output);
+
+    // Reference, max zoom only.
+    let ref_out = Command::new("tippecanoe-decode")
+        .arg("-Z")
+        .arg(MAX_ZOOM.to_string())
+        .arg("-z")
+        .arg(MAX_ZOOM.to_string())
+        .arg(&pmtiles)
+        .output()
+        .expect("run tippecanoe-decode");
+    assert!(
+        ref_out.status.success(),
+        "tippecanoe-decode failed: {}",
+        String::from_utf8_lossy(&ref_out.stderr)
+    );
+    let doc: serde_json::Value =
+        serde_json::from_slice(&ref_out.stdout).expect("tippecanoe-decode emits JSON");
+    let mut reference = Vec::new();
+    collect_tippecanoe_features(&doc, &mut reference);
+
+    // Same number of feature instances at max zoom.
+    assert_eq!(
+        ours.len(),
+        reference.len(),
+        "feature count at z{MAX_ZOOM}: ours {} vs tippecanoe-decode {}",
+        ours.len(),
+        reference.len()
+    );
+
+    // Every vertex we decode must appear in tippecanoe-decode's output for
+    // the same zoom, within a hair of float printing error (both sides
+    // implement the same integer world-coordinate transform).
+    let tol = 1e-6;
+    for row in &ours {
+        for (x, y) in vertices(&row.geometry) {
+            let matched = reference
+                .iter()
+                .flat_map(|(_, verts)| verts.iter())
+                .any(|&(rx, ry)| (rx - x).abs() <= tol && (ry - y).abs() <= tol);
+            assert!(
+                matched,
+                "vertex ({x}, {y}) from row id {:?} not found in tippecanoe-decode output",
+                row.id
+            );
+        }
+    }
+    println!(
+        "golden OK: {} features at z{MAX_ZOOM} match tippecanoe-decode",
+        ours.len()
+    );
+}

--- a/docs/decode.md
+++ b/docs/decode.md
@@ -1,0 +1,77 @@
+# Decoding PMTiles back to GeoParquet
+
+`gpq-tiles decode` converts a PMTiles vector-tile archive into a GeoParquet
+file, following the model of `tippecanoe-decode`. It works on any PMTiles v3
+MVT archive (not just ones produced by gpq-tiles) and supports all four spec
+compression codecs (none, gzip, brotli, zstd) for directories and tiles.
+
+```bash
+# Everything, all zooms (large: every feature, every tile, every zoom)
+gpq-tiles decode input.pmtiles output.parquet
+
+# Extract a single zoom (recommended for most use cases)
+gpq-tiles decode input.pmtiles output.parquet --zoom 14
+
+# Zoom range
+gpq-tiles decode input.pmtiles output.parquet --min-zoom 10 --max-zoom 14
+
+# One MVT layer only
+gpq-tiles decode input.pmtiles output.parquet --layer buildings
+
+# Machine-readable summary
+gpq-tiles decode input.pmtiles output.parquet --zoom 14 --report report.json
+```
+
+Rust API: `gpq_tiles_core::decode::decode_pmtiles(input, output, &DecodeOptions)`.
+
+## What you get — and what you don't
+
+**The output is the tiled representation, not the original source data.**
+Tiling is lossy by design; decoding recovers what the tiles contain, nothing
+more:
+
+| Limitation | Why | What to do |
+|------------|-----|------------|
+| **Simplified geometries** | Vertices are removed during tiling at lower zooms | Extract the maximum zoom (`--zoom <maxzoom>`) for the best available detail |
+| **Clipped geometries** | Features are cut at (buffered) tile boundaries | Accept clipped output, or post-process a merge keyed on a stable property |
+| **Duplicate features** | A feature near a tile seam appears once per neighboring tile (buffer copies), and once per zoom level | Filter to a single zoom (`--zoom`, or the output's `zoom` column); dedupe by a stable feature property if needed |
+| **Lost properties** | Attributes dropped during tiling are not in the tiles | Nothing — they cannot be recovered |
+| **No round-trip guarantee** | All of the above | `A.parquet → B.pmtiles → C.parquet` yields `C ≠ A`; this is inherent to vector tiles |
+
+Matching `tippecanoe-decode`, **nothing is deduplicated**: every feature from
+every selected tile is emitted as its own row.
+
+## Output schema
+
+Three provenance columns come first, so the duplicated representation stays
+filterable after the fact:
+
+| Column | Type | Meaning |
+|--------|------|---------|
+| `zoom` | UInt8 | Zoom level of the tile the row came from |
+| `layer` | Utf8 | MVT layer name (always present, even for single-layer archives, so the schema is stable) |
+| `mvt_id` | UInt64 (nullable) | The raw MVT feature id, when the encoder set one |
+
+They are followed by the union of all property columns seen across every
+tile and layer (alphabetical, all nullable — a feature that lacks a property
+gets null), then `geometry` (WKB GeoParquet with a bbox covering, EPSG:4326).
+
+Property types are unified across features: integers → Int64, floats/doubles
+→ Float64, Int64 mixed with Float64 → Float64, and any other mixture (e.g. a
+key that is a bool in one tile and a string in another) degrades to Utf8 with
+values stringified. A `uint` above `i64::MAX` degrades to Float64. A source
+property named `zoom`, `layer`, `mvt_id`, or `geometry` is rejected with an
+error rather than silently clobbered.
+
+Coordinates are recovered through tippecanoe's 32-bit world-coordinate
+transform (`write_json.cpp`), accurate to the tile quantization limit — about
+0.6 m at z14 with the standard 4096 extent, halving per zoom.
+
+## Tips
+
+- Decoded output is unsorted point-in-time data; before serving it anywhere,
+  optimize it with [geoparquet-io](https://github.com/geoparquet-io/geoparquet-io):
+  `gpio convert reproject decoded.parquet out.parquet -d EPSG:4326 --hilbert --row-group-size 100000`.
+- Feature counts match `tippecanoe-decode` exactly for the same zoom
+  selection; the integration suite pins this against the real binary when it
+  is installed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,8 @@ Multi-resolution **overviews for GeoParquet**, plus PMTiles export — in Rust.
 - **`gpq-tiles tiles`** (or the bare form) — one-shot GeoParquet → PMTiles,
   a thin facade over the two steps above.
 - **`gpq-tiles validate`** — check an overview file against the spec.
+- **`gpq-tiles decode`** — decode any PMTiles vector-tile archive back to
+  GeoParquet (the tiled representation; see [Decoding PMTiles](decode.md)).
 
 ## Quick Example
 
@@ -38,6 +40,7 @@ export_pmtiles("overviews.parquet", "output.pmtiles")
 ## Next Steps
 
 - [Getting Started](getting-started.md) — Installation and basic usage
+- [Decoding PMTiles](decode.md) — PMTiles → GeoParquet, limitations included
 - [Overview Tuning](OVERVIEW_TUNING.md) — Every generalization knob explained
 - [API Reference](api-reference.md) — CLI flags, Python API, Rust API
 - [Advanced Usage](advanced-usage.md) — Input optimization, memory, export

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Getting Started: getting-started.md
+  - Decoding PMTiles: decode.md
   - API Reference: api-reference.md
   - Advanced Usage: advanced-usage.md
   - Architecture: architecture.md


### PR DESCRIPTION
## Summary

Implements issue #112: decode any PMTiles v3 vector-tile archive back into GeoParquet, following `tippecanoe-decode` semantics. Built per the spike plan in `context/archive/SPIKE_112_DECODE.md` (spike branch `spike/112-pmtiles-decode`, left untouched).

- **Read-side primitives** (mirrors of existing write-side code): `compression::decompress` + `Compression::from_code`, `Header::from_bytes`, `tile_id_to_zxy` (inverse Hilbert addressing) — each unit-tested against its forward counterpart.
- **`core::decode::decode_pmtiles()`**: synchronous archive walk (no `pmtiles` crate, no async runtime; root + leaf directories, run-length expansion, all four spec compression codecs), manual MVT decode via our prost `vector_tile` types + existing zigzag/command decoders (geozero `with-mvt` rejected: it pins a second prost stack at ^0.11.9), full ring/multi-geometry assembly per MVT spec winding rules, tippecanoe's `write_json.cpp` coordinate transform, property schema union across tiles/layers (Int64/Float64 promotion; mixed types degrade to Utf8; nulls where absent), GeoParquet output through the existing GeoArrow writer stack (WKB + bbox covering), zoom-range and layer filters. Two-pass streaming keeps memory O(tile + batch).
- **CLI**: `gpq-tiles decode input.pmtiles output.parquet [--zoom N | --min-zoom N --max-zoom N] [--layer NAME] [--report PATH]` — thin facade per house style.
- **Docs**: `docs/decode.md` (linked from README, docs index, mkdocs nav), CLI help/after-help, `context/ARCHITECTURE.md` decision record.

### Drive-by fix: MVT polygon winding was spec-inverted

The decoder's spec-strict ring classifier exposed an encoder bug: `orient_polygon_for_mvt` used `Direction::Default` (exterior CCW in geographic coords), reasoning visually that geographic CCW "appears clockwise" after the Y-flip. MVT spec 4.3.3.3 defines exterior rings by a **positive surveyor's-formula area on the stored tile coordinates**, and a Y-flip negates that sign — so our exteriors carried negative area (holes positive), inverted vs the spec and tippecanoe. Winding-agnostic renderers masked it; spec-strict consumers would classify our holes as exteriors. Fixed to `Direction::Reversed`, pinned at the command-stream level by `test_encoded_exterior_ring_has_positive_tile_area`, and the export byte-hash anchor was re-captured (its refactor-guard purpose is unchanged). Archives written by older releases have inverted windings; re-export to fix.

### Output schema & no-dedup semantics

Provenance columns `zoom` (UInt8), `layer` (Utf8, always present for a stable schema), `mvt_id` (UInt64 nullable) come first, then the alphabetical union of property columns (nullable), then `geometry`. Matching tippecanoe-decode, **nothing is deduplicated** — filter by `--zoom` or the `zoom` column. Source properties colliding with provenance names are rejected with a typed error.

## Limitations (inherent to vector tiles)

| Limitation | Cause | Mitigation |
|------------|-------|------------|
| **Simplified geometries** | Vertices removed during tiling at lower zooms | Extract from max zoom for best detail |
| **Clipped geometries** | Features cut at tile boundaries | Accept clipped output |
| **Duplicate features** | Same feature in adjacent tiles (buffer) and across zoom levels | Filter to single zoom, or post-process dedupe by feature ID |
| **Lost properties** | Attributes filtered during tiling | Cannot recover what wasn't stored |
| **No round-trip guarantee** | `A.parquet → B.pmtiles → C.parquet` where `A ≠ C` | Inherent to vector tile format |

## Verification

- 21 decode unit tests (assembly round-trips against our own encoder for all six geometry types, degenerate MVT content, transform vs `tile_bounds` corners, property lattice) + new compression/header/tile-id inverse tests.
- 8 integration tests (`crates/core/tests/decode_roundtrip.rs`): full convert→export→decode round-trip (worst vertex error 0.28 m vs the 0.60 m z14 quantization tolerance), zoom/layer filters, empty-result schema, typed errors, and a **golden comparison against the real `tippecanoe-decode` binary** (skips gracefully when absent) — counts and every vertex match.
- CLI verified end-to-end on `tests/fixtures/golden/fieldmaps-boundaries.pmtiles`: 91 features at z10, exactly matching `tippecanoe-decode`'s count.

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)