### PR TITLE
perf(core): add --bbox row-group filtering for regional extracts

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -42,6 +42,27 @@ fn parse_size_bytes(s: &str) -> Result<u32, String> {
     u32::try_from(bytes).map_err(|_| format!("Size {} too large for u32", s))
 }
 
+/// Parse a --bbox argument: xmin,ymin,xmax,ymax (lon/lat degrees).
+fn parse_bbox(s: &str) -> Result<[f64; 4]> {
+    let parts: Vec<&str> = s.split(',').collect();
+    if parts.len() != 4 {
+        anyhow::bail!("--bbox must be xmin,ymin,xmax,ymax (4 comma-separated values)");
+    }
+    let vals: Vec<f64> = parts
+        .iter()
+        .map(|p| {
+            p.trim()
+                .parse::<f64>()
+                .map_err(|e| anyhow::anyhow!("invalid number in --bbox: {e}"))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let bbox = [vals[0], vals[1], vals[2], vals[3]];
+    if bbox[0] > bbox[2] || bbox[1] > bbox[3] {
+        anyhow::bail!("--bbox must satisfy xmin <= xmax and ymin <= ymax");
+    }
+    Ok(bbox)
+}
+
 /// Top-level CLI: a default (bare) tile pipeline plus subcommands.
 ///
 /// `gpq-tiles input.parquet output.pmtiles` still works (bare tile pipeline);
@@ -144,6 +165,15 @@ struct OverviewArgs {
     /// docs/OVERVIEW_TUNING.md.
     #[arg(long, value_name = "F", default_value = "1024.0")]
     gsd_base: f64,
+
+    /// Regional extract: only convert features whose bbox intersects this
+    /// bounding box (lon/lat degrees: xmin,ymin,xmax,ymax). Row groups whose
+    /// GeoParquet 1.1 covering statistics don't intersect are skipped at the
+    /// parquet footer level (no data pages read); inputs without covering
+    /// stats degrade gracefully (all row groups read, exact per-feature
+    /// filter still applies).
+    #[arg(long, value_name = "XMIN,YMIN,XMAX,YMAX")]
+    bbox: Option<String>,
 
     /// Column name used as the cell-winner priority (sort) key. Mutually
     /// exclusive with --class-rank.
@@ -451,6 +481,12 @@ struct TilesArgs {
     #[arg(long, default_value = "14")]
     max_zoom: u8,
 
+    /// Regional extract: only convert features whose bbox intersects this
+    /// bounding box (lon/lat degrees: xmin,ymin,xmax,ymax). See --bbox in
+    /// `gpq-tiles overview --help` for details.
+    #[arg(long, value_name = "XMIN,YMIN,XMAX,YMAX")]
+    bbox: Option<String>,
+
     /// Layer name for the output tiles (default: derived from input filename).
     #[arg(long)]
     layer_name: Option<String>,
@@ -548,11 +584,14 @@ fn run_tiles(args: TilesArgs) -> Result<()> {
             .to_string()
     });
 
+    let bbox = args.bbox.as_ref().map(|s| parse_bbox(s)).transpose()?;
+
     let options = ConvertOptions {
         levels: LevelPlan::ZoomRange {
             min_zoom: args.min_zoom,
             max_zoom: args.max_zoom,
         },
+        bbox,
         ..ConvertOptions::default()
     };
 
@@ -734,6 +773,7 @@ fn run_overview(args: OverviewArgs) -> Result<()> {
         coalesce_snap: args.coalesce_snap,
         coalesce_max_level_rows: args.coalesce_max_level_rows,
         coalesce_junction_angle: args.coalesce_junction_angle,
+        bbox: args.bbox.as_ref().map(|s| parse_bbox(s)).transpose()?,
     };
 
     let report = convert_to_overviews(&args.input, &args.output, &options)

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -353,6 +353,18 @@ pub struct ConvertOptions {
     /// merge best-pair-first, so arterials chain THROUGH same-class
     /// crossings (fewer, longer strokes at the cost of over-merging).
     pub coalesce_junction_angle: f64,
+    /// Regional extract (#102): `[xmin, ymin, xmax, ymax]` in EPSG:4326
+    /// lon/lat degrees. When set, the conversion behaves as if the input
+    /// contained only the features whose bounding box intersects this region
+    /// (closed-interval AABB test): input row groups whose GeoParquet 1.1
+    /// bbox covering statistics don't intersect are skipped at the parquet
+    /// footer level (their data pages are never read), and features of the
+    /// surviving row groups are filtered exactly by their own bbox. Inputs
+    /// without covering statistics degrade gracefully — every row group is
+    /// read and only the exact per-feature filter applies, so the output is
+    /// identical either way. Default `None` (full-extent conversion,
+    /// byte-identical output to a build without this option).
+    pub bbox: Option<[f64; 4]>,
 }
 
 /// Default rows per read batch for the streaming pipeline (H3).
@@ -384,6 +396,7 @@ impl Default for ConvertOptions {
             coalesce_snap: DEFAULT_SNAP_GSD_FACTOR,
             coalesce_max_level_rows: DEFAULT_COALESCE_MAX_LEVEL_ROWS,
             coalesce_junction_angle: DEFAULT_JUNCTION_ANGLE_DEG,
+            bbox: None,
         }
     }
 }
@@ -422,6 +435,13 @@ pub struct ConvertReport {
     pub total_vertices: usize,
     /// Total compressed output size (bytes) across all levels.
     pub total_compressed_bytes: i64,
+    /// Total row groups in the input file.
+    pub row_groups_total: usize,
+    /// Input row groups actually read. Less than
+    /// [`row_groups_total`](Self::row_groups_total) only when
+    /// [`ConvertOptions::bbox`] pruned row groups via the input's bbox
+    /// covering statistics (#102).
+    pub row_groups_read: usize,
     /// Features whose bbox spans more than 180° of longitude — almost
     /// certainly antimeridian-crossing geometry stored verbatim. Warned
     /// about (one aggregate `log::warn!`), never mutated; see
@@ -594,6 +614,18 @@ fn validate_options(options: &ConvertOptions) -> Result<(), ConvertError> {
             "coalesce-junction-angle must not be NaN (use 0 to disable)".to_string(),
         ));
     }
