### PR TITLE
perf: per-level row-group sizing sweep + zoom-scaled policy (#202)

### DIFF
--- a/benchmarks/overview/bench_access_remote.py
+++ b/benchmarks/overview/bench_access_remote.py
@@ -31,6 +31,13 @@ Env:
   BENCH_AWS_PROFILE (default nissim-admin)
   BENCH_RUNS        (default 3; medians reported)
   BENCH_DATASETS    (comma list; default all four)
+  BENCH_OVERVIEW_PREFIX (default "overviews"; e.g. "sweep202/rg50k" to
+                    point the overview path at a sweep variant prefix)
+  BENCH_REPORT_DIR  (default corpus/data/bench/overviews; local dir with
+                    <ds>.dup.report.json for the zoom->level mapping)
+  BENCH_RESULTS     (default remote_access_results.json; output path)
+  BENCH_SKIP_PMTILES=1  (overview path only -- for sweeps where the
+                    PMTiles side is unchanged)
 """
 import json
 import math
@@ -49,6 +56,14 @@ BUCKET = os.environ.get("BENCH_BUCKET", "gpq-tiles-bench")
 REGION = os.environ.get("BENCH_REGION", "us-east-2")
 PROFILE = os.environ.get("BENCH_AWS_PROFILE", "nissim-admin")
 N_RUNS = int(os.environ.get("BENCH_RUNS", "3"))
+OV_PREFIX = os.environ.get("BENCH_OVERVIEW_PREFIX", "overviews")
+REPORT_DIR = os.environ.get(
+    "BENCH_REPORT_DIR", os.path.join(DATA_ROOT, "bench", "overviews")
+)
+RESULTS_PATH = os.environ.get(
+    "BENCH_RESULTS", os.path.join(HERE, "remote_access_results.json")
+)
+SKIP_PMTILES = os.environ.get("BENCH_SKIP_PMTILES") == "1"
 
 DATASETS = os.environ.get(
     "BENCH_DATASETS",
@@ -79,9 +94,7 @@ def tiles_for_bbox(bbox, z):
 
 
 def zoom_to_level(ds):
-    rep = os.path.join(
-        DATA_ROOT, "bench", "overviews", ds + ".dup.report.json"
-    )
+    rep = os.path.join(REPORT_DIR, ds + ".dup.report.json")
     with open(rep) as f:
         r = json.load(f)
     return {lvl["zoom"]: lvl["level"] for lvl in r["levels"]}
@@ -126,7 +139,7 @@ def parse_duckdb_output(out):
 def overview_run(ds, bbox, zoom, z2l):
     """One fresh DuckDB process: cold query then warm repeat."""
     level = z2l.get(zoom)
-    url = f"s3://{BUCKET}/overviews/{ds}.dup.parquet"
+    url = f"s3://{BUCKET}/{OV_PREFIX}/{ds}.dup.parquet"
     xmin, ymin, xmax, ymax = bbox
     where = (
         f"WHERE level={level} "
@@ -252,16 +265,19 @@ def main():
         viewports = json.load(f)
 
     results = {"bucket": BUCKET, "region": REGION, "runs": N_RUNS,
-               "datasets": {}}
+               "overview_prefix": OV_PREFIX, "datasets": {}}
     for ds in DATASETS:
         z2l = zoom_to_level(ds)
-        pm_url = presign(f"pmtiles/{ds}.pmtiles")
         results["datasets"][ds] = {
             "overview_file_bytes": object_size(
-                f"overviews/{ds}.dup.parquet"
+                f"{OV_PREFIX}/{ds}.dup.parquet"
             ),
-            "pmtiles_file_bytes": object_size(f"pmtiles/{ds}.pmtiles"),
         }
+        if not SKIP_PMTILES:
+            pm_url = presign(f"pmtiles/{ds}.pmtiles")
+            results["datasets"][ds]["pmtiles_file_bytes"] = object_size(
+                f"pmtiles/{ds}.pmtiles"
+            )
         for vp in ("world", "regional", "street"):
             cfg = viewports[ds]["viewports"][vp]
             bbox, zoom = cfg["bbox"], cfg["zoom"]
@@ -271,32 +287,37 @@ def main():
                 c, w = overview_run(ds, bbox, zoom, z2l)
                 ov_cold.append(c)
                 ov_warm.append(w)
-                c, w = pmtiles_run(ds, bbox, zoom, pm_url)
-                pm_cold.append(c)
-                pm_warm.append(w)
+                if not SKIP_PMTILES:
+                    c, w = pmtiles_run(ds, bbox, zoom, pm_url)
+                    pm_cold.append(c)
+                    pm_warm.append(w)
 
             entry = {
                 "zoom": zoom, "bbox": bbox,
                 "overview": {"cold": median_of(ov_cold),
                              "warm": median_of(ov_warm)},
-                "pmtiles": {"cold": median_of(pm_cold),
-                            "warm": median_of(pm_warm)},
             }
+            if not SKIP_PMTILES:
+                entry["pmtiles"] = {"cold": median_of(pm_cold),
+                                    "warm": median_of(pm_warm)}
             results["datasets"][ds][vp] = entry
             oc = entry["overview"]["cold"]
-            pc = entry["pmtiles"]["cold"]
-            print(
+            line = (
                 f"{ds:28s} {vp:9s} z{zoom:<2d} | "
                 f"ov {oc['bytes']:>11,.0f}B "
                 f"{oc['head'] + oc['get']:>3d}req "
-                f"{oc['wall_ms']:>8.1f}ms {oc['features']:>7d}f | "
-                f"pm {pc['bytes']:>11,}B {pc['requests']:>3d}req "
-                f"{pc['wall_ms']:>8.1f}ms "
-                f"{pc['tiles_present']}/{pc['tiles_requested']}t",
-                flush=True,
+                f"{oc['wall_ms']:>8.1f}ms {oc['features']:>7d}f"
             )
+            if not SKIP_PMTILES:
+                pc = entry["pmtiles"]["cold"]
+                line += (
+                    f" | pm {pc['bytes']:>11,}B {pc['requests']:>3d}req "
+                    f"{pc['wall_ms']:>8.1f}ms "
+                    f"{pc['tiles_present']}/{pc['tiles_requested']}t"
+                )
+            print(line, flush=True)
 
-    out = os.path.join(HERE, "remote_access_results.json")
+    out = RESULTS_PATH
     with open(out, "w") as f:
         json.dump(results, f, indent=2)
     print(f"\nwrote {out}")

--- a/corpus/SWEEPS.md
+++ b/corpus/SWEEPS.md
@@ -103,3 +103,77 @@ arterial strokes at z0–z1 but over-merges through genuine turns and
 smears attributes across crossings. Line coalescing itself remains
 **ON by default** (same review: defaults should look right); opt out
 with `--no-coalesce-lines`.
+
+## Decision 5: `--row-group-size-policy zoom-scaled` (issue #202)
+
+**Sweep:** `--row-group-size` ∈ {10k, 25k, 50k, 100k} and the new
+`--row-group-size-policy zoom-scaled` on all four benchmark datasets
+(points-nyc, lines-portland, polygons-portland, polygons-ftw-moldova),
+duplicating mode, z0–14, default knobs. Measured against real S3
+(us-east-2) with the #200 harness: DuckDB cold requests/bytes/wall
+per viewport.
+
+**Request counts (cold, median of 3):**
+
+| dataset | viewport | z | rg10k | rg25k | rg50k | rg100k | zoom-scaled |
+|---|---|---|---|---|---|---|---|
+| points-nyc-medium | regional | 11 | 38 | 22 | 20 | 14 | **14** |
+| points-nyc-medium | street | 14 | 46 | 32 | 22 | 16 | **46** |
+| lines-portland-medium | regional | 11 | 32 | 20 | 14 | 8 | **8** |
+| lines-portland-medium | street | 14 | 27 | 21 | 15 | 15 | **27** |
+| polygons-portland-medium | street | 14 | 33 | 33 | 33 | 21 | **33** |
+| polygons-ftw-moldova-large | regional | 9 | **52** | 32 | 22 | 12 | **12** |
+| polygons-ftw-moldova-large | street | 14 | 25 | 24 | 23 | 13 | **25** |
+
+**Bytes fetched (cold, median of 3):**
+
+| dataset | viewport | z | rg10k | rg25k | rg50k | rg100k | zoom-scaled |
+|---|---|---|---|---|---|---|---|
+| points-nyc-medium | street | 14 | **5.1 MB** | 8.0 MB | 11.0 MB | 15.9 MB | **5.1 MB** |
+| lines-portland-medium | street | 14 | **4.5 MB** | 9.2 MB | 13.2 MB | 27.0 MB | **4.5 MB** |
+| polygons-portland-medium | street | 14 | **6.7 MB** | 16.7 MB | 34.2 MB | 39.3 MB | **6.7 MB** |
+| polygons-ftw-moldova-large | regional | 9 | 7.1 MB | 8.5 MB | 8.5 MB | 8.5 MB | 8.5 MB |
+| polygons-ftw-moldova-large | street | 14 | **2.0 MB** | 4.3 MB | 12.3 MB | 12.6 MB | **2.0 MB** |
+
+World viewports: all policies identical (row count < any cap).
+
+**Storage (local, file / footer / RGs):**
+
+| dataset | rg10k | rg100k | zoom-scaled |
+|---|---|---|---|
+| points-nyc-medium | 78.95 MB / 121 KB / 116 | 73.92 MB / 28 KB / 23 | 76.98 MB / 82 KB / 77 |
+| lines-portland-medium | 73.21 MB / 81 KB / 81 | 71.28 MB / 21 KB / 17 | 72.39 MB / 54 KB / 52 |
+| polygons-portland-medium | 186.68 MB / 156 KB / 148 | 180.75 MB / 24 KB / 20 | 184.78 MB / 121 KB / 114 |
+| polygons-ftw-moldova-large | 293.65 MB / 248 KB / 167 | 292.23 MB / 40 KB / 24 | 292.52 MB / 151 KB / 100 |
+
+File size: negligible (2–6% variation). Footer: linear in RG count but
+small either way (<250 KB on the 294 MB Moldova file).
+
+**Decision (2026-07-04, #202):** ship `zoom-scaled` as **opt-in**; keep
+`constant 10k` as the default for now. `zoom-scaled` doubles the
+row-group cap per zoom step below the finest level, so coarse bands —
+read mostly whole by wide viewports anyway — become fewer, larger row
+groups, while the finest level keeps tight bbox pruning:
+
+- Coarse/regional: matches rg100k request counts (Moldova regional
+  52 → 12 requests, 77% reduction).
+- Fine/street: maintains rg10k byte counts (Portland polygons 6.7 MB
+  vs rg100k's 39.3 MB, 6× less).
+- Best of both: the lowest wall times across the sweep on street
+  viewports (fewer bytes trumps fewer requests at the canonical level).
+
+The constant policies are a tradeoff: rg100k cuts requests but pulls
+3–6× more bytes at fine zoom (wider row groups mean coarser pruning);
+rg10k keeps bytes tight but pays 2–4× more round trips on coarse/mid
+viewports. `zoom-scaled` gets both — request efficiency at coarse zoom,
+byte efficiency at fine zoom.
+
+**Why opt-in (for now):** the sweep confirms the win, but the policy is
+new; shipping it as the default would be a behavior change to all users
+without a bake-in period. The option is there, documented, and proven;
+it can be promoted to the default in a subsequent release once real-world
+usage confirms no edge-case surprises.
+
+Raw data: `corpus/data/bench/sweep202/{rg10k,rg25k,rg50k,rg100k,zoom-scaled}/`
+(local), `s3://gpq-tiles-bench/sweep202/` (remote, can be deleted after
+this decision is final).

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -378,6 +378,20 @@ struct OverviewArgs {
     #[arg(long, default_value = "10000")]
     row_group_size: usize,
 
+    /// Per-level row-group sizing policy (#202).
+    ///
+    /// `constant`: every level uses --row-group-size as its cap (default).
+    /// `zoom-scaled`: the cap doubles per zoom step below the finest level
+    /// (cap = row_group_size << (max_zoom - level_zoom)) — coarse bands, which
+    /// wide viewports read mostly whole anyway, become fewer/larger row groups
+    /// (fewer remote requests) while the finest level keeps tight bbox pruning.
+    #[arg(
+        long,
+        default_value = "constant",
+        value_parser = ["constant", "zoom-scaled"]
+    )]
+    row_group_size_policy: String,
+
     /// Keep full Parquet statistics on every column, including high-cardinality
     /// string/binary property columns and the WKB geometry column.
     ///
@@ -626,6 +640,7 @@ fn run_overview(args: OverviewArgs) -> Result<()> {
     use gpq_tiles_core::overview::convert::{convert_to_overviews, ConvertOptions, LevelPlan};
     use gpq_tiles_core::overview::level::Mode;
     use gpq_tiles_core::overview::simplify::SimplifyOptions;
+    use gpq_tiles_core::overview::writer::RowGroupSizePolicy;
 
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
@@ -725,6 +740,13 @@ fn run_overview(args: OverviewArgs) -> Result<()> {
         gsd_base: args.gsd_base,
         cogp_compat_key: args.cogp_compat,
         max_row_group_size: args.row_group_size,
+        row_group_size_policy: match args.row_group_size_policy.as_str() {
+            "constant" => RowGroupSizePolicy::Constant,
+            "zoom-scaled" => RowGroupSizePolicy::ZoomScaled,
+            other => {
+                anyhow::bail!("invalid --row-group-size-policy '{other}' (constant|zoom-scaled)")
+            }
+        },
         full_column_stats: args.full_column_stats,
         streaming: !args.no_streaming,
         read_batch_size: args.read_batch_size,

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -65,7 +65,9 @@ use super::level::{
     METERS_PER_DEGREE,
 };
 use super::simplify::{simplify_for_level, Simplified, SimplifyOptions};
-use super::writer::{LevelSpec, OverviewWriter, OverviewWriterOptions, WriterError, LEVEL_COLUMN};
+use super::writer::{
+    LevelSpec, OverviewWriter, OverviewWriterOptions, RowGroupSizePolicy, WriterError, LEVEL_COLUMN,
+};
 
 /// How the caller specifies the overview levels.
 #[derive(Debug, Clone, PartialEq)]
@@ -285,6 +287,11 @@ pub struct ConvertOptions {
     pub cogp_compat_key: bool,
     /// Maximum row-group size in rows for the output writer.
     pub max_row_group_size: usize,
+    /// How the per-level row-group cap is derived from `max_row_group_size`
+    /// (#202). Default [`RowGroupSizePolicy::Constant`]; `ZoomScaled` doubles
+    /// the cap per zoom step below the finest level (fewer requests on coarse
+    /// bands that wide viewports read mostly whole anyway).
+    pub row_group_size_policy: RowGroupSizePolicy,
     /// Keep full Parquet statistics on every column (including high-cardinality
     /// string/binary property columns and the WKB geometry column). Default
     /// `false`: those stats are suppressed to keep the footer small (H1); the
@@ -375,6 +382,7 @@ impl Default for ConvertOptions {
             gsd_base: GSD_TILE_BASE,
             cogp_compat_key: false,
             max_row_group_size: super::writer::DEFAULT_MAX_ROW_GROUP_SIZE,
+            row_group_size_policy: RowGroupSizePolicy::default(),
             full_column_stats: false,
             streaming: true,
             read_batch_size: DEFAULT_READ_BATCH_SIZE,
@@ -953,6 +961,7 @@ pub fn convert_to_overviews(
     let emitted_gsds: Vec<f64> = emitted.iter().map(|e| e.gsd).collect();
     let mut writer_opts = OverviewWriterOptions::new(options.mode, writer_levels);
     writer_opts.max_row_group_size = options.max_row_group_size;
+    writer_opts.row_group_size_policy = options.row_group_size_policy;
     writer_opts.full_column_stats = options.full_column_stats;
     writer_opts.cogp_compat_key = options.cogp_compat_key;
     writer_opts.generalization = Some(build_generalization(

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -332,6 +332,7 @@ pub(super) fn convert_streaming(
     let emitted_gsds: Vec<f64> = emitted.iter().map(|e| e.gsd).collect();
     let mut writer_opts = OverviewWriterOptions::new(options.mode, writer_levels);
     writer_opts.max_row_group_size = options.max_row_group_size;
+    writer_opts.row_group_size_policy = options.row_group_size_policy;
     writer_opts.full_column_stats = options.full_column_stats;
     writer_opts.cogp_compat_key = options.cogp_compat_key;
     writer_opts.generalization = Some(build_generalization(

--- a/crates/core/src/overview/writer.rs
+++ b/crates/core/src/overview/writer.rs
@@ -64,6 +64,24 @@ impl LevelSpec {
     }
 }
 
+/// How the per-level row-group cap is derived from `max_row_group_size`
+/// (issue #202).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RowGroupSizePolicy {
+    /// Every level uses `max_row_group_size` as its cap (the shipped default).
+    #[default]
+    Constant,
+    /// The cap **doubles per zoom step below the finest level's zoom**:
+    /// `cap(level) = max_row_group_size << (finest_zoom − level_zoom)`,
+    /// saturating. Rationale: a viewport rendered at zoom `z` covers ~4× the
+    /// ground area of one at `z+1`, so the coarser a level is, the larger the
+    /// slice of its band any real viewport reads anyway — bigger row groups
+    /// there cost little pruning but cut request round trips. The finest
+    /// (canonical) level keeps the exact `max_row_group_size` cap for tight
+    /// bbox pruning. Levels without zoom metadata fall back to the base cap.
+    ZoomScaled,
+}
+
 /// Configuration for an [`OverviewWriter`].
 #[derive(Debug, Clone)]
 pub struct OverviewWriterOptions {
@@ -80,6 +98,9 @@ pub struct OverviewWriterOptions {
     /// one broad row group (read whole anyway) while fine bands keep tight
     /// per-row-group bbox statistics for pruning.
     pub max_row_group_size: usize,
+    /// How the per-level cap is derived from `max_row_group_size` (#202).
+    /// Default [`RowGroupSizePolicy::Constant`].
+    pub row_group_size_policy: RowGroupSizePolicy,
     /// Keep full Parquet statistics on **every** column, including
     /// high-cardinality string/binary property columns and the WKB geometry
     /// column (H1). Default `false`: those columns' per-row-group min/max are
@@ -106,6 +127,7 @@ impl OverviewWriterOptions {
             levels,
             zstd_level: DEFAULT_ZSTD_LEVEL,
             max_row_group_size: DEFAULT_MAX_ROW_GROUP_SIZE,
+            row_group_size_policy: RowGroupSizePolicy::default(),
             full_column_stats: false,
             cogp_compat_key: false,
             version: SPEC_VERSION.to_string(),
@@ -327,7 +349,13 @@ impl<W: Write + Send> OverviewWriter<W> {
         // `ArrowWriter` never splits on its own (its `max_row_group_size` is set
         // to `usize::MAX` in `build_writer_properties`); we drive every row-group
         // boundary here by slicing each encoded batch to `target` and flushing.
-        let target = rg_row_target(self.options.max_row_group_size, level_row_hint);
+        let cap = effective_rg_cap(
+            self.options.max_row_group_size,
+            self.options.row_group_size_policy,
+            self.options.levels.get(level_idx).and_then(|l| l.zoom),
+            self.options.levels.last().and_then(|l| l.zoom),
+        );
+        let target = rg_row_target(cap, level_row_hint);
 
         // Rows accumulated into the current (not-yet-flushed) row group.
         let mut in_rg: usize = 0;
@@ -493,6 +521,29 @@ fn covering_name_for(column_name: &str) -> String {
         "bbox".to_string()
     } else {
         format!("{column_name}_bbox")
+    }
+}
+
+/// Effective row-group cap for one level under a [`RowGroupSizePolicy`]
+/// (#202). `Constant` (and any level/file without zoom metadata) returns the
+/// base cap; `ZoomScaled` doubles it per zoom step below the finest level's
+/// zoom, saturating at `usize::MAX`.
+fn effective_rg_cap(
+    base: usize,
+    policy: RowGroupSizePolicy,
+    level_zoom: Option<u8>,
+    finest_zoom: Option<u8>,
+) -> usize {
+    match (policy, level_zoom, finest_zoom) {
+        (RowGroupSizePolicy::ZoomScaled, Some(z), Some(zmax)) if z < zmax => {
+            let steps = u32::from(zmax - z);
+            if steps >= usize::BITS {
+                usize::MAX
+            } else {
+                base.saturating_mul(1usize << steps)
+            }
+        }
+        _ => base,
     }
 }
 
@@ -1161,6 +1212,87 @@ mod tests {
         assert!(l1.iter().all(|&r| r <= 4), "row groups exceed cap: {l1:?}");
 
         // Every row group is single-level (invariant §4.2) and validates.
+        assert!(crate::overview::check::validate_file(tmp.path())
+            .unwrap()
+            .is_valid());
+    }
+
+    #[test]
+    fn effective_rg_cap_scales_with_zoom_distance() {
+        use RowGroupSizePolicy::{Constant, ZoomScaled};
+        // Constant: the base cap regardless of zooms.
+        assert_eq!(effective_rg_cap(4, Constant, Some(2), Some(4)), 4);
+        // ZoomScaled: doubles per zoom step below the finest level's zoom.
+        assert_eq!(effective_rg_cap(4, ZoomScaled, Some(4), Some(4)), 4);
+        assert_eq!(effective_rg_cap(4, ZoomScaled, Some(3), Some(4)), 8);
+        assert_eq!(effective_rg_cap(4, ZoomScaled, Some(2), Some(4)), 16);
+        // Missing zoom metadata falls back to the base cap.
+        assert_eq!(effective_rg_cap(4, ZoomScaled, None, Some(4)), 4);
+        assert_eq!(effective_rg_cap(4, ZoomScaled, Some(2), None), 4);
+        // Saturates instead of overflowing on absurd zoom spans.
+        assert_eq!(
+            effective_rg_cap(usize::MAX / 2, ZoomScaled, Some(0), Some(30)),
+            usize::MAX
+        );
+    }
+
+    #[test]
+    fn zoom_scaled_policy_widens_coarse_level_caps() {
+        // Two levels of 10 rows each, base cap 4. Under the constant policy
+        // BOTH levels split into 3 row groups. Under zoom-scaled the coarse
+        // level (z2, two steps below the finest z4) gets cap 4<<2 = 16 and
+        // becomes a SINGLE row group, while the finest level keeps cap 4.
+        let schema = Arc::new(source_schema());
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let mut opts = OverviewWriterOptions::new(
+            Mode::Duplicating,
+            vec![
+                LevelSpec::new(gsd(2), Some(2)),
+                LevelSpec::new(gsd(4), Some(4)),
+            ],
+        );
+        opts.max_row_group_size = 4;
+        opts.row_group_size_policy = RowGroupSizePolicy::ZoomScaled;
+
+        let ids: Vec<i64> = (0..10).collect();
+        let meta = {
+            let mut writer = OverviewWriter::create(tmp.path(), &schema, opts).unwrap();
+            writer
+                .write_level(
+                    0,
+                    Some(ids.len()),
+                    std::iter::once(source_batch(&schema, &ids)),
+                )
+                .unwrap();
+            writer
+                .write_level(
+                    1,
+                    Some(ids.len()),
+                    std::iter::once(source_batch(&schema, &ids)),
+                )
+                .unwrap();
+            writer.finish().unwrap()
+        };
+
+        // Coarse band: one row group (RG 0); fine band: RGs 1..=3.
+        assert_eq!(meta.levels[0].row_group_end, 0);
+        assert_eq!(meta.levels[1].row_group_end, 3);
+
+        let file = File::open(tmp.path()).unwrap();
+        let pm = ParquetRecordBatchReaderBuilder::try_new(file)
+            .unwrap()
+            .metadata()
+            .clone();
+        assert_eq!(pm.num_row_groups(), 4);
+        assert_eq!(pm.row_group(0).num_rows(), 10);
+        let l1: Vec<i64> = (1..=3).map(|r| pm.row_group(r).num_rows()).collect();
+        assert_eq!(l1.iter().sum::<i64>(), 10);
+        assert!(
+            l1.iter().all(|&r| r <= 4),
+            "fine row groups exceed cap: {l1:?}"
+        );
+
+        // Level↔row-group alignment invariants still hold.
         assert!(crate::overview::check::validate_file(tmp.path())
             .unwrap()
             .is_valid());

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -485,6 +485,7 @@ fn overview(
         gsd_base,
         cogp_compat_key: cogp_compat,
         max_row_group_size: row_group_size,
+        row_group_size_policy: Default::default(),
         full_column_stats,
         streaming,
         read_batch_size,


### PR DESCRIPTION
## Summary

Sweep `--row-group-size` at {10k, 25k, 50k, 100k} and the new `--row-group-size-policy zoom-scaled` against real S3 (us-east-2). Implements and measures the opt-in `zoom-scaled` policy: row-group cap doubles per zoom step below the finest level.

**Key findings:**

| viewport | rg10k req | rg100k req | zoom-scaled req | rg100k bytes | zoom-scaled bytes |
|---|---|---|---|---|---|
| Moldova regional (z9) | 52 | 12 | **12** | 8.5 MB | 8.5 MB |
| Moldova street (z14) | 25 | 13 | **25** | 12.6 MB | **2.0 MB** |
| Portland polygons street (z14) | 33 | 21 | **33** | 39.3 MB | **6.7 MB** |

`zoom-scaled` gets the best of both: rg100k request counts on coarse/regional (77% reduction on Moldova regional), rg10k byte counts at fine/street (6x less than rg100k on Portland polygons).

**Decision:** ship `zoom-scaled` as opt-in (`--row-group-size-policy zoom-scaled`); keep constant 10k as the untouched default for now. The policy is proven by the sweep; it can be promoted to default after bake-in.

## Changes

- `crates/core/src/overview/writer.rs`: `RowGroupSizePolicy` enum + `effective_rg_cap()` helper (TDD)
- `crates/core/src/overview/convert.rs`, `stream.rs`: plumb policy through ConvertOptions
- `crates/cli/src/main.rs`: `--row-group-size-policy constant|zoom-scaled`
- `benchmarks/overview/bench_access_remote.py`: env vars for sweep runs
- `corpus/SWEEPS.md`: Decision 5 with full tables

## Test plan

- [x] TDD unit tests: `effective_rg_cap_scales_with_zoom_distance`, `zoom_scaled_policy_widens_coarse_level_caps`
- [x] `cargo check` passes
- [x] Remote measurement completes on all 5 variants
- [x] Feature counts identical across all variants (no data loss)

Closes #202

---
Generated with [Claude Code](https://claude.com/claude-code)