### PR TITLE
docs: evidence-based DuckDB recipe for remote overview reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ convert("input.parquet", "output.pmtiles", min_zoom=0, max_zoom=14)
 - **[Decoding PMTiles](docs/decode.md)** — PMTiles → GeoParquet, limitations included
 - **[API Reference](docs/api-reference.md)** — CLI flags, Python API, Rust API
 - **[Advanced Usage](docs/advanced-usage.md)** — Input optimization, memory, remote reads, CI/CD
+- **[Remote Reads](docs/remote-reads.md)** — Querying overview files on object storage with DuckDB
 - **[Format Spec (draft)](context/OVERVIEWS_SPEC.md)** — The `geo:overviews` format contract
 
 ## Development

--- a/benchmarks/overview/README.md
+++ b/benchmarks/overview/README.md
@@ -41,6 +41,8 @@ tippecanoe goldens come from `corpus/goldens.sh`.
 | `parallel_reader.py` | purpose-built parallel range-request reader (issue #201): 1 footer fetch → stats pruning → concurrent row-group fetches |
 | `bench_parallel.py` | run `parallel_reader.py` over the same S3 artifacts/viewports, cold + footer-cached, asserting feature-count parity with the DuckDB baseline → `parallel_reader_results.json` |
 | `format_parallel.py` | render `parallel_reader_results.json` (+ the DuckDB/PMTiles baseline) into the RESULTS.md "latency floor" tables |
+| `bench_duckdb_knobs.py` | DuckDB httpfs client-knob sweep on the overview path (issue #203): per-knob cold configs + session (repeat / adjacent-pan) behavior → `duckdb_knobs_results.json` |
+| `format_duckdb_knobs.py` | render `duckdb_knobs_results.json` into the RESULTS.md §2b knob-sweep tables |
 | `run_conversion.sh` | conversion-cost table (overview vs tippecanoe, `/usr/bin/time -v`) |
 
 Raw/large outputs (regenerated overview parquet, per-run logs, timing
@@ -113,6 +115,23 @@ BENCH_AWS_PROFILE=<profile> \
   python3 bench_parallel.py
 python3 format_parallel.py  # -> the "latency floor" tables
 ```
+
+### DuckDB knob-sweep leg (issue #203)
+
+Same bucket/artifacts as the remote leg; stdlib-only (drives the
+`duckdb` CLI). Sweeps client configs (defaults, each candidate knob
+individually, the recommended stack) plus two session configs
+(the #200 symmetric config vs the real-user cache-on config) over
+the two knob-sweep datasets:
+
+```bash
+BENCH_BUCKET=$BUCKET BENCH_REGION=us-east-2 \
+BENCH_AWS_PROFILE=<profile> \
+  python3 bench_duckdb_knobs.py
+python3 format_duckdb_knobs.py  # -> the §2b knob-sweep tables
+```
+
+The resulting recipe is documented in `docs/remote-reads.md`.
 
 ## Fairness rules (enforced by the harness)
 

--- a/benchmarks/overview/RESULTS.md
+++ b/benchmarks/overview/RESULTS.md
@@ -423,6 +423,82 @@ Harness: `parallel_reader.py` (the reader) + `bench_parallel.py`
 baseline) → `parallel_reader_results.json`; tables via
 `format_parallel.py`.
 
+### DuckDB client knobs (issue #203)
+
+The tables above ran DuckDB near-defaults. This addendum sweeps the
+httpfs client knobs (verified present in DuckDB v1.4.1) on two of the
+four datasets — same bucket, viewports, and 3-run-median protocol.
+The resulting recipe is documented in `docs/remote-reads.md`.
+
+**Cold, per knob** — a fresh process, one viewport query
+(median wall ms / requests / bytes):
+
+| dataset | viewport | defaults | `threads=64` | `disable_parquet_prefetching` | `prefetch_all_parquet_files` | `http_keep_alive=false` | metadata caches on | recommended stack |
+|---|---|---|---|---|---|---|---|---|
+| points-nyc-medium | world | 1,930 / 7 / 564 KB | 1,890 / 7 / 564 KB | 2,010 / 5 / 2.00 MB | 1,990 / 7 / 564 KB | 4,060 / 7 / 564 KB | 1,950 / 7 / 564 KB | 2,040 / 7 / 564 KB |
+| points-nyc-medium | regional | 2,120 / 32 / 4.10 MB | 2,080 / 32 / 4.10 MB | 2,020 / 15 / 11.50 MB | 2,120 / 32 / 4.10 MB | 4,350 / 32 / 4.10 MB | 2,110 / 32 / 4.10 MB | 2,080 / 32 / 4.10 MB |
+| points-nyc-medium | street | 2,200 / 39 / 4.90 MB | 2,130 / 39 / 4.90 MB | 2,090 / 19 / 15.30 MB | 2,160 / 39 / 4.90 MB | 4,330 / 39 / 4.90 MB | 2,080 / 39 / 4.90 MB | 2,130 / 39 / 4.90 MB |
+| polygons-ftw-moldova-large | world | 3,170 / 11 / 8.30 MB | 3,200 / 11 / 8.30 MB | 3,270 / 14 / 10.80 MB | 3,200 / 11 / 8.30 MB | 6,550 / 11 / 8.30 MB | 3,240 / 11 / 8.30 MB | 3,190 / 11 / 8.30 MB |
+| polygons-ftw-moldova-large | regional | 3,120 / 47 / 20.70 MB | 3,050 / 47 / 20.70 MB | 2,990 / 34 / 29.70 MB | 3,040 / 47 / 20.70 MB | 6,570 / 47 / 20.70 MB | 3,100 / 47 / 20.70 MB | 3,040 / 47 / 20.70 MB |
+| polygons-ftw-moldova-large | street | 2,760 / 23 / 1.90 MB | 2,690 / 23 / 1.90 MB | 2,080 / 10 / 6.90 MB | 2,670 / 23 / 1.90 MB | 6,100 / 23 / 1.90 MB | 2,740 / 23 / 1.90 MB | 2,720 / 23 / 1.90 MB |
+
+Configs: `metadata caches on` = `enable_http_metadata_cache` +
+`parquet_metadata_cache`; `recommended stack` = those two + `threads=64`
++ `enable_external_file_cache=true` (the default).
+
+**Session behavior** — one process runs cold → exact repeat →
+adjacent pan (bbox shifted east by one width, same level). `sym200` is
+this section's original symmetric-benchmark config (http metadata cache
+ON, external file/data cache OFF — a fairness device against the
+cacheless pmtiles reader, not a recommendation); `real` is the
+recommended user config (both metadata caches + data cache ON):
+
+| dataset | viewport | config | cold | repeat | adjacent pan |
+|---|---|---|---|---|---|
+| points-nyc-medium | world | sym200 | 1,910 ms / 7 req / 564 KB | 1,860 ms / 6 req / 564 KB | 623 ms / 1 req / 128 KB |
+| points-nyc-medium | world | real | 1,970 ms / 7 req / 564 KB | 10 ms / 0 req / 0 B | 6 ms / 0 req / 0 B |
+| points-nyc-medium | regional | sym200 | 2,090 ms / 32 req / 4.10 MB | 2,030 ms / 31 req / 4.10 MB | 2,030 ms / 17 req / 2.30 MB |
+| points-nyc-medium | regional | real | 2,090 ms / 32 req / 4.10 MB | 12 ms / 0 req / 0 B | 1,310 ms / 5 req / 693 KB |
+| points-nyc-medium | street | sym200 | 2,190 ms / 39 req / 4.90 MB | 2,010 ms / 38 req / 4.90 MB | 1,970 ms / 28 req / 3.80 MB |
+| points-nyc-medium | street | real | 2,250 ms / 39 req / 4.90 MB | 19 ms / 0 req / 0 B | 1,360 ms / 11 req / 1.50 MB |
+| polygons-ftw-moldova-large | world | sym200 | 3,190 ms / 11 req / 8.30 MB | 3,080 ms / 10 req / 8.30 MB | 751 ms / 1 req / 256 KB |
+| polygons-ftw-moldova-large | world | real | 3,170 ms / 11 req / 8.30 MB | 84 ms / 0 req / 0 B | 9 ms / 0 req / 0 B |
+| polygons-ftw-moldova-large | regional | sym200 | 3,070 ms / 47 req / 20.70 MB | 2,990 ms / 46 req / 20.70 MB | 2,900 ms / 37 req / 17.10 MB |
+| polygons-ftw-moldova-large | regional | real | 3,020 ms / 47 req / 20.70 MB | 35 ms / 0 req / 0 B | 46 ms / 0 req / 0 B |
+| polygons-ftw-moldova-large | street | sym200 | 2,680 ms / 23 req / 1.90 MB | 2,630 ms / 22 req / 1.90 MB | 2,520 ms / 22 req / 1.90 MB |
+| polygons-ftw-moldova-large | street | real | 2,710 ms / 23 req / 1.90 MB | 16 ms / 0 req / 0 B | 13 ms / 0 req / 0 B |
+
+(The world adjacent pans land on sparse/empty ground — sym200 still
+pays a request to find that out; `real` answers from cached row
+groups and footer without touching the network.)
+
+Reading the knobs:
+
+- **No knob makes the cold query materially faster.** Cold wall is
+  TLS + footer + data round trips; `threads=64`,
+  `prefetch_all_parquet_files`, and the metadata caches are all
+  within ±3 % of defaults on a single cold viewport.
+- **The defaults that matter are already right.**
+  `http_keep_alive=false` roughly doubles every cold wall
+  (1.9 → 4.1 s NYC world, 3.2 → 6.6 s Moldova world);
+  `disable_parquet_prefetching=true` cuts request counts (39 → 19,
+  NYC street) but fetches 2.3–3.6× the bytes for wall times within
+  noise. Leave both alone.
+- **The session is where configuration pays.** With the real-user
+  config, an exact repeat is 0 requests / 10–84 ms (sym200:
+  1,860–3,080 ms), and an adjacent pan re-fetches only uncached row
+  groups — NYC street 11 req / 1.5 MB / 1.36 s vs 28 req / 3.8 MB /
+  1.97 s; both non-empty Moldova pans were served entirely from
+  cache (0 requests, 13–46 ms) because the Hilbert-clustered row
+  groups fetched for the first viewport already cover the neighbor.
+- Implication for §2b's warm tables above: they understate what a
+  real DuckDB user sees, by design — the external file cache was off
+  there for symmetry with the cacheless pmtiles reader.
+
+Harness: `bench_duckdb_knobs.py` → `duckdb_knobs_results.json`;
+tables via `format_duckdb_knobs.py`; recipe in
+`docs/remote-reads.md`.
+
 ---
 
 ## 3. Conversion cost (wall time + peak RSS)

--- a/benchmarks/overview/bench_duckdb_knobs.py
+++ b/benchmarks/overview/bench_duckdb_knobs.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""DuckDB httpfs client-knob sweep for remote overview reads — issue #203.
+
+Same bucket, viewports, and 3-run-median protocol as
+bench_access_remote.py (issue #176 / PR #200), but instead of comparing
+formats it compares DuckDB client configurations on the overview path:
+
+Part 1 — cold, per-knob:
+  a fresh `duckdb` process runs ONE viewport query per config.
+  Configs: pure defaults, each candidate knob flipped individually,
+  and the recommended stack.  Request/byte counts come from DuckDB's
+  own HTTPFS HTTP Stats (EXPLAIN ANALYZE); wall is the query's
+  Total Time.  Median of BENCH_RUNS process launches.
+
+Part 2 — session behavior:
+  one process runs cold -> exact repeat -> adjacent viewport (bbox
+  panned east by one width, same level).  Two configs:
+    sym200 -- the PR #200 symmetric-benchmark config
+              (http metadata cache ON, external file (data) cache OFF;
+              chosen there so DuckDB re-fetched data like the
+              cacheless python pmtiles reader did)
+    real   -- the real-user map-session config (both metadata caches
+              ON, external file cache ON i.e. left at default)
+
+Knobs verified present in DuckDB v1.4.1 via duckdb_settings().
+
+Run:
+  python3 bench_duckdb_knobs.py            # stdlib only
+
+Env:
+  BENCH_BUCKET      (default gpq-tiles-bench)
+  BENCH_REGION      (default us-east-2)
+  BENCH_AWS_PROFILE (default nissim-admin)
+  BENCH_RUNS        (default 3; medians reported)
+  BENCH_DATASETS    (comma list; default the two knob-sweep datasets)
+"""
+import json
+import os
+import re
+import statistics
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+BUCKET = os.environ.get("BENCH_BUCKET", "gpq-tiles-bench")
+REGION = os.environ.get("BENCH_REGION", "us-east-2")
+PROFILE = os.environ.get("BENCH_AWS_PROFILE", "nissim-admin")
+N_RUNS = int(os.environ.get("BENCH_RUNS", "3"))
+
+DATASETS = os.environ.get(
+    "BENCH_DATASETS", "points-nyc-medium,polygons-ftw-moldova-large"
+).split(",")
+
+# zoom -> overview level, from the #200 run (corpus dup.report.json;
+# recorded in remote_access_results.json so the sweep does not need
+# the local corpus artifacts).
+ZOOM_TO_LEVEL = {
+    "points-nyc-medium": {8: 8, 11: 11, 14: 14},
+    "lines-portland-medium": {8: 8, 11: 11, 14: 14},
+    "polygons-portland-medium": {8: 8, 11: 11, 14: 14},
+    "polygons-ftw-moldova-large": {6: 3, 9: 6, 14: 11},
+}
+
+# ---- configs ---------------------------------------------------------
+# Part 1: cold single-query configs (fresh process each).
+COLD_CONFIGS = {
+    "defaults": [],
+    "threads_64": ["SET threads=64;"],
+    "no_parquet_prefetch": ["SET disable_parquet_prefetching=true;"],
+    "prefetch_all": ["SET prefetch_all_parquet_files=true;"],
+    "keepalive_off": ["SET http_keep_alive=false;"],
+    "metadata_caches_on": [
+        # expected no-op on a single cold query; included to prove it
+        "SET enable_http_metadata_cache=true;",
+        "SET parquet_metadata_cache=true;",
+    ],
+    "stack": [
+        "SET threads=64;",
+        "SET enable_http_metadata_cache=true;",
+        "SET parquet_metadata_cache=true;",
+        # enable_external_file_cache=true is the default; stated for
+        # clarity since PR #200 benchmarked with it OFF
+        "SET enable_external_file_cache=true;",
+    ],
+}
+
+# Part 2: session configs (one process: cold, repeat, adjacent pan).
+SESSION_CONFIGS = {
+    "sym200": [
+        "SET enable_http_metadata_cache=true;",
+        "SET enable_external_file_cache=false;",
+    ],
+    "real": [
+        "SET threads=64;",
+        "SET enable_http_metadata_cache=true;",
+        "SET parquet_metadata_cache=true;",
+        "SET enable_external_file_cache=true;",
+    ],
+}
+
+_UNIT = {"bytes": 1, "byte": 1, "KiB": 1024, "MiB": 1024 ** 2,
+         "GiB": 1024 ** 3}
+MARK = "===Q{}==="
+
+
+def _parse_size(txt):
+    m = re.match(r"([\d.]+)\s*(bytes|byte|KiB|MiB|GiB)", txt)
+    return float(m.group(1)) * _UNIT[m.group(2)] if m else 0.0
+
+
+def parse_segment(seg):
+    """HTTPFS stats + Total Time from one query's output segment.
+
+    A fully cache-served query performs no HTTP, so the stats block
+    may be absent -> zeros.
+    """
+    out = {"bytes": 0.0, "head": 0, "get": 0, "wall_ms": None}
+    blk = re.search(r"HTTPFS HTTP Stats(.*?)#DELETE:\s*\d+", seg, re.S)
+    if blk:
+        b = blk.group(1)
+        out["bytes"] = _parse_size(
+            re.search(r"in:\s*([\d.]+\s*\w+)", b).group(1))
+        out["head"] = int(re.search(r"#HEAD:\s*(\d+)", b).group(1))
+        out["get"] = int(re.search(r"#GET:\s*(\d+)", b).group(1))
+    t = re.search(r"Total Time:\s*([\d.]+)s", seg)
+    if t:
+        out["wall_ms"] = float(t.group(1)) * 1000.0
+    return out
+
+
+def where_clause(level, bbox):
+    xmin, ymin, xmax, ymax = bbox
+    return (
+        f"WHERE level={level} "
+        f"AND bbox.xmin <= {xmax} AND bbox.xmax >= {xmin} "
+        f"AND bbox.ymin <= {ymax} AND bbox.ymax >= {ymin}"
+    )
+
+
+def run_duckdb(sets, queries):
+    """One duckdb process; returns per-query parsed stats + counts.
+
+    queries: list of WHERE clauses; each becomes
+    EXPLAIN ANALYZE CREATE TABLE t<i> AS SELECT * ... <where>
+    followed by a marker + count(*).
+    """
+    url = f"s3://{BUCKET}/overviews/{DS_CURRENT}.dup.parquet"
+    sql = [
+        "INSTALL httpfs;LOAD httpfs;",
+        "CREATE SECRET (TYPE s3, PROVIDER credential_chain, "
+        f"PROFILE '{PROFILE}', REGION '{REGION}');",
+    ] + list(sets)
+    for i, where in enumerate(queries):
+        sql.append(f"SELECT '{MARK.format(i)}';")
+        sql.append(
+            f"EXPLAIN ANALYZE CREATE TABLE t{i} AS "
+            f"SELECT * FROM read_parquet('{url}') {where};"
+        )
+        sql.append(f"SELECT count(*) FROM t{i};")
+    out = subprocess.run(
+        ["duckdb", "-noheader", "-list", "-c", "".join(sql)],
+        capture_output=True, text=True,
+    )
+    if out.returncode != 0:
+        sys.stderr.write(out.stderr)
+        raise RuntimeError("duckdb failed")
+    parts = re.split(r"===Q\d+===", out.stdout)[1:]
+    assert len(parts) == len(queries), (len(parts), len(queries))
+    results = []
+    for seg in parts:
+        s = parse_segment(seg)
+        # last non-empty line of the segment is the count(*) result
+        s["features"] = int(
+            [ln for ln in seg.strip().splitlines() if ln.strip()][-1])
+        assert s["wall_ms"] is not None
+        results.append(s)
+    return results
+
+
+def median_runs(runs):
+    """runs: list of per-run dicts. Median wall; req/bytes from the
+    median-wall run (they are near-deterministic anyway)."""
+    walls = sorted(runs, key=lambda r: r["wall_ms"])
+    med = dict(walls[len(walls) // 2])
+    med["wall_ms"] = statistics.median(r["wall_ms"] for r in runs)
+    med["wall_ms_min"] = min(r["wall_ms"] for r in runs)
+    med["wall_ms_max"] = max(r["wall_ms"] for r in runs)
+    return med
+
+
+def pan_east(bbox):
+    xmin, ymin, xmax, ymax = bbox
+    w = xmax - xmin
+    return [xmin + w, ymin, xmax + w, ymax]
+
+
+DS_CURRENT = None
+
+
+def main():
+    global DS_CURRENT
+    with open(os.path.join(HERE, "viewports.json")) as f:
+        viewports = json.load(f)
+
+    results = {"bucket": BUCKET, "region": REGION, "runs": N_RUNS,
+               "duckdb": subprocess.run(
+                   ["duckdb", "--version"], capture_output=True,
+                   text=True).stdout.strip(),
+               "cold_configs": {k: v for k, v in COLD_CONFIGS.items()},
+               "session_configs": SESSION_CONFIGS,
+               "datasets": {}}
+
+    for ds in DATASETS:
+        DS_CURRENT = ds
+        z2l = ZOOM_TO_LEVEL[ds]
+        results["datasets"][ds] = {}
+        for vp in ("world", "regional", "street"):
+            cfg = viewports[ds]["viewports"][vp]
+            bbox, zoom = cfg["bbox"], cfg["zoom"]
+            level = z2l[zoom]
+            entry = {"zoom": zoom, "level": level, "bbox": bbox,
+                     "cold": {}, "session": {}}
+
+            # Part 1: cold per-knob
+            for name, sets in COLD_CONFIGS.items():
+                runs = []
+                for _ in range(N_RUNS):
+                    (r,) = run_duckdb(sets, [where_clause(level, bbox)])
+                    runs.append(r)
+                med = median_runs(runs)
+                entry["cold"][name] = med
+                print(f"{ds:27s} {vp:9s} cold {name:20s} "
+                      f"{med['bytes']:>12,.0f}B "
+                      f"{med['head'] + med['get']:>3d}req "
+                      f"{med['wall_ms']:>8.1f}ms "
+                      f"{med['features']:>6d}f", flush=True)
+
+            # Part 2: sessions (cold, repeat, adjacent pan)
+            w0 = where_clause(level, bbox)
+            w_adj = where_clause(level, pan_east(bbox))
+            for name, sets in SESSION_CONFIGS.items():
+                per_q = [[], [], []]
+                for _ in range(N_RUNS):
+                    rs = run_duckdb(sets, [w0, w0, w_adj])
+                    for i, r in enumerate(rs):
+                        per_q[i].append(r)
+                meds = [median_runs(q) for q in per_q]
+                entry["session"][name] = {
+                    "cold": meds[0], "repeat": meds[1],
+                    "adjacent": meds[2],
+                }
+                for label, m in zip(("cold", "repeat", "adjacent"),
+                                    meds):
+                    print(f"{ds:27s} {vp:9s} sess {name:7s} "
+                          f"{label:8s} {m['bytes']:>12,.0f}B "
+                          f"{m['head'] + m['get']:>3d}req "
+                          f"{m['wall_ms']:>8.1f}ms "
+                          f"{m['features']:>6d}f", flush=True)
+
+            results["datasets"][ds][vp] = entry
+
+    out = os.path.join(HERE, "duckdb_knobs_results.json")
+    with open(out, "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"\nwrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/overview/duckdb_knobs_results.json
+++ b/benchmarks/overview/duckdb_knobs_results.json
@@ -1,0 +1,859 @@
+{
+  "bucket": "gpq-tiles-bench",
+  "region": "us-east-2",
+  "runs": 3,
+  "duckdb": "v1.4.1 (Andium) b390a7c376",
+  "cold_configs": {
+    "defaults": [],
+    "threads_64": [
+      "SET threads=64;"
+    ],
+    "no_parquet_prefetch": [
+      "SET disable_parquet_prefetching=true;"
+    ],
+    "prefetch_all": [
+      "SET prefetch_all_parquet_files=true;"
+    ],
+    "keepalive_off": [
+      "SET http_keep_alive=false;"
+    ],
+    "metadata_caches_on": [
+      "SET enable_http_metadata_cache=true;",
+      "SET parquet_metadata_cache=true;"
+    ],
+    "stack": [
+      "SET threads=64;",
+      "SET enable_http_metadata_cache=true;",
+      "SET parquet_metadata_cache=true;",
+      "SET enable_external_file_cache=true;"
+    ]
+  },
+  "session_configs": {
+    "sym200": [
+      "SET enable_http_metadata_cache=true;",
+      "SET enable_external_file_cache=false;"
+    ],
+    "real": [
+      "SET threads=64;",
+      "SET enable_http_metadata_cache=true;",
+      "SET parquet_metadata_cache=true;",
+      "SET enable_external_file_cache=true;"
+    ]
+  },
+  "datasets": {
+    "points-nyc-medium": {
+      "world": {
+        "zoom": 8,
+        "level": 8,
+        "bbox": [
+          -74.299992,
+          40.50005907,
+          -73.69999261,
+          40.9000036
+        ],
+        "cold": {
+          "defaults": {
+            "bytes": 577740.8,
+            "head": 1,
+            "get": 6,
+            "wall_ms": 1930.0,
+            "features": 5772,
+            "wall_ms_min": 1920.0,
+            "wall_ms_max": 2009.9999999999998
+          },
+          "threads_64": {
+            "bytes": 577740.8,
+            "head": 1,
+            "get": 6,
+            "wall_ms": 1890.0,
+            "features": 5772,
+            "wall_ms_min": 1840.0,
+            "wall_ms_max": 1990.0
+          },
+          "no_parquet_prefetch": {
+            "bytes": 2097152.0,
+            "head": 1,
+            "get": 4,
+            "wall_ms": 2009.9999999999998,
+            "features": 5772,
+            "wall_ms_min": 1930.0,
+            "wall_ms_max": 2050.0
+          },
+          "prefetch_all": {
+            "bytes": 577740.8,
+            "head": 1,
+            "get": 6,
+            "wall_ms": 1990.0,
+            "features": 5772,
+            "wall_ms_min": 1900.0,
+            "wall_ms_max": 2029.9999999999998
+          },
+          "keepalive_off": {
+            "bytes": 577740.8,
+            "head": 1,
+            "get": 6,
+            "wall_ms": 4059.9999999999995,
+            "features": 5772,
+            "wall_ms_min": 4050.0,
+            "wall_ms_max": 4100.0
+          },
+          "metadata_caches_on": {
+            "bytes": 577740.8,
+            "head": 1,
+            "get": 6,
+            "wall_ms": 1950.0,
+            "features": 5772,
+            "wall_ms_min": 1920.0,
+            "wall_ms_max": 1990.0
+          },
+          "stack": {
+            "bytes": 577740.8,
+            "head": 1,
+            "get": 6,
+            "wall_ms": 2040.0,
+            "features": 5772,
+            "wall_ms_min": 1940.0,
+            "wall_ms_max": 2070.0
+          }
+        },
+        "session": {
+          "sym200": {
+            "cold": {
+              "bytes": 577740.8,
+              "head": 1,
+              "get": 6,
+              "wall_ms": 1910.0,
+              "features": 5772,
+              "wall_ms_min": 1790.0,
+              "wall_ms_max": 2029.9999999999998
+            },
+            "repeat": {
+              "bytes": 577740.8,
+              "head": 0,
+              "get": 6,
+              "wall_ms": 1860.0,
+              "features": 5772,
+              "wall_ms_min": 1800.0,
+              "wall_ms_max": 1930.0
+            },
+            "adjacent": {
+              "bytes": 131072.0,
+              "head": 0,
+              "get": 1,
+              "wall_ms": 623.0,
+              "features": 0,
+              "wall_ms_min": 619.0,
+              "wall_ms_max": 795.0
+            }
+          },
+          "real": {
+            "cold": {
+              "bytes": 577740.8,
+              "head": 1,
+              "get": 6,
+              "wall_ms": 1970.0,
+              "features": 5772,
+              "wall_ms_min": 1940.0,
+              "wall_ms_max": 2090.0
+            },
+            "repeat": {
+              "bytes": 0.0,
+              "head": 0,
+              "get": 0,
+              "wall_ms": 10.5,
+              "features": 5772,
+              "wall_ms_min": 9.6,
+              "wall_ms_max": 10.9
+            },
+            "adjacent": {
+              "bytes": 0.0,
+              "head": 0,
+              "get": 0,
+              "wall_ms": 5.8999999999999995,
+              "features": 0,
+              "wall_ms_min": 5.5,
+              "wall_ms_max": 6.5
+            }
+          }
+        }
+      },
+      "regional": {
+        "zoom": 11,
+        "level": 11,
+        "bbox": [
+          -74.07499222875,
+          40.650038268749995,
+          -73.92499238125001,
+          40.75002440125
+        ],
+        "cold": {
+          "defaults": {
+            "bytes": 4299161.6,
+            "head": 1,
+            "get": 31,
+            "wall_ms": 2120.0,
+            "features": 14321,
+            "wall_ms_min": 2120.0,
+            "wall_ms_max": 2130.0
+          },
+          "threads_64": {
+            "bytes": 4299161.6,
+            "head": 1,
+            "get": 31,
+            "wall_ms": 2080.0,
+            "features": 14321,
+            "wall_ms_min": 2020.0,
+            "wall_ms_max": 2250.0
+          },
+          "no_parquet_prefetch": {
+            "bytes": 12058624.0,
+            "head": 1,
+            "get": 14,
+            "wall_ms": 2020.0,
+            "features": 14321,
+            "wall_ms_min": 2000.0,
+            "wall_ms_max": 2070.0
+          },
+          "prefetch_all": {
+            "bytes": 4299161.6,
+            "head": 1,
+            "get": 31,
+            "wall_ms": 2120.0,
+            "features": 14321,
+            "wall_ms_min": 2020.0,
+            "wall_ms_max": 2210.0
+          },
+          "keepalive_off": {
+            "bytes": 4299161.6,
+            "head": 1,
+            "get": 31,
+            "wall_ms": 4350.0,
+            "features": 14321,
+            "wall_ms_min": 4280.0,
+            "wall_ms_max": 4370.0
+          },
+          "metadata_caches_on": {
+            "bytes": 4299161.6,
+            "head": 1,
+            "get": 31,
+            "wall_ms": 2110.0,
+            "features": 14321,
+            "wall_ms_min": 2050.0,
+            "wall_ms_max": 2180.0
+          },
+          "stack": {
+            "bytes": 4299161.6,
+            "head": 1,
+            "get": 31,
+            "wall_ms": 2080.0,
+            "features": 14321,
+            "wall_ms_min": 2070.0,
+            "wall_ms_max": 2190.0
+          }
+        },
+        "session": {
+          "sym200": {
+            "cold": {
+              "bytes": 4299161.6,
+              "head": 1,
+              "get": 31,
+              "wall_ms": 2090.0,
+              "features": 14321,
+              "wall_ms_min": 2029.9999999999998,
+              "wall_ms_max": 2180.0
+            },
+            "repeat": {
+              "bytes": 4299161.6,
+              "head": 0,
+              "get": 31,
+              "wall_ms": 2029.9999999999998,
+              "features": 14321,
+              "wall_ms_min": 2009.9999999999998,
+              "wall_ms_max": 2090.0
+            },
+            "adjacent": {
+              "bytes": 2411724.8,
+              "head": 0,
+              "get": 17,
+              "wall_ms": 2029.9999999999998,
+              "features": 11222,
+              "wall_ms_min": 1990.0,
+              "wall_ms_max": 2060.0
+            }
+          },
+          "real": {
+            "cold": {
+              "bytes": 4299161.6,
+              "head": 1,
+              "get": 31,
+              "wall_ms": 2090.0,
+              "features": 14321,
+              "wall_ms_min": 2009.9999999999998,
+              "wall_ms_max": 2090.0
+            },
+            "repeat": {
+              "bytes": 0.0,
+              "head": 0,
+              "get": 0,
+              "wall_ms": 12.3,
+              "features": 14321,
+              "wall_ms_min": 10.0,
+              "wall_ms_max": 12.8
+            },
+            "adjacent": {
+              "bytes": 709324.8,
+              "head": 0,
+              "get": 5,
+              "wall_ms": 1310.0,
+              "features": 11222,
+              "wall_ms_min": 1190.0,
+              "wall_ms_max": 1380.0
+            }
+          }
+        }
+      },
+      "street": {
+        "zoom": 14,
+        "level": 14,
+        "bbox": [
+          -73.99000000000001,
+          40.75,
+          -73.97,
+          40.769999999999996
+        ],
+        "cold": {
+          "defaults": {
+            "bytes": 5138022.4,
+            "head": 1,
+            "get": 38,
+            "wall_ms": 2200.0,
+            "features": 33865,
+            "wall_ms_min": 2110.0,
+            "wall_ms_max": 2250.0
+          },
+          "threads_64": {
+            "bytes": 5138022.4,
+            "head": 1,
+            "get": 38,
+            "wall_ms": 2130.0,
+            "features": 33865,
+            "wall_ms_min": 2100.0,
+            "wall_ms_max": 2150.0
+          },
+          "no_parquet_prefetch": {
+            "bytes": 16043212.8,
+            "head": 1,
+            "get": 18,
+            "wall_ms": 2090.0,
+            "features": 33865,
+            "wall_ms_min": 2000.0,
+            "wall_ms_max": 2110.0
+          },
+          "prefetch_all": {
+            "bytes": 5138022.4,
+            "head": 1,
+            "get": 38,
+            "wall_ms": 2160.0,
+            "features": 33865,
+            "wall_ms_min": 2090.0,
+            "wall_ms_max": 2300.0
+          },
+          "keepalive_off": {
+            "bytes": 5138022.4,
+            "head": 1,
+            "get": 38,
+            "wall_ms": 4330.0,
+            "features": 33865,
+            "wall_ms_min": 4300.0,
+            "wall_ms_max": 4750.0
+          },
+          "metadata_caches_on": {
+            "bytes": 5138022.4,
+            "head": 1,
+            "get": 38,
+            "wall_ms": 2080.0,
+            "features": 33865,
+            "wall_ms_min": 2029.9999999999998,
+            "wall_ms_max": 2240.0
+          },
+          "stack": {
+            "bytes": 5138022.4,
+            "head": 1,
+            "get": 38,
+            "wall_ms": 2130.0,
+            "features": 33865,
+            "wall_ms_min": 2050.0,
+            "wall_ms_max": 2160.0
+          }
+        },
+        "session": {
+          "sym200": {
+            "cold": {
+              "bytes": 5138022.4,
+              "head": 1,
+              "get": 38,
+              "wall_ms": 2190.0,
+              "features": 33865,
+              "wall_ms_min": 2070.0,
+              "wall_ms_max": 2240.0
+            },
+            "repeat": {
+              "bytes": 5138022.4,
+              "head": 0,
+              "get": 38,
+              "wall_ms": 2009.9999999999998,
+              "features": 33865,
+              "wall_ms_min": 2000.0,
+              "wall_ms_max": 2060.0
+            },
+            "adjacent": {
+              "bytes": 3984588.8,
+              "head": 0,
+              "get": 28,
+              "wall_ms": 1970.0,
+              "features": 9206,
+              "wall_ms_min": 1910.0,
+              "wall_ms_max": 1970.0
+            }
+          },
+          "real": {
+            "cold": {
+              "bytes": 5138022.4,
+              "head": 1,
+              "get": 38,
+              "wall_ms": 2250.0,
+              "features": 33865,
+              "wall_ms_min": 2100.0,
+              "wall_ms_max": 2260.0
+            },
+            "repeat": {
+              "bytes": 0.0,
+              "head": 0,
+              "get": 0,
+              "wall_ms": 19.0,
+              "features": 33865,
+              "wall_ms_min": 18.9,
+              "wall_ms_max": 20.0
+            },
+            "adjacent": {
+              "bytes": 1572864.0,
+              "head": 0,
+              "get": 11,
+              "wall_ms": 1360.0,
+              "features": 9206,
+              "wall_ms_min": 1220.0,
+              "wall_ms_max": 1370.0
+            }
+          }
+        }
+      }
+    },
+    "polygons-ftw-moldova-large": {
+      "world": {
+        "zoom": 6,
+        "level": 3,
+        "bbox": [
+          26.592531983585204,
+          45.4719002653674,
+          30.15892038332341,
+          48.4902285248874
+        ],
+        "cold": {
+          "defaults": {
+            "bytes": 8703180.8,
+            "head": 1,
+            "get": 10,
+            "wall_ms": 3170.0,
+            "features": 7804,
+            "wall_ms_min": 3020.0,
+            "wall_ms_max": 3430.0
+          },
+          "threads_64": {
+            "bytes": 8703180.8,
+            "head": 1,
+            "get": 10,
+            "wall_ms": 3200.0,
+            "features": 7804,
+            "wall_ms_min": 3120.0,
+            "wall_ms_max": 3210.0
+          },
+          "no_parquet_prefetch": {
+            "bytes": 11324620.8,
+            "head": 1,
+            "get": 13,
+            "wall_ms": 3270.0,
+            "features": 7804,
+            "wall_ms_min": 3270.0,
+            "wall_ms_max": 3400.0
+          },
+          "prefetch_all": {
+            "bytes": 8703180.8,
+            "head": 1,
+            "get": 10,
+            "wall_ms": 3200.0,
+            "features": 7804,
+            "wall_ms_min": 3190.0,
+            "wall_ms_max": 3210.0
+          },
+          "keepalive_off": {
+            "bytes": 8703180.8,
+            "head": 1,
+            "get": 10,
+            "wall_ms": 6550.0,
+            "features": 7804,
+            "wall_ms_min": 6530.0,
+            "wall_ms_max": 6560.0
+          },
+          "metadata_caches_on": {
+            "bytes": 8703180.8,
+            "head": 1,
+            "get": 10,
+            "wall_ms": 3240.0,
+            "features": 7804,
+            "wall_ms_min": 3110.0,
+            "wall_ms_max": 3250.0
+          },
+          "stack": {
+            "bytes": 8703180.8,
+            "head": 1,
+            "get": 10,
+            "wall_ms": 3190.0,
+            "features": 7804,
+            "wall_ms_min": 3180.0,
+            "wall_ms_max": 3200.0
+          }
+        },
+        "session": {
+          "sym200": {
+            "cold": {
+              "bytes": 8703180.8,
+              "head": 1,
+              "get": 10,
+              "wall_ms": 3190.0,
+              "features": 7804,
+              "wall_ms_min": 3080.0,
+              "wall_ms_max": 3200.0
+            },
+            "repeat": {
+              "bytes": 8703180.8,
+              "head": 0,
+              "get": 10,
+              "wall_ms": 3080.0,
+              "features": 7804,
+              "wall_ms_min": 3070.0,
+              "wall_ms_max": 3200.0
+            },
+            "adjacent": {
+              "bytes": 262144.0,
+              "head": 0,
+              "get": 1,
+              "wall_ms": 751.0,
+              "features": 0,
+              "wall_ms_min": 724.0,
+              "wall_ms_max": 756.0
+            }
+          },
+          "real": {
+            "cold": {
+              "bytes": 8703180.8,
+              "head": 1,
+              "get": 10,
+              "wall_ms": 3170.0,
+              "features": 7804,
+              "wall_ms_min": 3140.0,
+              "wall_ms_max": 3300.0
+            },
+            "repeat": {
+              "bytes": 0.0,
+              "head": 0,
+              "get": 0,
+              "wall_ms": 83.9,
+              "features": 7804,
+              "wall_ms_min": 76.6,
+              "wall_ms_max": 92.60000000000001
+            },
+            "adjacent": {
+              "bytes": 0.0,
+              "head": 0,
+              "get": 0,
+              "wall_ms": 9.4,
+              "features": 0,
+              "wall_ms_min": 9.2,
+              "wall_ms_max": 9.4
+            }
+          }
+        }
+      },
+      "regional": {
+        "zoom": 9,
+        "level": 6,
+        "bbox": [
+          27.92992763348703,
+          46.603773362687406,
+          28.82152473342158,
+          47.3583554275674
+        ],
+        "cold": {
+          "defaults": {
+            "bytes": 21705523.2,
+            "head": 1,
+            "get": 46,
+            "wall_ms": 3120.0,
+            "features": 8008,
+            "wall_ms_min": 3100.0,
+            "wall_ms_max": 3200.0
+          },
+          "threads_64": {
+            "bytes": 21705523.2,
+            "head": 1,
+            "get": 46,
+            "wall_ms": 3050.0,
+            "features": 8008,
+            "wall_ms_min": 2980.0,
+            "wall_ms_max": 3210.0
+          },
+          "no_parquet_prefetch": {
+            "bytes": 31142707.2,
+            "head": 1,
+            "get": 33,
+            "wall_ms": 2990.0,
+            "features": 8008,
+            "wall_ms_min": 2860.0,
+            "wall_ms_max": 3010.0
+          },
+          "prefetch_all": {
+            "bytes": 21705523.2,
+            "head": 1,
+            "get": 46,
+            "wall_ms": 3040.0,
+            "features": 8008,
+            "wall_ms_min": 3030.0,
+            "wall_ms_max": 3060.0
+          },
+          "keepalive_off": {
+            "bytes": 21705523.2,
+            "head": 1,
+            "get": 46,
+            "wall_ms": 6570.0,
+            "features": 8008,
+            "wall_ms_min": 6480.0,
+            "wall_ms_max": 6940.0
+          },
+          "metadata_caches_on": {
+            "bytes": 21705523.2,
+            "head": 1,
+            "get": 46,
+            "wall_ms": 3100.0,
+            "features": 8008,
+            "wall_ms_min": 2980.0,
+            "wall_ms_max": 3320.0
+          },
+          "stack": {
+            "bytes": 21705523.2,
+            "head": 1,
+            "get": 46,
+            "wall_ms": 3040.0,
+            "features": 8008,
+            "wall_ms_min": 2980.0,
+            "wall_ms_max": 3100.0
+          }
+        },
+        "session": {
+          "sym200": {
+            "cold": {
+              "bytes": 21705523.2,
+              "head": 1,
+              "get": 46,
+              "wall_ms": 3070.0,
+              "features": 8008,
+              "wall_ms_min": 3010.0,
+              "wall_ms_max": 3100.0
+            },
+            "repeat": {
+              "bytes": 21705523.2,
+              "head": 0,
+              "get": 46,
+              "wall_ms": 2990.0,
+              "features": 8008,
+              "wall_ms_min": 2910.0,
+              "wall_ms_max": 3040.0
+            },
+            "adjacent": {
+              "bytes": 17930649.6,
+              "head": 0,
+              "get": 37,
+              "wall_ms": 2900.0,
+              "features": 7345,
+              "wall_ms_min": 2850.0,
+              "wall_ms_max": 3000.0
+            }
+          },
+          "real": {
+            "cold": {
+              "bytes": 21705523.2,
+              "head": 1,
+              "get": 46,
+              "wall_ms": 3020.0,
+              "features": 8008,
+              "wall_ms_min": 2950.0,
+              "wall_ms_max": 3190.0
+            },
+            "repeat": {
+              "bytes": 0.0,
+              "head": 0,
+              "get": 0,
+              "wall_ms": 35.4,
+              "features": 8008,
+              "wall_ms_min": 33.8,
+              "wall_ms_max": 35.4
+            },
+            "adjacent": {
+              "bytes": 0.0,
+              "head": 0,
+              "get": 0,
+              "wall_ms": 45.8,
+              "features": 7345,
+              "wall_ms_min": 44.5,
+              "wall_ms_max": 45.900000000000006
+            }
+          }
+        }
+      },
+      "street": {
+        "zoom": 14,
+        "level": 11,
+        "bbox": [
+          28.11,
+          47.150000000000006,
+          28.130000000000003,
+          47.17
+        ],
+        "cold": {
+          "defaults": {
+            "bytes": 1992294.4,
+            "head": 1,
+            "get": 22,
+            "wall_ms": 2760.0,
+            "features": 1527,
+            "wall_ms_min": 2760.0,
+            "wall_ms_max": 2790.0
+          },
+          "threads_64": {
+            "bytes": 1992294.4,
+            "head": 1,
+            "get": 22,
+            "wall_ms": 2690.0,
+            "features": 1527,
+            "wall_ms_min": 2660.0,
+            "wall_ms_max": 2830.0
+          },
+          "no_parquet_prefetch": {
+            "bytes": 7235174.4,
+            "head": 1,
+            "get": 9,
+            "wall_ms": 2080.0,
+            "features": 1527,
+            "wall_ms_min": 2000.0,
+            "wall_ms_max": 2190.0
+          },
+          "prefetch_all": {
+            "bytes": 1992294.4,
+            "head": 1,
+            "get": 22,
+            "wall_ms": 2670.0,
+            "features": 1527,
+            "wall_ms_min": 2650.0,
+            "wall_ms_max": 2800.0
+          },
+          "keepalive_off": {
+            "bytes": 1992294.4,
+            "head": 1,
+            "get": 22,
+            "wall_ms": 6100.0,
+            "features": 1527,
+            "wall_ms_min": 5960.0,
+            "wall_ms_max": 6120.0
+          },
+          "metadata_caches_on": {
+            "bytes": 1992294.4,
+            "head": 1,
+            "get": 22,
+            "wall_ms": 2740.0,
+            "features": 1527,
+            "wall_ms_min": 2710.0,
+            "wall_ms_max": 2750.0
+          },
+          "stack": {
+            "bytes": 1992294.4,
+            "head": 1,
+            "get": 22,
+            "wall_ms": 2720.0,
+            "features": 1527,
+            "wall_ms_min": 2660.0,
+            "wall_ms_max": 2740.0
+          }
+        },
+        "session": {
+          "sym200": {
+            "cold": {
+              "bytes": 1992294.4,
+              "head": 1,
+              "get": 22,
+              "wall_ms": 2680.0,
+              "features": 1527,
+              "wall_ms_min": 2570.0,
+              "wall_ms_max": 2780.0
+            },
+            "repeat": {
+              "bytes": 1992294.4,
+              "head": 0,
+              "get": 22,
+              "wall_ms": 2630.0,
+              "features": 1527,
+              "wall_ms_min": 2600.0,
+              "wall_ms_max": 2710.0
+            },
+            "adjacent": {
+              "bytes": 1992294.4,
+              "head": 0,
+              "get": 22,
+              "wall_ms": 2520.0,
+              "features": 427,
+              "wall_ms_min": 2480.0,
+              "wall_ms_max": 2600.0
+            }
+          },
+          "real": {
+            "cold": {
+              "bytes": 1992294.4,
+              "head": 1,
+              "get": 22,
+              "wall_ms": 2710.0,
+              "features": 1527,
+              "wall_ms_min": 2550.0,
+              "wall_ms_max": 2800.0
+            },
+            "repeat": {
+              "bytes": 0.0,
+              "head": 0,
+              "get": 0,
+              "wall_ms": 16.2,
+              "features": 1527,
+              "wall_ms_min": 16.1,
+              "wall_ms_max": 16.9
+            },
+            "adjacent": {
+              "bytes": 0.0,
+              "head": 0,
+              "get": 0,
+              "wall_ms": 13.0,
+              "features": 427,
+              "wall_ms_min": 12.4,
+              "wall_ms_max": 14.5
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/benchmarks/overview/format_duckdb_knobs.py
+++ b/benchmarks/overview/format_duckdb_knobs.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Format duckdb_knobs_results.json (issue #203) as markdown tables.
+
+Emits the two compact tables used in the RESULTS.md §2b addendum:
+  1. cold per-knob wall/requests/bytes vs defaults
+  2. session behavior (cold / repeat / adjacent pan) for the PR #200
+     symmetric config vs the real-user config
+
+Run:
+  python3 format_duckdb_knobs.py
+"""
+import json
+import os
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+CONFIG_LABELS = [
+    ("defaults", "defaults"),
+    ("threads_64", "`threads=64`"),
+    ("no_parquet_prefetch", "`disable_parquet_prefetching`"),
+    ("prefetch_all", "`prefetch_all_parquet_files`"),
+    ("keepalive_off", "`http_keep_alive=false`"),
+    ("metadata_caches_on", "metadata caches on"),
+    ("stack", "recommended stack"),
+]
+
+
+def fmt_bytes(b):
+    if b >= 1024 ** 2:
+        return f"{b / 1024 ** 2:.2f} MB"
+    if b >= 1024:
+        return f"{b / 1024:.0f} KB"
+    return f"{b:.0f} B"
+
+
+def main():
+    with open(os.path.join(HERE, "duckdb_knobs_results.json")) as f:
+        r = json.load(f)
+
+    cells = [
+        (ds, vp, r["datasets"][ds][vp])
+        for ds in r["datasets"]
+        for vp in ("world", "regional", "street")
+    ]
+
+    print("### Cold, per knob (median wall ms / requests / bytes)\n")
+    hdr = "| dataset | viewport |" + "".join(
+        f" {label} |" for _, label in CONFIG_LABELS)
+    print(hdr)
+    print("|---|---|" + "---|" * len(CONFIG_LABELS))
+    for ds, vp, e in cells:
+        row = f"| {ds} | {vp} |"
+        for key, _ in CONFIG_LABELS:
+            m = e["cold"][key]
+            row += (f" {m['wall_ms']:,.0f} / "
+                    f"{m['head'] + m['get']} / "
+                    f"{fmt_bytes(m['bytes'])} |")
+        print(row)
+
+    print("\n### Session behavior (same process)\n")
+    print("| dataset | viewport | config | cold | repeat | adjacent pan |")
+    print("|---|---|---|---|---|---|")
+    for ds, vp, e in cells:
+        for cfg in ("sym200", "real"):
+            s = e["session"][cfg]
+            row = f"| {ds} | {vp} | {cfg} |"
+            for q in ("cold", "repeat", "adjacent"):
+                m = s[q]
+                row += (f" {m['wall_ms']:,.0f} ms / "
+                        f"{m['head'] + m['get']} req / "
+                        f"{fmt_bytes(m['bytes'])} |")
+            print(row)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -126,9 +126,12 @@ SELECT * FROM read_parquet('overviews.parquet')
 WHERE level = (SELECT max(level) FROM read_parquet('overviews.parquet'));
 ```
 
-The format contract is `context/OVERVIEWS_SPEC.md`; a dedicated
-consumption guide (DuckDB recipes, GeoPandas, browser demo) is tracked
-in [#175](https://github.com/geoparquet-io/gpq-tiles/issues/175).
+The format contract is `context/OVERVIEWS_SPEC.md`. For querying
+overview files directly on object storage — the DuckDB secret setup,
+recommended session settings, and the level+bbox viewport query — see
+[Remote Reads](remote-reads.md). The broader consumption guide
+(GeoPandas, browser demo) is tracked in
+[#175](https://github.com/geoparquet-io/gpq-tiles/issues/175).
 
 ## Export Details
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@ export_pmtiles("overviews.parquet", "output.pmtiles")
 - [Overview Tuning](OVERVIEW_TUNING.md) — Every generalization knob explained
 - [API Reference](api-reference.md) — CLI flags, Python API, Rust API
 - [Advanced Usage](advanced-usage.md) — Input optimization, memory, export
+- [Remote Reads](remote-reads.md) — Querying overview files on object storage with DuckDB
 - [Architecture](architecture.md) — Design decisions and internals
 
 ## License

--- a/docs/remote-reads.md
+++ b/docs/remote-reads.md
@@ -1,0 +1,158 @@
+# Reading Overviews from Object Storage with DuckDB
+
+Overview GeoParquet is designed to be queried in place over HTTP range
+requests: a viewport query touches **0.14–6.5 % of the file**, whatever
+the file size (measured against real S3 in
+[`benchmarks/overview/RESULTS.md` §2b](https://github.com/geoparquet-io/gpq-tiles/blob/main/benchmarks/overview/RESULTS.md)).
+This page is the evidence-based DuckDB client recipe for that read
+path: the one-time secret setup, the settings that measurably help, the
+ones that don't, and what a warm session actually behaves like.
+
+All numbers below are from the issue
+[#203](https://github.com/geoparquet-io/gpq-tiles/issues/203) knob
+sweep (DuckDB v1.4.1, S3 `us-east-2`, 3-run medians on the same bucket,
+viewports, and harness as the §2b baseline; raw data in
+[`benchmarks/overview/duckdb_knobs_results.json`](https://github.com/geoparquet-io/gpq-tiles/blob/main/benchmarks/overview/duckdb_knobs_results.json),
+harness `bench_duckdb_knobs.py`).
+
+## One-time setup
+
+```sql
+INSTALL httpfs;
+LOAD httpfs;
+
+-- Private buckets: one secret, credentials from your AWS config
+CREATE SECRET (
+    TYPE s3,
+    PROVIDER credential_chain,
+    PROFILE 'my-profile',      -- omit to use the default chain
+    REGION  'us-east-2'        -- set it: avoids a redirect round trip
+);
+```
+
+Public buckets / plain HTTPS need no secret at all —
+`read_parquet('https://…')` just works. Setting `REGION` explicitly
+matters: with the wrong (or defaulted) region every request can pay an
+extra 301-redirect round trip.
+
+## Recommended session settings
+
+```sql
+SET enable_http_metadata_cache = true;  -- cache HEAD results across queries
+SET parquet_metadata_cache = true;      -- cache parsed parquet footers
+-- enable_external_file_cache defaults to true; leave it on.
+-- http_keep_alive defaults to true; leave it on.
+-- Leave parquet prefetching alone (defaults are right).
+```
+
+That is the whole recipe. The rest of this section is the evidence.
+
+### What each knob measurably did
+
+Sweep: two datasets (79 MB points, 343 MB polygons), three viewports
+each (world/regional/street), cold = fresh process, 3-run medians.
+
+| knob | cold effect | session effect | verdict |
+|---|---|---|---|
+| `enable_external_file_cache` (default ON) | none (nothing cached yet) | **repeat viewport: 0 requests, 10–84 ms** (was 1,860–3,080 ms with it off); adjacent pan fetches only uncached row groups | the knob that matters; leave ON |
+| `enable_http_metadata_cache` (default OFF) | none (±3 %) | skips per-query HEADs in a session (−1 request/query); pairs with the file cache | turn ON |
+| `parquet_metadata_cache` (default OFF) | none (±3 %) | skips footer re-fetch/re-parse on later queries against the same file | turn ON |
+| `http_keep_alive` (default ON) | turning it OFF ~**doubled** every cold wall (1.9 s → 4.1 s NYC world; 3.2 s → 6.6 s Moldova world) | same | leave ON (default already right) |
+| `disable_parquet_prefetching` | fewer, larger requests (39 → 19, NYC street) but **2.3–3.6× the bytes** (4.9 → 15.3 MB); wall within noise | — | leave OFF |
+| `prefetch_all_parquet_files` | no measurable change on these single-file viewport queries | — | leave OFF |
+| `threads` (16 → 64) | no measurable change (7–47 requests/viewport don't saturate 16 threads) | — | leave default |
+
+Honest summary: **no client knob makes the cold query materially
+faster** — cold wall is TLS + footer + data round trips to the bucket
+(~2–3 s from a residential link to `us-east-2`), and DuckDB's defaults
+(keep-alive, prefetch coalescing) are already right. What the knobs buy
+you is the *session*: metadata caches plus the (default-on) external
+file cache turn repeat and overlapping viewports from seconds into
+milliseconds.
+
+### Cold vs warm-session behavior
+
+What to expect, using the 343 MB polygons file as the example
+(medians; the small file behaves the same, scaled down):
+
+| query | requests | bytes | wall |
+|---|---|---|---|
+| cold viewport (fresh process) | 11–47 | 1.9–20.7 MB | 2.7–3.2 s |
+| exact repeat, recommended settings | **0** | **0** | **16–84 ms** |
+| adjacent pan (bbox shifted one width) | **0** (served from cache) | 0 | **9–46 ms** |
+
+The Moldova pans landing at 0 requests is not a fluke: the row groups
+fetched for the first viewport spatially overlap the shifted one
+(Hilbert-clustered data), so the cache absorbs the pan. Where a pan
+does need new data (the NYC dataset), the recommended settings still
+fetch only the uncached remainder — street pan: 11 requests / 1.5 MB /
+1.36 s, vs 28 requests / 3.8 MB / 1.97 s with the data cache off.
+
+A note on the §2b baseline tables: that benchmark deliberately ran
+DuckDB with the external file (data) cache **off**, so its "warm"
+numbers stay symmetric with a cacheless PMTiles reader — a fairness
+device, not a recommendation. A real user should run with the cache on
+(the default) and gets the session behavior above, not §2b's
+warm-equals-cold-minus-metadata numbers.
+
+If you need lower cold latency than a generic SQL client can give, the
+format supports it: a purpose-built reader gets footer-cached pans of
+130–300 ms (see the latency-floor section of `RESULTS.md` §2b and
+`benchmarks/overview/parallel_reader.py`).
+
+## The viewport query (read protocol)
+
+An overview file is plain GeoParquet plus a `level` column and a
+`geo:overviews` footer key. The whole read protocol is: pick a level,
+then bbox-filter it (spec §5.1 in `context/OVERVIEWS_SPEC.md`).
+
+**1. Inspect the levels** (footer-only — a few KB even on a
+multi-hundred-MB object):
+
+```sql
+WITH meta AS (
+    SELECT decode(value)::JSON AS ov
+    FROM parquet_kv_metadata('s3://bucket/overviews.parquet')
+    WHERE decode(key) = 'geo:overviews'
+), lv AS (
+    SELECT i - 1                                   AS level,
+           (ov->'levels'->(i - 1)->>'gsd')::DOUBLE AS gsd_m,
+           (ov->'levels'->(i - 1)->>'zoom')::INT   AS zoom
+    FROM meta,
+         generate_series(1, json_array_length(ov->'levels')::BIGINT) t(i)
+)
+SELECT * FROM lv;
+```
+
+**2. Pick the level for a target Web Mercator zoom `z`** — the finest
+level whose GSD is at least the display GSD (spec §5.2). Replace the
+final `SELECT` above with:
+
+```sql
+SELECT max(level) AS level_for_z
+FROM lv
+WHERE gsd_m >= 40075016.69 / 1024 / pow(2, {z});
+```
+
+(If no level qualifies you are zoomed past the finest level: use
+`json_array_length(ov->'levels') - 1`.)
+
+**3. The viewport query** — one level band + bbox overlap; DuckDB
+prunes row groups on the `level` and `bbox` column statistics and
+range-reads only the survivors:
+
+```sql
+SELECT *
+FROM read_parquet('s3://bucket/overviews.parquet')
+WHERE level = {k}
+  AND bbox.xmin <= {xmax} AND bbox.xmax >= {xmin}
+  AND bbox.ymin <= {ymax} AND bbox.ymax >= {ymin};
+```
+
+For exact (non-generalized) data instead of a rendering level, filter
+to the canonical level (`ov->>'canonical_level'`) in `duplicating`
+mode, or read the whole table in `partitioning` mode — see spec §5.3.
+
+Producer-side layout knobs that affect this read path
+(`--row-group-size`, `--full-column-stats`) are covered in
+[Advanced Usage](advanced-usage.md#output-layout-for-remote-reads).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
   - Decoding PMTiles: decode.md
   - API Reference: api-reference.md
   - Advanced Usage: advanced-usage.md
+  - Remote Reads: remote-reads.md
   - Architecture: architecture.md
   - Overview Tuning: OVERVIEW_TUNING.md
   - Development: development.md


### PR DESCRIPTION
Closes #203

## What

Benchmarks the DuckDB 1.4.1 httpfs client knobs against the #200 bucket (same viewports, EXPLAIN ANALYZE HTTPFS-stats protocol, 3-run medians on `points-nyc-medium` + `polygons-ftw-moldova-large`) and writes the resulting recipe into the docs. No Rust changes.

## Measured findings

**Cold (fresh client): no knob helps.** `threads=64`, `prefetch_all_parquet_files`, and the metadata caches are within ±3 % of defaults. The defaults that matter are already right:
- `http_keep_alive=false` roughly **doubles** every cold wall (1.9 → 4.1 s NYC world; 3.2 → 6.6 s Moldova world)
- `disable_parquet_prefetching=true` cuts requests (39 → 19, NYC street) but fetches **2.3–3.6× the bytes** for wall times within noise

**Session (same process): configuration pays.** With `enable_http_metadata_cache` + `parquet_metadata_cache` + the default-on `enable_external_file_cache`:
- exact repeat viewport: **0 requests / 10–84 ms** (vs 1,860–3,080 ms under the #200 symmetric config)
- adjacent pan: only uncached row groups (NYC street: 11 req / 1.5 MB / 1.36 s vs 28 req / 3.8 MB / 1.97 s); both non-empty Moldova pans were fully cache-absorbed (0 requests, 13–46 ms) thanks to Hilbert clustering

The PR spells out the distinction between the #200 symmetric-benchmark config (data cache off, a fairness device vs the cacheless pmtiles reader) and the real-user cache-on config.

## Deliverables

- `docs/remote-reads.md` — "Reading Overviews from Object Storage with DuckDB": one-time secret setup, recommended settings with the measured effect of each (honest about the no-ops), cold vs warm-session expectations, and the level+bbox read-protocol SQL (every snippet verified against the bench bucket). Linked from README, docs index, mkdocs nav, and advanced-usage. Feeds the #175 consumption guide.
- `benchmarks/overview/RESULTS.md` — §2b addendum with the compact knob + session tables
- `benchmarks/overview/bench_duckdb_knobs.py` / `format_duckdb_knobs.py` / `duckdb_knobs_results.json` — reproducible harness + raw numbers (documented in the benchmarks README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)