+    if let Some(bb) = &options.bbox {
+        if bb.iter().any(|v| !v.is_finite()) {
+            return Err(ConvertError::InvalidConfig(format!(
+                "bbox {bb:?} must contain only finite values"
+            )));
+        }
+        if bb[0] > bb[2] || bb[1] > bb[3] {
+            return Err(ConvertError::InvalidConfig(format!(
+                "bbox {bb:?} must satisfy xmin <= xmax and ymin <= ymax"
+            )));
+        }
+    }
     Ok(())
 }
 
@@ -684,6 +716,22 @@ pub fn convert_to_overviews(
     // Coalescing schema check (Q3).
     validate_coalesce_schema(&input_schema, options)?;
 
+    // Regional extract (#102): prune input row groups by bbox covering
+    // statistics (footer-only), before any data pages are read. Groups
+    // without stats are kept; the exact per-feature filter below guarantees
+    // identical output either way.
+    let row_groups_total = builder.metadata().num_row_groups();
+    let bbox_units = options.bbox.map(|b| bbox_to_crs_units(&b, crs));
+    let (builder, row_groups_read) = match &bbox_units {
+        Some(bb) => {
+            let sel = select_input_row_groups(builder.metadata(), bb);
+            let n = sel.len();
+            log::info!("bbox filter: reading {n}/{row_groups_total} input row groups");
+            (builder.with_row_groups(sel), n)
+        }
+        None => (builder, row_groups_total),
+    };
+
     let reader = builder.build()?;
     let mut batches: Vec<RecordBatch> = Vec::new();
     for batch in reader {
@@ -701,17 +749,30 @@ pub fn convert_to_overviews(
             .map_err(|e| crate::Error::GeoParquetRead(format!("geometry decode: {e}")))?;
     let mut geom_opts: Vec<Option<Geometry<f64>>> = Vec::with_capacity(full.num_rows());
     extract_geometries_opt_from_array(geom_array.as_ref(), &mut geom_opts)?;
+    let mut geom_skipped = 0usize;
     let keep: Vec<bool> = geom_opts
         .iter()
-        .map(|g| g.as_ref().is_some_and(usable_geometry))
+        .map(|g| match g.as_ref().filter(|g| usable_geometry(g)) {
+            // Regional extract (#102): drop features whose bbox misses the
+            // requested region exactly, independent of row-group pruning.
+            Some(g) => bbox_units
+                .as_ref()
+                .is_none_or(|bb| bboxes_intersect(&geometry_bbox(g), bb)),
+            None => {
+                geom_skipped += 1;
+                false
+            }
+        })
         .collect();
     let skipped = keep.iter().filter(|k| !**k).count();
     let (full, geometries): (RecordBatch, Vec<Geometry<f64>>) = if skipped > 0 {
-        log::warn!(
-            "skipping {skipped} of {} input rows with a null, empty, or \
-             non-finite geometry",
-            full.num_rows()
-        );
+        if geom_skipped > 0 {
+            log::warn!(
+                "skipping {geom_skipped} of {} input rows with a null, empty, or \
+                 non-finite geometry",
+                full.num_rows()
+            );
+        }
         let mask = arrow_array::BooleanArray::from(keep.clone());
         let filtered = arrow_select::filter::filter_record_batch(&full, &mask)?;
         let geoms = geom_opts
@@ -1016,6 +1077,8 @@ pub fn convert_to_overviews(
         total_rows,
         total_vertices,
         total_compressed_bytes,
+        row_groups_total,
+        row_groups_read,
         antimeridian_suspect_features,
         duration_secs: start.elapsed().as_secs_f64(),
     })
@@ -1045,6 +1108,74 @@ pub(super) fn detect_crs(path: &Path) -> Result<Crs, ConvertError> {
             .or_else(|| info.name.clone())
             .unwrap_or_else(|| "unknown".to_string()),
     })
+}
+
+/// Half the Web Mercator world extent in meters (`±` = the x/y range of
+/// EPSG:3857). Matches the constant used by the export reprojection.
+const WEBMERC_HALF_M: f64 = 20_037_508.342_789_244;
+
+/// Web Mercator latitude clamp (the projection diverges at the poles).
+const WEBMERC_MAX_LAT: f64 = 85.051_128_779_806_59;
+
+/// Reproject one EPSG:4326 point (lon/lat degrees) to EPSG:3857 (meters) —
+/// the exact inverse of the export path's `webmerc_to_lnglat`. Latitude is
+/// clamped to the projection's valid range.
+#[inline]
+fn lnglat_to_webmerc(lng: f64, lat: f64) -> (f64, f64) {
+    use std::f64::consts::{FRAC_PI_4, PI};
+    let x = lng / 180.0 * WEBMERC_HALF_M;
+    let lat = lat.clamp(-WEBMERC_MAX_LAT, WEBMERC_MAX_LAT);
+    let y = (FRAC_PI_4 + lat.to_radians() / 2.0).tan().ln() / PI * WEBMERC_HALF_M;
+    (x, y)
+}
+
+/// Express a `[xmin, ymin, xmax, ymax]` EPSG:4326 bbox in the input file's
+/// coordinate units ([`ConvertOptions::bbox`] is always lon/lat degrees; a
+/// 3857 input stores meters).
+pub(super) fn bbox_to_crs_units(bbox: &[f64; 4], crs: Crs) -> [f64; 4] {
+    match crs {
+        Crs::Epsg4326 => *bbox,
+        Crs::Epsg3857 => {
+            let (xmin, ymin) = lnglat_to_webmerc(bbox[0], bbox[1]);
+            let (xmax, ymax) = lnglat_to_webmerc(bbox[2], bbox[3]);
+            [xmin, ymin, xmax, ymax]
+        }
+    }
+}
+
+/// Closed-interval AABB intersection of two `[xmin, ymin, xmax, ymax]` boxes
+/// (touching edges count as intersecting, matching
+/// [`crate::covering::RowGroupBounds::intersects`]).
+pub(super) fn bboxes_intersect(a: &[f64; 4], b: &[f64; 4]) -> bool {
+    a[0] <= b[2] && a[2] >= b[0] && a[1] <= b[3] && a[3] >= b[1]
+}
+
+/// Row groups of the input whose bbox covering statistics intersect
+/// `bbox_units` (`[xmin, ymin, xmax, ymax]` in the file's CRS units).
+///
+/// Statistics-only: operates purely on the parsed parquet footer
+/// ([`crate::covering::extract_row_group_bounds_from_metadata`]); no data
+/// pages are touched. Row groups with missing/unparseable covering
+/// statistics are conservatively KEPT (graceful degradation — the exact
+/// per-feature bbox filter downstream guarantees correctness either way).
+pub(super) fn select_input_row_groups(
+    metadata: &parquet::file::metadata::ParquetMetaData,
+    bbox_units: &[f64; 4],
+) -> Vec<usize> {
+    let bounds = crate::covering::extract_row_group_bounds_from_metadata(metadata)
+        .unwrap_or_else(|_| vec![None; metadata.num_row_groups()]);
+    let filter = crate::tile::TileBounds {
+        lng_min: bbox_units[0],
+        lat_min: bbox_units[1],
+        lng_max: bbox_units[2],
+        lat_max: bbox_units[3],
+    };
+    (0..metadata.num_row_groups())
+        .filter(|&i| match bounds.get(i).and_then(|b| b.as_ref()) {
+            Some(b) => b.intersects(&filter),
+            None => true, // no stats — must read to stay correct
+        })
+        .collect()
 }
 
 /// Find the primary geometry column index (name `geometry`, else first `geom*`).
@@ -3998,5 +4129,210 @@ mod tests {
         };
         let err = convert_to_overviews(tin.path(), tout.path(), &opts).unwrap_err();
         assert!(matches!(err, ConvertError::SortKeyColumnMissing { .. }));
+    }
+
+    // ========================================================================
+    // Bbox row-group filtering tests (#102)
+    // ========================================================================
+
+    /// Write a multi-row-group GeoParquet file with covering column stats so
+    /// row-group pruning can actually bite. Each row group contains one point
+    /// at `(x, y)` with id = row-group index.
+    fn write_multi_rg_input(path: &Path, coords: &[(f64, f64)], with_covering: bool) {
+        use parquet::file::properties::WriterProperties;
+
+        let geoms: Vec<Geometry<f64>> = coords
+            .iter()
+            .map(|&(x, y)| Geometry::Point(Point::new(x, y)))
+            .collect();
+        let n = geoms.len();
+        let id = Int64Array::from((0..n as i64).collect::<Vec<_>>());
+        let geom_arr = build_geometry_array(&geoms);
+        let geom_field = geom_arr.data_type().to_field("geometry", true);
+        let fields = vec![
+            Arc::new(Field::new("id", DataType::Int64, false)),
+            Arc::new(geom_field),
+        ];
+        let columns: Vec<Arc<dyn Array>> = vec![Arc::new(id), geom_arr.to_array_ref()];
+        let schema = Arc::new(Schema::new(fields));
+        let batch = RecordBatch::try_new(schema.clone(), columns).unwrap();
+
+        let gpq_options = GeoParquetWriterOptionsBuilder::default()
+            .set_encoding(GeoParquetWriterEncoding::WKB)
+            .set_generate_covering(with_covering)
+            .build();
+        let encoder = GeoParquetRecordBatchEncoder::try_new(&schema, &gpq_options).unwrap();
+        let target_schema = encoder.target_schema();
+        // Row-group size = 1 to force n row groups.
+        let props = WriterProperties::builder()
+            .set_max_row_group_size(1)
+            .build();
+        let file = std::fs::File::create(path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, target_schema, Some(props)).unwrap();
+        let mut encoder = encoder;
+        let encoded = encoder.encode_record_batch(&batch).unwrap();
+        writer.write(&encoded).unwrap();
+        writer.append_key_value_metadata(encoder.into_keyvalue().unwrap());
+        writer.close().unwrap();
+    }
+
+    /// Read all ids from all levels of an overview file.
+    fn read_all_ids(reader: &OverviewReader) -> Vec<i64> {
+        use arrow_array::cast::AsArray;
+        let mut ids = Vec::new();
+        for level in 0..reader.num_levels() {
+            let rdr = reader.read_level(level, None).unwrap();
+            for batch in rdr {
+                let batch = batch.unwrap();
+                let col = batch
+                    .column(batch.schema().index_of("id").unwrap())
+                    .as_primitive::<arrow_array::types::Int64Type>();
+                ids.extend(col.iter().flatten());
+            }
+        }
+        ids.sort_unstable();
+        ids.dedup();
+        ids
+    }
+
+    #[test]
+    fn bbox_filter_matches_posthoc_filter() {
+        // 4 row groups with points at (0,0), (10,10), (20,20), (30,30).
+        // A bbox around (10,10) should keep only id=1.
+        let coords = vec![(0.0, 0.0), (10.0, 10.0), (20.0, 20.0), (30.0, 30.0)];
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        write_multi_rg_input(tin.path(), &coords, true);
+
+        // Full unfiltered conversion.
+        let tout_full = tempfile::NamedTempFile::new().unwrap();
+        let opts_full = ConvertOptions {
+            mode: Mode::Duplicating,
+            levels: LevelPlan::ZoomRange {
+                min_zoom: 6,
+                max_zoom: 6,
+            },
+            ..Default::default()
+        };
+        let report_full = convert_to_overviews(tin.path(), tout_full.path(), &opts_full).unwrap();
+        assert_eq!(report_full.row_groups_total, 4);
+        assert_eq!(report_full.row_groups_read, 4);
+        let reader_full = OverviewReader::open(tout_full.path()).unwrap();
+        let ids_full = read_all_ids(&reader_full);
+
+        // Bbox-filtered conversion: keep only (10,10).
+        let tout_bbox = tempfile::NamedTempFile::new().unwrap();
+        let opts_bbox = ConvertOptions {
+            bbox: Some([9.0, 9.0, 11.0, 11.0]),
+            ..opts_full.clone()
+        };
+        let report_bbox = convert_to_overviews(tin.path(), tout_bbox.path(), &opts_bbox).unwrap();
+        // The bbox intersects only one row group, so pruning should fire.
+        assert_eq!(report_bbox.row_groups_total, 4);
+        assert_eq!(
+            report_bbox.row_groups_read, 1,
+            "bbox pruning did not fire: read {} row groups",
+            report_bbox.row_groups_read
+        );
+        let reader_bbox = OverviewReader::open(tout_bbox.path()).unwrap();
+        let ids_bbox = read_all_ids(&reader_bbox);
+        assert_eq!(ids_bbox, vec![1], "bbox filter kept wrong ids");
+
+        // Correctness: filtered == unfiltered then post-hoc filtered.
+        let ids_posthoc: Vec<i64> = ids_full
+            .into_iter()
+            .filter(|&id| {
+                let (x, y) = coords[id as usize];
+                x >= 9.0 && x <= 11.0 && y >= 9.0 && y <= 11.0
+            })
+            .collect();
+        assert_eq!(ids_bbox, ids_posthoc);
+    }
+
+    #[test]
+    fn bbox_filter_stats_free_degradation() {
+        // Same layout but WITHOUT covering column (stats-free input).
+        let coords = vec![(0.0, 0.0), (10.0, 10.0), (20.0, 20.0), (30.0, 30.0)];
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        write_multi_rg_input(tin.path(), &coords, false);
+
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        let opts = ConvertOptions {
+            mode: Mode::Duplicating,
+            levels: LevelPlan::ZoomRange {
+                min_zoom: 6,
+                max_zoom: 6,
+            },
+            bbox: Some([9.0, 9.0, 11.0, 11.0]),
+            ..Default::default()
+        };
+        let report = convert_to_overviews(tin.path(), tout.path(), &opts).unwrap();
+        // Without stats, all row groups are read (graceful degradation).
+        assert_eq!(report.row_groups_total, 4);
+        assert_eq!(
+            report.row_groups_read, 4,
+            "stats-free should read all row groups"
+        );
+        // Exact per-feature filter still applies: only id=1 survives.
+        let reader = OverviewReader::open(tout.path()).unwrap();
+        let ids = read_all_ids(&reader);
+        assert_eq!(ids, vec![1], "exact filter did not apply");
+    }
+
+    #[test]
+    fn bbox_filter_nothing_intersects() {
+        let coords = vec![(0.0, 0.0), (10.0, 10.0)];
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        write_multi_rg_input(tin.path(), &coords, true);
+
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        let opts = ConvertOptions {
+            mode: Mode::Duplicating,
+            levels: LevelPlan::ZoomRange {
+                min_zoom: 6,
+                max_zoom: 6,
+            },
+            bbox: Some([100.0, 100.0, 110.0, 110.0]), // far away
+            ..Default::default()
+        };
+        let err = convert_to_overviews(tin.path(), tout.path(), &opts).unwrap_err();
+        // No features survive → NoData error.
+        assert!(
+            matches!(err, ConvertError::NoData),
+            "expected NoData, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn bbox_filter_everything_intersects() {
+        let coords = vec![(0.0, 0.0), (10.0, 10.0)];
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        write_multi_rg_input(tin.path(), &coords, true);
+
+        // Full conversion (no bbox).
+        let tout_full = tempfile::NamedTempFile::new().unwrap();
+        let opts_full = ConvertOptions {
+            mode: Mode::Duplicating,
+            levels: LevelPlan::ZoomRange {
+                min_zoom: 6,
+                max_zoom: 6,
+            },
+            ..Default::default()
+        };
+        let report_full = convert_to_overviews(tin.path(), tout_full.path(), &opts_full).unwrap();
+        let reader_full = OverviewReader::open(tout_full.path()).unwrap();
+        let ids_full = read_all_ids(&reader_full);
+
+        // Bbox containing everything.
+        let tout_bbox = tempfile::NamedTempFile::new().unwrap();
+        let opts_bbox = ConvertOptions {
+            bbox: Some([-1.0, -1.0, 11.0, 11.0]),
+            ..opts_full.clone()
+        };
+        let report_bbox = convert_to_overviews(tin.path(), tout_bbox.path(), &opts_bbox).unwrap();
+        // All row groups intersect, so row_groups_read == row_groups_total.
+        assert_eq!(report_bbox.row_groups_read, report_bbox.row_groups_total);
+        let reader_bbox = OverviewReader::open(tout_bbox.path()).unwrap();
+        let ids_bbox = read_all_ids(&reader_bbox);
+        assert_eq!(ids_bbox, ids_full);
     }
 }

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -763,9 +763,12 @@ pub fn convert_to_overviews(
         .map(|g| match g.as_ref().filter(|g| usable_geometry(g)) {
             // Regional extract (#102): drop features whose bbox misses the
             // requested region exactly, independent of row-group pruning.
+            // (map_or, not is_none_or: the latter is stable only since Rust
+            // 1.82 and the crate MSRV is 1.75.)
+            #[allow(clippy::unnecessary_map_or)]
             Some(g) => bbox_units
                 .as_ref()
-                .is_none_or(|bb| bboxes_intersect(&geometry_bbox(g), bb)),
+                .map_or(true, |bb| bboxes_intersect(&geometry_bbox(g), bb)),
             None => {
                 geom_skipped += 1;
                 false
@@ -4174,7 +4177,7 @@ mod tests {
         let target_schema = encoder.target_schema();
         // Row-group size = 1 to force n row groups.
         let props = WriterProperties::builder()
-            .set_max_row_group_size(1)
+            .set_max_row_group_row_count(Some(1))
             .build();
         let file = std::fs::File::create(path).unwrap();
         let mut writer = ArrowWriter::try_new(file, target_schema, Some(props)).unwrap();
@@ -4251,7 +4254,7 @@ mod tests {
             .into_iter()
             .filter(|&id| {
                 let (x, y) = coords[id as usize];
-                x >= 9.0 && x <= 11.0 && y >= 9.0 && y <= 11.0
+                (9.0..=11.0).contains(&x) && (9.0..=11.0).contains(&y)
             })
             .collect();
         assert_eq!(ids_bbox, ids_posthoc);
@@ -4327,7 +4330,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let report_full = convert_to_overviews(tin.path(), tout_full.path(), &opts_full).unwrap();
+        let _report_full = convert_to_overviews(tin.path(), tout_full.path(), &opts_full).unwrap();
         let reader_full = OverviewReader::open(tout_full.path()).unwrap();
         let ids_full = read_all_ids(&reader_full);
 

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -116,6 +116,26 @@ pub(super) fn convert_streaming(
     let file = File::open(input_path)?;
     let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
     let input_schema: SchemaRef = builder.schema().clone();
+
+    // Regional extract (#102): prune input row groups by bbox covering
+    // statistics — footer metadata only, no data pages of skipped groups are
+    // ever read. Both passes read the SAME selection, so the global row
+    // indices addressing the winner tables stay aligned. Groups without
+    // stats are kept; the exact per-feature filter in pass 1 guarantees
+    // identical output either way.
+    let row_groups_total = builder.metadata().num_row_groups();
+    let bbox_units = options
+        .bbox
+        .map(|b| super::convert::bbox_to_crs_units(&b, crs));
+    let selected_row_groups: Option<Vec<usize>> = bbox_units
+        .as_ref()
+        .map(|bb| super::convert::select_input_row_groups(builder.metadata(), bb));
+    let row_groups_read = selected_row_groups
+        .as_ref()
+        .map_or(row_groups_total, Vec::len);
+    if selected_row_groups.is_some() {
+        log::info!("bbox filter: reading {row_groups_read}/{row_groups_total} input row groups");
+    }
     drop(builder);
 
     if input_schema
@@ -142,7 +162,15 @@ pub(super) fn convert_streaming(
         coalesce: coalesce_scratch,
         num_rows,
         skipped_rows,
-    } = run_pass1(input_path, &input_schema, geom_idx, options, &acc_cols)?;
+    } = run_pass1(
+        input_path,
+        &input_schema,
+        geom_idx,
+        options,
+        &acc_cols,
+        selected_row_groups.as_deref(),
+        bbox_units.as_ref(),
+    )?;
     if skipped_rows > 0 {
         log::warn!(
             "skipping {skipped_rows} of {num_rows} input rows with a null, \
@@ -400,6 +428,7 @@ pub(super) fn convert_streaming(
             e.hint,
             input_path,
             options.read_batch_size,
+            selected_row_groups.as_deref(),
             &ctx,
         )?;
         level_reports.push(LevelReport {
@@ -437,6 +466,8 @@ pub(super) fn convert_streaming(
         total_rows,
         total_vertices,
         total_compressed_bytes,
+        row_groups_total,
+        row_groups_read,
         antimeridian_suspect_features,
         duration_secs: start.elapsed().as_secs_f64(),
     })
@@ -645,6 +676,8 @@ fn run_pass1(
     geom_idx: usize,
     options: &ConvertOptions,
     acc_cols: &[usize],
+    row_groups: Option<&[usize]>,
+    bbox_units: Option<&[f64; 4]>,
 ) -> Result<Pass1Output, ConvertError> {
     let mut plan = build_rank_plan(input_schema, options)?;
 
@@ -668,8 +701,13 @@ fn run_pass1(
     let proj = |orig: usize| cols.binary_search(&orig).expect("projected column");
 
     let file = File::open(input_path)?;
-    let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
+    let mut builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
     let mask = ProjectionMask::roots(builder.parquet_schema(), cols.iter().copied());
+    // Regional extract (#102): read only the bbox-selected row groups
+    // (identical selection in pass 2, keeping row indices aligned).
+    if let Some(rgs) = row_groups {
+        builder = builder.with_row_groups(rgs.to_vec());
+    }
     let reader = builder
         .with_projection(mask)
         .with_batch_size(options.read_batch_size.max(1))
@@ -715,6 +753,16 @@ fn run_pass1(
                 skipped_rows += 1;
                 continue;
             };
+            // Regional extract (#102): a feature whose bbox misses the region
+            // produces no AssignFeature — its winner-table slot stays at the
+            // UNASSIGNED sentinel, so pass 2 drops the row too. The row index
+            // still advances (row-keyed tables stay aligned).
+            let fbbox = geometry_bbox(g);
+            if let Some(bb) = bbox_units {
+                if !super::convert::bboxes_intersect(&fbbox, bb) {
+                    continue;
+                }
+            }
             let kind = feature_kind(g);
             if matches!(kind, FeatureKind::Point) {
                 point_count += 1;
@@ -726,7 +774,7 @@ fn run_pass1(
             }
             features.push(AssignFeature {
                 index: base + i,
-                bbox: geometry_bbox(g),
+                bbox: fbbox,
                 kind,
                 sort_key: None, // filled below once the ranking tier resolves
             });
@@ -953,12 +1001,18 @@ fn write_level_streaming(
     hint: usize,
     input_path: &Path,
     read_batch_size: usize,
+    row_groups: Option<&[usize]>,
     ctx: &LevelStreamCtx<'_>,
 ) -> Result<(usize, usize), ConvertError> {
     let file = File::open(input_path)?;
-    let mut reader = ParquetRecordBatchReaderBuilder::try_new(file)?
-        .with_batch_size(read_batch_size.max(1))
-        .build()?;
+    let mut builder =
+        ParquetRecordBatchReaderBuilder::try_new(file)?.with_batch_size(read_batch_size.max(1));
+    // Regional extract (#102): read the same bbox-selected row groups as
+    // pass 1, so the winner tables' global row indices line up.
+    if let Some(rgs) = row_groups {
+        builder = builder.with_row_groups(rgs.to_vec());
+    }
+    let mut reader = builder.build()?;
 
     // `write_level` consumes an infallible batch iterator; errors inside the
     // stream are parked in `err` (fusing the iterator) and re-raised after.

--- a/crates/python/gpq_tiles.pyi
+++ b/crates/python/gpq_tiles.pyi
@@ -51,6 +51,7 @@ def overview(
     full_column_stats: bool = False,
     streaming: bool = True,
     read_batch_size: int = 8192,
+    bbox: tuple[float, float, float, float] | None = None,
 ) -> dict[str, Any]: ...
 def export_pmtiles(
     input: str,

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -167,6 +167,8 @@ fn convert_report_to_dict(py: Python<'_>, report: &ConvertReport) -> PyResult<Py
     dict.set_item("total_rows", report.total_rows)?;
     dict.set_item("total_vertices", report.total_vertices)?;
     dict.set_item("total_compressed_bytes", report.total_compressed_bytes)?;
+    dict.set_item("row_groups_total", report.row_groups_total)?;
+    dict.set_item("row_groups_read", report.row_groups_read)?;
     dict.set_item("duration_secs", report.duration_secs)?;
     Ok(dict.into())
 }
@@ -268,13 +270,20 @@ fn convert_report_to_dict(py: Python<'_>, report: &ConvertReport) -> PyResult<Py
 ///         pipeline. Defaults to True.
 ///     read_batch_size (int, optional): Rows per Arrow read batch in the
 ///         streaming pipeline. Defaults to 8192.
+///     bbox (tuple, optional): Regional extract as ``(xmin, ymin, xmax,
+///         ymax)`` in EPSG:4326 lon/lat degrees. Only features whose bbox
+///         intersects the region are converted; input row groups whose bbox
+///         covering statistics don't intersect are skipped without reading
+///         their data pages (inputs without covering stats read everything
+///         and rely on the exact per-feature filter). Defaults to None
+///         (full extent).
 ///
 /// Returns:
 ///     dict: Conversion report with keys "mode", "levels" (list of dicts with
 ///     "level", "gsd", "zoom", "feature_count", "vertex_count",
 ///     "uncompressed_bytes", "compressed_bytes"), "input_features",
 ///     "total_rows", "total_vertices", "total_compressed_bytes",
-///     "duration_secs".
+///     "row_groups_total", "row_groups_read", "duration_secs".
 ///
 /// Raises:
 ///     ValueError: Invalid options (bad mode/direction/op, conflicting or
@@ -327,6 +336,7 @@ fn convert_report_to_dict(py: Python<'_>, report: &ConvertReport) -> PyResult<Py
     full_column_stats=false,
     streaming=true,
     read_batch_size=8192,
+    bbox=None,
 ))]
 #[allow(clippy::too_many_arguments)] // Python API mirrors CLI flags; grouping into struct would hurt usability
 fn overview(
@@ -365,6 +375,7 @@ fn overview(
     full_column_stats: bool,
     streaming: bool,
     read_batch_size: usize,
+    bbox: Option<(f64, f64, f64, f64)>,
 ) -> PyResult<Py<PyDict>> {
     let mode = match mode {
         "duplicating" => Mode::Duplicating,
@@ -495,6 +506,7 @@ fn overview(
         coalesce_snap,
         coalesce_max_level_rows,
         coalesce_junction_angle,
+        bbox: bbox.map(|(xmin, ymin, xmax, ymax)| [xmin, ymin, xmax, ymax]),
     };
 
     let input_path = Path::new(input).to_path_buf();

--- a/docs/OVERVIEW_TUNING.md
+++ b/docs/OVERVIEW_TUNING.md
@@ -544,6 +544,46 @@ stay laptop-sized.
 
 ---
 
+## Regional extract: `--bbox`
+
+`--bbox xmin,ymin,xmax,ymax` (lon/lat degrees, EPSG:4326) converts only the
+features whose bounding box intersects the given region — useful for extracting
+a city from a country-wide file without processing the whole dataset.
+
+```bash
+# Tile just Antananarivo from a Madagascar-wide file
+gpq-tiles overview madagascar.parquet antananarivo.parquet \
+  --bbox 47.4,-19.0,47.6,-18.8 \
+  --min-zoom 0 --max-zoom 14
+```
+
+The filter is two-stage:
+
+1. **Row-group pruning** (statistics-based): row groups whose GeoParquet 1.1
+   bbox covering column statistics don't intersect the region are skipped at
+   the parquet footer level — their data pages are never read. This is the
+   big win: a gpio-optimized (Hilbert-sorted) file typically reduces I/O by
+   90%+ for small regional extracts.
+
+2. **Exact feature filter**: features of the surviving row groups whose own
+   bbox misses the region are dropped exactly. This guarantees correctness
+   even when the input lacks covering statistics.
+
+**Graceful degradation**: if the input has no covering column or its statistics
+are unavailable (non-gpio-optimized, GDAL without covering, etc.), all row
+groups are read and only the exact per-feature filter applies — the output is
+identical, just slower. Check `ConvertReport.row_groups_read` vs
+`row_groups_total` to see whether pruning fired.
+
+| Knob | Default | Units | Effect |
+|------|---------|-------|--------|
+| `--bbox xmin,ymin,xmax,ymax` | — | lon/lat degrees | only features intersecting this region; omit = full extent |
+
+**Tip**: for EPSG:3857 inputs, still pass lon/lat degrees — the converter
+reprojects the bbox internally.
+
+---
+
 ## Worked scenarios
 
 | Symptom | Fix |


### PR DESCRIPTION
> **Note:** originally held out of the v0.7.0 release-testing window; the maintainer pulled it into the pre-release window on 2026-07-04. Mergeable once CI is green.

## Summary

- Skip input row groups whose GeoParquet 1.1 bbox covering column statistics don't intersect the requested `--bbox` region — data pages of skipped groups are never read
- For gpio-optimized (Hilbert-sorted) inputs, this reduces read work dramatically on regional extracts (the ticket's "tile just Antananarivo from a Madagascar file" use case)
- Two-stage filter: (1) row-group pruning via parquet footer stats, (2) exact per-feature bbox filter on surviving groups
- Graceful degradation: inputs without covering stats read all row groups but still apply the exact filter — never wrong results
- `ConvertReport` gains `row_groups_total` / `row_groups_read` so the pruning effect is visible and testable
- Wired through the CLI (`--bbox` on `overview` and `tiles`) and the Python bindings (`bbox=(xmin, ymin, xmax, ymax)` kwarg on `overview()`)

## CLI

```bash
gpq-tiles overview madagascar.parquet antananarivo.parquet \
  --bbox 47.4,-19.0,47.6,-18.8 \
  --min-zoom 0 --max-zoom 14

gpq-tiles tiles madagascar.parquet antananarivo.pmtiles \
  --bbox 47.4,-19.0,47.6,-18.8 \
  --min-zoom 0 --max-zoom 14
```

## Test plan

- [x] `bbox_filter_matches_posthoc_filter` — correctness invariant: filtered output == unfiltered output filtered post-hoc
- [x] `bbox_filter_stats_free_degradation` — inputs without covering stats degrade gracefully (all RGs read, exact filter still applies)
- [x] `bbox_filter_nothing_intersects` — bbox missing all features produces `NoData` error
- [x] `bbox_filter_everything_intersects` — bbox containing everything produces identical output to no-bbox

Run:
```bash
cargo test --package gpq-tiles-core \
  convert::tests::bbox_filter -- --nocapture
```

## Measured speedup

Release build, `corpus/data/gpio/polygons-ftw-moldova-large.parquet` (gpio-optimized/Hilbert-sorted, 632k polygons, 93 MB, 6 row groups), Chișinău city bbox `28.75,46.95,28.95,47.10` (~0.5% of features), `--min-zoom 0 --max-zoom 6`, 3 runs each via `/usr/bin/time`:

| Run | Wall time | Peak RSS | Row groups read | Input features |
|-----|-----------|----------|-----------------|----------------|
| Full (no `--bbox`), 3 runs | 8.22 / 8.35 / 8.19 s (avg **8.25 s**) | ~332 MB | 6 / 6 | 631,910 |
| `--bbox` Chișinău, 3 runs | 1.83 / 1.77 / 1.79 s (avg **1.80 s**) | ~267 MB | **3 / 6** | 3,489 |

**4.6× faster** end-to-end for the city-scale extract. Note the pruning granularity: this file has only 6 (large) row groups, so stats pruning halved the reads; the rest of the win comes from the exact feature filter cutting downstream work to 3,489 features. Files written with smaller row groups (the ticket's 364-row-group example, or `gpio` with tighter row-group sizing) prune proportionally harder.

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)
