### PR TITLE
fix: auto-clamp empty coarse overview levels instead of failing (#211)

### DIFF
--- a/context/OVERVIEWS_SPEC.md
+++ b/context/OVERVIEWS_SPEC.md
@@ -651,6 +651,12 @@ future version. (Resolved Q3, §11.)
 - If generalization would empty a level (e.g. every feature dropped below
   the visibility gate), the writer MUST either merge it into the adjacent
   coarser level or omit it entirely (renumbering levels).
+- Omitting empty *coarse* levels is expected and normal, not an edge case:
+  a dataset of small features (e.g. country-scale buildings) is legitimately
+  invisible at world scales, so its pyramid simply starts at a finer GSD
+  than a producer's requested range. Readers MUST NOT assume level 0
+  corresponds to any particular zoom or GSD — the `levels[].gsd` (and
+  optional `zoom`) values are the only source of truth for a level's scale.
 
 ### 7.4 Single-level degenerate files
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -933,6 +933,22 @@ fn run_overview(args: OverviewArgs) -> Result<()> {
             HumanBytes(lvl.compressed_bytes.max(0) as u64)
         );
     }
+    if !report.skipped_empty_levels.is_empty() {
+        let planned: Vec<String> = report
+            .skipped_empty_levels
+            .iter()
+            .map(|s| match s.zoom {
+                Some(z) => format!("z{z}"),
+                None => format!("level {}", s.planned_level),
+            })
+            .collect();
+        println!(
+            "  note: {} empty level(s) omitted ({}) — no features visible at those \
+             scales; the pyramid starts at the coarsest non-empty level",
+            report.skipped_empty_levels.len(),
+            planned.join(", ")
+        );
+    }
 
     if let Some(report_path) = &args.report {
         let json =

--- a/crates/core/src/overview/check.rs
+++ b/crates/core/src/overview/check.rs
@@ -957,7 +957,7 @@ mod tests {
         opts.cogp_compat_key = cogp;
         let mut writer = OverviewWriter::create(path, &schema, opts).unwrap();
         for (k, ids) in level_ids.iter().enumerate() {
-            writer
+            let _ = writer
                 .write_level(
                     k,
                     Some(ids.len()),
@@ -1103,7 +1103,7 @@ mod tests {
                 columns.push(Arc::new(I64::from(counts[k].clone())));
             }
             let batch = RecordBatch::try_new(schema.clone(), columns).unwrap();
-            writer
+            let _ = writer
                 .write_level(k, Some(ids.len()), std::iter::once(batch))
                 .unwrap();
         }
@@ -1296,7 +1296,7 @@ mod tests {
                 columns.push(Arc::new(I32::from(counts[k].clone())));
             }
             let batch = RecordBatch::try_new(schema.clone(), columns).unwrap();
-            writer
+            let _ = writer
                 .write_level(k, Some(ids.len()), std::iter::once(batch))
                 .unwrap();
         }

--- a/crates/core/src/overview/check.rs
+++ b/crates/core/src/overview/check.rs
@@ -876,7 +876,9 @@ fn parse_semver_major(v: &str) -> Option<u64> {
 mod tests {
     use super::*;
     use crate::overview::level::{gsd, Level};
-    use crate::overview::writer::{LevelSpec, OverviewWriter, OverviewWriterOptions};
+    use crate::overview::writer::{
+        LevelSpec, LevelWriteOutcome, OverviewWriter, OverviewWriterOptions,
+    };
     use arrow_array::{Int64Array, RecordBatch, StringArray};
     use arrow_schema::{DataType, Field, Schema, SchemaRef};
     use geo::{Geometry, LineString, Point, Polygon};
@@ -957,13 +959,16 @@ mod tests {
         opts.cogp_compat_key = cogp;
         let mut writer = OverviewWriter::create(path, &schema, opts).unwrap();
         for (k, ids) in level_ids.iter().enumerate() {
-            let _ = writer
-                .write_level(
-                    k,
-                    Some(ids.len()),
-                    std::iter::once(source_batch(&schema, ids)),
-                )
-                .unwrap();
+            assert_eq!(
+                writer
+                    .write_level(
+                        k,
+                        Some(ids.len()),
+                        std::iter::once(source_batch(&schema, ids)),
+                    )
+                    .unwrap(),
+                LevelWriteOutcome::Written
+            );
         }
         writer.finish().unwrap()
     }
@@ -1103,9 +1108,12 @@ mod tests {
                 columns.push(Arc::new(I64::from(counts[k].clone())));
             }
             let batch = RecordBatch::try_new(schema.clone(), columns).unwrap();
-            let _ = writer
-                .write_level(k, Some(ids.len()), std::iter::once(batch))
-                .unwrap();
+            assert_eq!(
+                writer
+                    .write_level(k, Some(ids.len()), std::iter::once(batch))
+                    .unwrap(),
+                LevelWriteOutcome::Written
+            );
         }
         writer.finish().unwrap();
     }
@@ -1296,9 +1304,12 @@ mod tests {
                 columns.push(Arc::new(I32::from(counts[k].clone())));
             }
             let batch = RecordBatch::try_new(schema.clone(), columns).unwrap();
-            let _ = writer
-                .write_level(k, Some(ids.len()), std::iter::once(batch))
-                .unwrap();
+            assert_eq!(
+                writer
+                    .write_level(k, Some(ids.len()), std::iter::once(batch))
+                    .unwrap(),
+                LevelWriteOutcome::Written
+            );
         }
         writer.finish().unwrap();
     }

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -68,7 +68,8 @@ use super::level::{
 };
 use super::simplify::{simplify_for_level, Simplified, SimplifyOptions};
 use super::writer::{
-    LevelSpec, OverviewWriter, OverviewWriterOptions, RowGroupSizePolicy, WriterError, LEVEL_COLUMN,
+    LevelSpec, LevelWriteOutcome, OverviewWriter, OverviewWriterOptions, RowGroupSizePolicy,
+    WriterError, LEVEL_COLUMN,
 };
 
 /// How the caller specifies the overview levels.
@@ -449,13 +450,71 @@ pub struct LevelReport {
     pub compressed_bytes: i64,
 }
 
+/// A planned level omitted from the output because it contained no rows
+/// (#211 auto-clamp; spec §7.3 requires empty levels to be omitted and the
+/// remaining levels renumbered).
+///
+/// The most common shape is a coarse prefix: e.g. country-scale buildings
+/// where every feature is culled by the visibility gates at world zooms, so
+/// the written pyramid starts at the first zoom with visible features.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SkippedLevelReport {
+    /// Index of the level in the *planned* (requested) level range
+    /// (0 = requested coarsest). NOT an index into the written file.
+    pub planned_level: usize,
+    /// Planned ground sample distance in meters.
+    pub gsd: f64,
+    /// Planned Web Mercator zoom, if the level plan supplied one.
+    pub zoom: Option<u8>,
+}
+
+/// One WARN for the planned levels omitted because no feature is visible at
+/// their scale (#211 auto-clamp). No-op when nothing was skipped.
+pub(super) fn warn_plan_skipped_levels(
+    skipped: &[SkippedLevelReport],
+    input_features: usize,
+    first_written_gsd: f64,
+    first_written_zoom: Option<u8>,
+) {
+    if skipped.is_empty() {
+        return;
+    }
+    let ids: Vec<String> = skipped
+        .iter()
+        .map(|s| s.planned_level.to_string())
+        .collect();
+    let gsd_max = skipped.iter().map(|s| s.gsd).fold(f64::MIN, f64::max);
+    let gsd_min = skipped.iter().map(|s| s.gsd).fold(f64::MAX, f64::min);
+    let zoom_note = first_written_zoom.map_or_else(String::new, |z| format!(" (zoom {z})"));
+    log::warn!(
+        "omitting {} empty level(s) [{}] spanning GSD {:.2}–{:.2} m: none of the {} input \
+         feature(s) are visible at those scales (visibility gates / density budget); the \
+         output pyramid starts at GSD {:.2} m{}",
+        skipped.len(),
+        ids.join(", "),
+        gsd_max,
+        gsd_min,
+        input_features,
+        first_written_gsd,
+        zoom_note,
+    );
+}
+
 /// Result of a conversion, `Serialize` for JSON output (benchmark tasks).
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ConvertReport {
     /// Level materialization mode used.
     pub mode: Mode,
-    /// Per-level statistics, coarse→fine.
+    /// Per-level statistics, coarse→fine. `level` here is the index in the
+    /// WRITTEN file, which is shifted down from the planned range when empty
+    /// levels were skipped (see
+    /// [`skipped_empty_levels`](Self::skipped_empty_levels)).
     pub levels: Vec<LevelReport>,
+    /// Planned levels omitted because they contained no rows (#211
+    /// auto-clamp), ordered by planned level. Empty when every planned level
+    /// was written. The effective level range of the output is exactly
+    /// [`levels`](Self::levels).
+    pub skipped_empty_levels: Vec<SkippedLevelReport>,
     /// Number of source features read from the input.
     pub input_features: usize,
     /// Total rows written across all levels.
@@ -716,6 +775,61 @@ pub(crate) fn convert_to_overviews_strategy(
     convert_to_overviews_source_strategy(&source, output_path.as_ref(), options, strategy)
 }
 
+/// Decode every geometry in `full` (row-aligned to the batch) and drop the rows
+/// that cannot participate in level assignment: a null/empty/non-finite
+/// geometry, or — under a regional extract (#102) — one whose bbox misses
+/// `bbox_units`. The batch and the geometry vec are filtered together so every
+/// downstream index stays aligned. Returns the filtered batch and its surviving
+/// geometries.
+fn decode_and_filter_geometries(
+    full: RecordBatch,
+    geom_idx: usize,
+    geom_field: &Field,
+    bbox_units: Option<&[f64; 4]>,
+) -> Result<(RecordBatch, Vec<Geometry<f64>>), ConvertError> {
+    let geom_array: Arc<dyn GeoArrowArray> =
+        from_arrow_array(full.column(geom_idx).as_ref(), geom_field)
+            .map_err(|e| crate::Error::GeoParquetRead(format!("geometry decode: {e}")))?;
+    let mut geom_opts: Vec<Option<Geometry<f64>>> = Vec::with_capacity(full.num_rows());
+    extract_geometries_opt_from_array(geom_array.as_ref(), &mut geom_opts)?;
+    let mut geom_skipped = 0usize;
+    let keep: Vec<bool> = geom_opts
+        .iter()
+        .map(|g| match g.as_ref().filter(|g| usable_geometry(g)) {
+            // Regional extract (#102): drop features whose bbox misses the
+            // requested region exactly, independent of row-group pruning.
+            // (map_or, not is_none_or: the latter is stable only since Rust
+            // 1.82 and the crate MSRV is 1.75.)
+            #[allow(clippy::unnecessary_map_or)]
+            Some(g) => bbox_units.map_or(true, |bb| bboxes_intersect(&geometry_bbox(g), bb)),
+            None => {
+                geom_skipped += 1;
+                false
+            }
+        })
+        .collect();
+    let dropped = keep.iter().filter(|k| !**k).count();
+    if dropped == 0 {
+        return Ok((full, geom_opts.into_iter().flatten().collect()));
+    }
+    if geom_skipped > 0 {
+        log::warn!(
+            "skipping {geom_skipped} of {} input rows with a null, empty, or \
+             non-finite geometry",
+            full.num_rows()
+        );
+    }
+    let mask = arrow_array::BooleanArray::from(keep.clone());
+    let filtered = arrow_select::filter::filter_record_batch(&full, &mask)?;
+    let geoms = geom_opts
+        .into_iter()
+        .zip(&keep)
+        .filter(|(_, k)| **k)
+        .map(|(g, _)| g.expect("kept rows are Some"))
+        .collect();
+    Ok((filtered, geoms))
+}
+
 /// [`convert_to_overviews_source`] with an explicit pass-2 [`Pass2Strategy`].
 /// Runs the full option normalization (validation, cluster/accumulate checks,
 /// the partitioning-coalesce-inert rewrite) before dispatching.
@@ -826,53 +940,11 @@ pub(crate) fn convert_to_overviews_source_strategy(
 
     // Decode geometries once (in-memory v1), row-aligned. Rows with a null,
     // empty, or non-finite geometry cannot participate in level assignment:
-    // they are dropped HERE, from the batch and the geometry vec together, so
-    // every downstream index stays aligned (H4: an interleaved null geometry
-    // must never shift attributes onto a neighboring row's geometry).
-    let geom_array: Arc<dyn GeoArrowArray> =
-        from_arrow_array(full.column(geom_idx).as_ref(), &geom_field)
-            .map_err(|e| crate::Error::GeoParquetRead(format!("geometry decode: {e}")))?;
-    let mut geom_opts: Vec<Option<Geometry<f64>>> = Vec::with_capacity(full.num_rows());
-    extract_geometries_opt_from_array(geom_array.as_ref(), &mut geom_opts)?;
-    let mut geom_skipped = 0usize;
-    let keep: Vec<bool> = geom_opts
-        .iter()
-        .map(|g| match g.as_ref().filter(|g| usable_geometry(g)) {
-            // Regional extract (#102): drop features whose bbox misses the
-            // requested region exactly, independent of row-group pruning.
-            // (map_or, not is_none_or: the latter is stable only since Rust
-            // 1.82 and the crate MSRV is 1.75.)
-            #[allow(clippy::unnecessary_map_or)]
-            Some(g) => bbox_units
-                .as_ref()
-                .map_or(true, |bb| bboxes_intersect(&geometry_bbox(g), bb)),
-            None => {
-                geom_skipped += 1;
-                false
-            }
-        })
-        .collect();
-    let skipped = keep.iter().filter(|k| !**k).count();
-    let (full, geometries): (RecordBatch, Vec<Geometry<f64>>) = if skipped > 0 {
-        if geom_skipped > 0 {
-            log::warn!(
-                "skipping {geom_skipped} of {} input rows with a null, empty, or \
-                 non-finite geometry",
-                full.num_rows()
-            );
-        }
-        let mask = arrow_array::BooleanArray::from(keep.clone());
-        let filtered = arrow_select::filter::filter_record_batch(&full, &mask)?;
-        let geoms = geom_opts
-            .into_iter()
-            .zip(&keep)
-            .filter(|(_, k)| **k)
-            .map(|(g, _)| g.expect("kept rows are Some"))
-            .collect();
-        (filtered, geoms)
-    } else {
-        (full, geom_opts.into_iter().flatten().collect())
-    };
+    // they are dropped, from the batch and the geometry vec together, so every
+    // downstream index stays aligned (H4: an interleaved null geometry must
+    // never shift attributes onto a neighboring row's geometry).
+    let (full, geometries) =
+        decode_and_filter_geometries(full, geom_idx, &geom_field, bbox_units.as_ref())?;
     let num_features = full.num_rows();
 
     // Resolve the cell-winner ranking (Q1): explicit sort key / explicit class
@@ -980,6 +1052,7 @@ pub(crate) fn convert_to_overviews_source_strategy(
         coalesce: Option<CoalesceTable>,
     }
     let mut emitted: Vec<EmittedLevel> = Vec::new();
+    let mut skipped: Vec<SkippedLevelReport> = Vec::new();
 
     for (level, &(gsd_m, zoom)) in level_specs.iter().enumerate() {
         let member_indices: Vec<usize> = match options.mode {
@@ -1056,8 +1129,14 @@ pub(crate) fn convert_to_overviews_source_strategy(
             }
         }
 
-        // Empty levels are not allowed (§7.3): omit and renumber.
+        // Empty levels are not allowed (§7.3): omit and renumber (#211
+        // auto-clamp), recording the omission for the report + warning.
         if indices.is_empty() {
+            skipped.push(SkippedLevelReport {
+                planned_level: level,
+                gsd: gsd_m,
+                zoom,
+            });
             continue;
         }
         emitted.push(EmittedLevel {
@@ -1074,6 +1153,7 @@ pub(crate) fn convert_to_overviews_source_strategy(
     if emitted.is_empty() {
         return Err(ConvertError::NoData);
     }
+    warn_plan_skipped_levels(&skipped, num_features, emitted[0].gsd, emitted[0].zoom);
 
     // --- Build the output writer schema (source schema + geoarrow geometry). -
     let geom_name = geom_field.name().clone();
@@ -1138,17 +1218,28 @@ pub(crate) fn convert_to_overviews_source_strategy(
             // Canonical level (and guard-skipped runs): table is None ⇒ all 1.
             batch = apply_coalesced_count(batch, &out_schema, &e.indices, e.coalesce.as_ref())?;
         }
-        writer.write_level(level_idx, Some(e.indices.len()), std::iter::once(batch))?;
-        level_reports.push(LevelReport {
-            level: level_idx,
-            gsd: e.gsd,
-            zoom: e.zoom,
-            feature_count: e.indices.len(),
-            vertex_count: e.vertex_count,
-            uncompressed_bytes: 0,
-            compressed_bytes: 0,
-        });
+        match writer.write_level(level_idx, Some(e.indices.len()), std::iter::once(batch))? {
+            // Unreachable here (every emitted level has >= 1 feature), but
+            // kept aligned with the streaming path's bookkeeping.
+            LevelWriteOutcome::SkippedEmpty => {
+                skipped.push(SkippedLevelReport {
+                    planned_level: e.orig,
+                    gsd: e.gsd,
+                    zoom: e.zoom,
+                });
+            }
+            LevelWriteOutcome::Written => level_reports.push(LevelReport {
+                level: level_reports.len(),
+                gsd: e.gsd,
+                zoom: e.zoom,
+                feature_count: e.indices.len(),
+                vertex_count: e.vertex_count,
+                uncompressed_bytes: 0,
+                compressed_bytes: 0,
+            }),
+        }
     }
+    skipped.sort_by_key(|s| s.planned_level);
 
     let meta = writer.finish()?;
 
@@ -1162,6 +1253,7 @@ pub(crate) fn convert_to_overviews_source_strategy(
     Ok(ConvertReport {
         mode: options.mode,
         levels: level_reports,
+        skipped_empty_levels: skipped,
         input_features: num_features,
         total_rows,
         total_vertices,
@@ -4829,5 +4921,204 @@ mod tests {
                 100.0 * stats.bytes_fetched as f64 / stats.object_size as f64
             );
         }
+    }
+
+    // --- empty coarse levels: auto-clamp (#211) ------------------------------
+
+    /// Tiny (~10 m) squares spread far apart: they fail the polygon
+    /// visibility gate (4 × GSD) at every coarse zoom, so only the canonical
+    /// level keeps them.
+    fn tiny_polygons(n: usize) -> Vec<Geometry<f64>> {
+        (0..n)
+            .map(|i| {
+                let cx = -150.0 + (i % 10) as f64 * 3.0;
+                let cy = -60.0 + (i / 10) as f64 * 1.5;
+                let h = 5e-5;
+                let ext = LineString::from(vec![
+                    (cx - h, cy - h),
+                    (cx + h, cy - h),
+                    (cx + h, cy + h),
+                    (cx - h, cy + h),
+                    (cx - h, cy - h),
+                ]);
+                Geometry::Polygon(Polygon::new(ext, vec![]))
+            })
+            .collect()
+    }
+
+    /// Convert `tiny_polygons` over z0..z4 and assert the pyramid is clamped
+    /// to the canonical level, with the skipped planned levels recorded.
+    fn assert_clamped_pyramid(mode: Mode, streaming: bool) {
+        let geoms = tiny_polygons(20);
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        write_input(tin.path(), &geoms, false, None);
+
+        let opts = ConvertOptions {
+            mode,
+            levels: LevelPlan::ZoomRange {
+                min_zoom: 0,
+                max_zoom: 4,
+            },
+            streaming,
+            ..Default::default()
+        };
+        let report = convert_to_overviews(tin.path(), tout.path(), &opts).unwrap();
+
+        // Only the canonical level survives; the pyramid clamps to it.
+        assert_eq!(report.levels.len(), 1, "expected a single written level");
+        assert_eq!(report.levels[0].level, 0);
+        assert_eq!(report.levels[0].zoom, Some(4));
+        assert_eq!(report.levels[0].feature_count, geoms.len());
+        assert_eq!(report.total_rows, geoms.len());
+
+        // The skipped planned levels are recorded coarse→fine with their
+        // planned zoom and a positive GSD.
+        let skipped: Vec<(usize, Option<u8>)> = report
+            .skipped_empty_levels
+            .iter()
+            .map(|s| (s.planned_level, s.zoom))
+            .collect();
+        assert_eq!(
+            skipped,
+            vec![(0, Some(0)), (1, Some(1)), (2, Some(2)), (3, Some(3))]
+        );
+        assert!(report.skipped_empty_levels.iter().all(|s| s.gsd > 0.0));
+
+        // The clamped file is valid, readable, and exportable: the PMTiles
+        // header starts at the clamped (canonical) zoom.
+        let vr = validate_file(tout.path()).unwrap();
+        assert!(
+            vr.is_valid(),
+            "failures: {:?}",
+            vr.failures().collect::<Vec<_>>()
+        );
+        let reader = OverviewReader::open(tout.path()).unwrap();
+        assert_eq!(reader.num_levels(), 1);
+        let tpm = tempfile::NamedTempFile::new().unwrap();
+        let export = crate::overview::export::export_pmtiles(
+            tout.path(),
+            tpm.path(),
+            &crate::overview::export::ExportOptions::default(),
+        )
+        .unwrap();
+        assert_eq!(export.min_zoom, 4);
+        assert_eq!(export.max_zoom, 4);
+    }
+
+    #[test]
+    fn empty_coarse_levels_clamped_duplicating_memory() {
+        assert_clamped_pyramid(Mode::Duplicating, false);
+    }
+
+    #[test]
+    fn empty_coarse_levels_clamped_duplicating_streaming() {
+        assert_clamped_pyramid(Mode::Duplicating, true);
+    }
+
+    #[test]
+    fn empty_coarse_levels_clamped_partitioning_memory() {
+        assert_clamped_pyramid(Mode::Partitioning, false);
+    }
+
+    #[test]
+    fn empty_coarse_levels_clamped_partitioning_streaming() {
+        assert_clamped_pyramid(Mode::Partitioning, true);
+    }
+
+    /// The degenerate extreme — NO level has any rows (empty input) — must
+    /// remain a hard, actionable error in both pipelines.
+    #[test]
+    fn all_levels_empty_is_hard_error() {
+        for streaming in [false, true] {
+            let tin = tempfile::NamedTempFile::new().unwrap();
+            let tout = tempfile::NamedTempFile::new().unwrap();
+            write_input(tin.path(), &[], false, None);
+            let opts = ConvertOptions {
+                mode: Mode::Duplicating,
+                levels: LevelPlan::ZoomRange {
+                    min_zoom: 0,
+                    max_zoom: 3,
+                },
+                streaming,
+                ..Default::default()
+            };
+            let err = convert_to_overviews(tin.path(), tout.path(), &opts).unwrap_err();
+            assert!(
+                matches!(err, ConvertError::NoData),
+                "streaming={streaming}: expected NoData, got {err:?}"
+            );
+        }
+    }
+
+    /// #211 regression: a feature can pass the assign visibility gate (huge
+    /// bbox) yet be dropped by simplification at write time (degenerate
+    /// sliver). The streaming pass 2 must skip the now-empty level instead of
+    /// failing the whole conversion with `EmptyLevel`.
+    #[test]
+    fn write_time_empty_level_skipped_streaming() {
+        let mut geoms = tiny_polygons(8);
+        // Pathological feature: a MultiPolygon of two ~10 m squares 160°
+        // apart. Its whole-feature bbox diagonal passes the assign visibility
+        // gate at every zoom, but each PART is far below the per-level
+        // simplify tolerance, so `simplify_for_level` drops the feature at
+        // every non-canonical level.
+        let square = |cx: f64, cy: f64| {
+            let h = 5e-5;
+            Polygon::new(
+                LineString::from(vec![
+                    (cx - h, cy - h),
+                    (cx + h, cy - h),
+                    (cx + h, cy + h),
+                    (cx - h, cy + h),
+                    (cx - h, cy - h),
+                ]),
+                vec![],
+            )
+        };
+        geoms.push(Geometry::MultiPolygon(geo::MultiPolygon::new(vec![
+            square(-80.0, 10.0),
+            square(80.0, 30.0),
+        ])));
+
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        write_input(tin.path(), &geoms, false, None);
+
+        let opts = ConvertOptions {
+            mode: Mode::Duplicating,
+            levels: LevelPlan::ZoomRange {
+                min_zoom: 0,
+                max_zoom: 3,
+            },
+            streaming: true,
+            ..Default::default()
+        };
+        let report = convert_to_overviews(tin.path(), tout.path(), &opts).unwrap();
+
+        // Levels z0..z2 each contained only the sliver, which simplification
+        // dropped: they are skipped at write time and the pyramid clamps to
+        // the canonical level.
+        assert_eq!(report.levels.len(), 1);
+        assert_eq!(report.levels[0].level, 0);
+        assert_eq!(report.levels[0].zoom, Some(3));
+        assert_eq!(report.levels[0].feature_count, geoms.len());
+        assert_eq!(
+            report
+                .skipped_empty_levels
+                .iter()
+                .map(|s| s.planned_level)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+
+        let vr = validate_file(tout.path()).unwrap();
+        assert!(
+            vr.is_valid(),
+            "failures: {:?}",
+            vr.failures().collect::<Vec<_>>()
+        );
+        let reader = OverviewReader::open(tout.path()).unwrap();
+        assert_eq!(reader.num_levels(), 1);
     }
 }

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -500,6 +500,45 @@ pub(super) fn warn_plan_skipped_levels(
     );
 }
 
+/// Fold one [`OverviewWriter::write_level`] outcome into the driver
+/// bookkeeping shared by both pipelines (#211): a written level appends a
+/// [`LevelReport`] renumbered to the written count; an empty level (every
+/// candidate collapsed during simplification) warns and records `planned` in
+/// the skipped list instead.
+pub(super) fn record_level_outcome(
+    outcome: LevelWriteOutcome,
+    planned: SkippedLevelReport,
+    candidates: usize,
+    rows: usize,
+    vertices: usize,
+    level_reports: &mut Vec<LevelReport>,
+    skipped: &mut Vec<SkippedLevelReport>,
+) {
+    match outcome {
+        LevelWriteOutcome::SkippedEmpty => {
+            log::warn!(
+                "level planned at GSD {:.2} m{} became empty after simplification \
+                 (all {} candidate feature(s) collapsed); omitted from the output pyramid",
+                planned.gsd,
+                planned
+                    .zoom
+                    .map_or_else(String::new, |z| format!(" (zoom {z})")),
+                candidates,
+            );
+            skipped.push(planned);
+        }
+        LevelWriteOutcome::Written => level_reports.push(LevelReport {
+            level: level_reports.len(),
+            gsd: planned.gsd,
+            zoom: planned.zoom,
+            feature_count: rows,
+            vertex_count: vertices,
+            uncompressed_bytes: 0,
+            compressed_bytes: 0,
+        }),
+    }
+}
+
 /// Result of a conversion, `Serialize` for JSON output (benchmark tasks).
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ConvertReport {
@@ -1218,26 +1257,23 @@ pub(crate) fn convert_to_overviews_source_strategy(
             // Canonical level (and guard-skipped runs): table is None ⇒ all 1.
             batch = apply_coalesced_count(batch, &out_schema, &e.indices, e.coalesce.as_ref())?;
         }
-        match writer.write_level(level_idx, Some(e.indices.len()), std::iter::once(batch))? {
-            // Unreachable here (every emitted level has >= 1 feature), but
-            // kept aligned with the streaming path's bookkeeping.
-            LevelWriteOutcome::SkippedEmpty => {
-                skipped.push(SkippedLevelReport {
-                    planned_level: e.orig,
-                    gsd: e.gsd,
-                    zoom: e.zoom,
-                });
-            }
-            LevelWriteOutcome::Written => level_reports.push(LevelReport {
-                level: level_reports.len(),
+        // SkippedEmpty is unreachable here (every emitted level has >= 1
+        // feature), but the bookkeeping stays aligned with the streaming path.
+        let outcome =
+            writer.write_level(level_idx, Some(e.indices.len()), std::iter::once(batch))?;
+        record_level_outcome(
+            outcome,
+            SkippedLevelReport {
+                planned_level: e.orig,
                 gsd: e.gsd,
                 zoom: e.zoom,
-                feature_count: e.indices.len(),
-                vertex_count: e.vertex_count,
-                uncompressed_bytes: 0,
-                compressed_bytes: 0,
-            }),
-        }
+            },
+            e.indices.len(),
+            e.indices.len(),
+            e.vertex_count,
+            &mut level_reports,
+            &mut skipped,
+        );
     }
     skipped.sort_by_key(|s| s.planned_level);
 

--- a/crates/core/src/overview/export.rs
+++ b/crates/core/src/overview/export.rs
@@ -1124,7 +1124,7 @@ mod tests {
         opts.max_row_group_size = 10_000;
         let mut writer = OverviewWriter::create(path, &schema, opts).unwrap();
         for (k, (ids, geoms)) in level_geoms.iter().enumerate() {
-            writer
+            let _ = writer
                 .write_level(
                     k,
                     Some(ids.len()),
@@ -1326,26 +1326,28 @@ mod tests {
         let mut opts = OverviewWriterOptions::new(Mode::Partitioning, specs);
         opts.max_row_group_size = 10_000;
         let mut w = OverviewWriter::create(tmp.path(), &schema, opts).unwrap();
-        w.write_level(
-            0,
-            Some(1),
-            std::iter::once(batch(
-                &schema,
-                &[0],
-                &[Geometry::Point(Point::new(1.0, 1.0))],
-            )),
-        )
-        .unwrap();
-        w.write_level(
-            1,
-            Some(1),
-            std::iter::once(batch(
-                &schema,
-                &[1],
-                &[Geometry::Point(Point::new(2.0, 2.0))],
-            )),
-        )
-        .unwrap();
+        let _ = w
+            .write_level(
+                0,
+                Some(1),
+                std::iter::once(batch(
+                    &schema,
+                    &[0],
+                    &[Geometry::Point(Point::new(1.0, 1.0))],
+                )),
+            )
+            .unwrap();
+        let _ = w
+            .write_level(
+                1,
+                Some(1),
+                std::iter::once(batch(
+                    &schema,
+                    &[1],
+                    &[Geometry::Point(Point::new(2.0, 2.0))],
+                )),
+            )
+            .unwrap();
         w.finish().unwrap();
 
         let reader = OverviewReader::open(tmp.path()).unwrap();

--- a/crates/core/src/overview/export.rs
+++ b/crates/core/src/overview/export.rs
@@ -1070,7 +1070,9 @@ mod tests {
     use super::*;
     use crate::mvt::{command_decode, zigzag_decode};
     use crate::overview::level::{gsd, Level, Mode};
-    use crate::overview::writer::{LevelSpec, OverviewWriter, OverviewWriterOptions};
+    use crate::overview::writer::{
+        LevelSpec, LevelWriteOutcome, OverviewWriter, OverviewWriterOptions,
+    };
     use crate::vector_tile::tile::GeomType;
     use crate::vector_tile::Tile;
     use arrow_array::{Int64Array, RecordBatch, StringArray};
@@ -1124,13 +1126,16 @@ mod tests {
         opts.max_row_group_size = 10_000;
         let mut writer = OverviewWriter::create(path, &schema, opts).unwrap();
         for (k, (ids, geoms)) in level_geoms.iter().enumerate() {
-            let _ = writer
-                .write_level(
-                    k,
-                    Some(ids.len()),
-                    std::iter::once(batch(&schema, ids, geoms)),
-                )
-                .unwrap();
+            assert_eq!(
+                writer
+                    .write_level(
+                        k,
+                        Some(ids.len()),
+                        std::iter::once(batch(&schema, ids, geoms)),
+                    )
+                    .unwrap(),
+                LevelWriteOutcome::Written
+            );
         }
         writer.finish().unwrap()
     }
@@ -1326,8 +1331,8 @@ mod tests {
         let mut opts = OverviewWriterOptions::new(Mode::Partitioning, specs);
         opts.max_row_group_size = 10_000;
         let mut w = OverviewWriter::create(tmp.path(), &schema, opts).unwrap();
-        let _ = w
-            .write_level(
+        assert_eq!(
+            w.write_level(
                 0,
                 Some(1),
                 std::iter::once(batch(
@@ -1336,9 +1341,11 @@ mod tests {
                     &[Geometry::Point(Point::new(1.0, 1.0))],
                 )),
             )
-            .unwrap();
-        let _ = w
-            .write_level(
+            .unwrap(),
+            LevelWriteOutcome::Written
+        );
+        assert_eq!(
+            w.write_level(
                 1,
                 Some(1),
                 std::iter::once(batch(
@@ -1347,7 +1354,9 @@ mod tests {
                     &[Geometry::Point(Point::new(2.0, 2.0))],
                 )),
             )
-            .unwrap();
+            .unwrap(),
+            LevelWriteOutcome::Written
+        );
         w.finish().unwrap();
 
         let reader = OverviewReader::open(tmp.path()).unwrap();

--- a/crates/core/src/overview/hostile.rs
+++ b/crates/core/src/overview/hostile.rs
@@ -735,7 +735,8 @@ fn reserved_columns_rejected_case_insensitive() {
 fn empty_coarse_levels_omitted_across_pipelines() {
     // Tiny lines fail the visibility gate at every coarse level: with
     // coalescing off those levels are empty and must be omitted (not written,
-    // not EmptyLevel-crashed), leaving a valid file with fewer levels.
+    // not crashed on — #211 auto-clamp), leaving a valid file with fewer
+    // levels.
     let tiny_lines: Vec<Option<Geometry<f64>>> = (0..4)
         .map(|i| {
             let x = 10.0 + i as f64 * 5.0;

--- a/crates/core/src/overview/pipeline.rs
+++ b/crates/core/src/overview/pipeline.rs
@@ -49,7 +49,7 @@ use crate::input::InputSource;
 use super::convert::ConvertError;
 use super::level::{MemoryProfile, Mode};
 use super::stream::{process_level_batch, LevelStreamCtx, Pass2Timers};
-use super::writer::OverviewWriter;
+use super::writer::{LevelWriteOutcome, OverviewWriter};
 
 /// How a level's buffered output is held until it is written.
 #[derive(Clone, Copy, Debug)]
@@ -167,8 +167,10 @@ impl SpillState {
 }
 
 /// Buffer + write levels `0..ctxs.len()` (all but the streamed finest level)
-/// from a single read of the input. Returns `(rows_written, vertex_count)` per
-/// level, in level order.
+/// from a single read of the input. Returns `(outcome, rows_written,
+/// vertex_count)` per level, in level order — the outcome flags a level the
+/// writer skipped because every candidate collapsed during simplification
+/// (#211).
 #[allow(clippy::too_many_arguments)]
 pub(super) fn run_pass2_buffered(
     writer: &mut OverviewWriter<File>,
@@ -180,7 +182,7 @@ pub(super) fn run_pass2_buffered(
     in_flight: usize,
     backing: SinkBacking,
     out_schema: &Schema,
-) -> Result<Vec<(usize, usize)>, ConvertError> {
+) -> Result<Vec<(LevelWriteOutcome, usize, usize)>, ConvertError> {
     let num_levels = ctxs.len();
     debug_assert_eq!(num_levels, hints.len());
 
@@ -265,14 +267,21 @@ pub(super) fn run_pass2_buffered(
     }
     consume?;
 
-    // Drain each level's sink into the writer, in level order.
+    // Drain each level's sink into the writer, in level order. An empty
+    // buffered level is skipped and renumbered by the writer (#211); the
+    // outcome is threaded back to the caller with the level's stats.
+    let mut outcomes = Vec::with_capacity(num_levels);
     for li in 0..num_levels {
         let sink = std::mem::replace(&mut sinks[li], LevelSink::Ram(Vec::new()));
-        drain_sink(writer, li, hints[li], sink)?;
+        outcomes.push(drain_sink(writer, li, hints[li], sink)?);
     }
 
     timers.log_engine_summary(t_engine.elapsed().as_secs_f64(), rows.iter().sum());
-    Ok(rows.into_iter().zip(verts).collect())
+    Ok(outcomes
+        .into_iter()
+        .zip(rows.into_iter().zip(verts))
+        .map(|(outcome, (r, v))| (outcome, r, v))
+        .collect())
 }
 
 /// Drain one level's sink into `writer.write_level`. The RAM path is
@@ -284,11 +293,10 @@ fn drain_sink(
     level_idx: usize,
     hint: usize,
     sink: LevelSink,
-) -> Result<(), ConvertError> {
+) -> Result<LevelWriteOutcome, ConvertError> {
     match sink {
         LevelSink::Ram(batches) => {
-            writer.write_level(level_idx, Some(hint), batches.into_iter())?;
-            Ok(())
+            Ok(writer.write_level(level_idx, Some(hint), batches.into_iter())?)
         }
         LevelSink::Spill(state) => {
             // `_temp` keeps the spill file on disk until the reader is drained.
@@ -306,8 +314,7 @@ fn drain_sink(
             if let Some(e) = err.borrow_mut().take() {
                 return Err(e); // spill read error takes precedence over the writer's
             }
-            res?;
-            Ok(())
+            Ok(res?)
         }
     }
 }

--- a/crates/core/src/overview/reader.rs
+++ b/crates/core/src/overview/reader.rs
@@ -356,7 +356,7 @@ mod tests {
 
         let mut writer = OverviewWriter::create(path, &schema, opts).unwrap();
         for (k, ids) in level_ids.iter().enumerate() {
-            writer
+            let _ = writer
                 .write_level(
                     k,
                     Some(ids.len()),

--- a/crates/core/src/overview/reader.rs
+++ b/crates/core/src/overview/reader.rs
@@ -273,7 +273,9 @@ impl OverviewReader {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::overview::writer::{LevelSpec, OverviewWriter, OverviewWriterOptions};
+    use crate::overview::writer::{
+        LevelSpec, LevelWriteOutcome, OverviewWriter, OverviewWriterOptions,
+    };
     use arrow_array::{Int64Array, RecordBatch, StringArray};
     use arrow_schema::{DataType, Field, Schema};
     use geo::{Geometry, LineString, Point, Polygon};
@@ -356,13 +358,16 @@ mod tests {
 
         let mut writer = OverviewWriter::create(path, &schema, opts).unwrap();
         for (k, ids) in level_ids.iter().enumerate() {
-            let _ = writer
-                .write_level(
-                    k,
-                    Some(ids.len()),
-                    std::iter::once(source_batch(&schema, ids)),
-                )
-                .unwrap();
+            assert_eq!(
+                writer
+                    .write_level(
+                        k,
+                        Some(ids.len()),
+                        std::iter::once(source_batch(&schema, ids)),
+                    )
+                    .unwrap(),
+                LevelWriteOutcome::Written
+            );
         }
         writer.finish().unwrap()
     }

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -36,13 +36,16 @@
 //! in-memory path omits (and renumbers past) a level whose *simplified*
 //! output is empty, whereas this path decides level omission from the winner
 //! table before simplification. The two only differ when **every** winner of
-//! a level degenerates during simplification — impossible under the default
-//! knobs (the assign visibility gates, 2–4 × GSD, are stricter than the
-//! simplify drop gate at 1 × GSD) and pathological otherwise; if it ever
-//! happens the writer reports [`WriterError::EmptyLevel`] instead of silently
-//! renumbering.
+//! a level degenerates during simplification — rare under the default knobs
+//! (the assign visibility gates, 2–4 × GSD, are stricter than the simplify
+//! drop gate at 1 × GSD) but real on dirty data (#211: a sliver with a huge
+//! bbox passes the gate, then collapses). When it happens the writer skips
+//! the level ([`LevelWriteOutcome::SkippedEmpty`]) and this driver records it
+//! in [`ConvertReport::skipped_empty_levels`], exactly like a plan-time
+//! omission — the two pipelines converge on the same output pyramid.
 //!
-//! [`WriterError::EmptyLevel`]: super::writer::WriterError::EmptyLevel
+//! [`LevelWriteOutcome::SkippedEmpty`]: super::writer::LevelWriteOutcome::SkippedEmpty
+//! [`ConvertReport::skipped_empty_levels`]: super::convert::ConvertReport::skipped_empty_levels
 
 use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
@@ -71,16 +74,18 @@ use super::convert::{
     build_source_schema, class_ranking_provenance, coalesce_effective, coalesce_level_chains,
     count_vertices, extract_class_ranks, extract_sort_keys, feature_kind, fill_level_bytes,
     find_geometry_column, geometry_bbox, mixed_geometry_field, overture_road_ranking,
-    usable_geometry, validate_cluster_schema, validate_coalesce_schema, ClassRanking,
-    CoalesceTable, ConvertError, ConvertOptions, ConvertReport, GroupInterner, LevelReport,
-    KNOWN_ROAD_CLASSES, ROAD_VOCAB_MIN_DISTINCT,
+    usable_geometry, validate_cluster_schema, validate_coalesce_schema, warn_plan_skipped_levels,
+    ClassRanking, CoalesceTable, ConvertError, ConvertOptions, ConvertReport, GroupInterner,
+    LevelReport, SkippedLevelReport, KNOWN_ROAD_CLASSES, ROAD_VOCAB_MIN_DISTINCT,
 };
 use super::level::{Crs, Mode, RankingProvenance};
 use super::pipeline;
 use super::simplify::{
     full_resolution_fallback_count, simplify_for_level, Simplified, SimplifyOptions,
 };
-use super::writer::{LevelSpec, OverviewWriter, OverviewWriterOptions, LEVEL_COLUMN};
+use super::writer::{
+    LevelSpec, LevelWriteOutcome, OverviewWriter, OverviewWriterOptions, LEVEL_COLUMN,
+};
 
 /// Row-indexed winner-table sentinel for rows with no feature (null, empty,
 /// or non-finite geometry — skipped in pass 1). It matches no level in either
@@ -340,6 +345,18 @@ pub(crate) fn convert_streaming_strategy(
         }
     }
 
+    // Planned levels with no winners are omitted (§7.3, #211 auto-clamp);
+    // record them for the report + warning.
+    let mut skipped: Vec<SkippedLevelReport> = level_specs
+        .iter()
+        .enumerate()
+        .filter(|&(l, _)| counts[l] == 0)
+        .map(|(l, &(gsd, zoom))| SkippedLevelReport {
+            planned_level: l,
+            gsd,
+            zoom,
+        })
+        .collect();
     let emitted: Vec<EmitLevel> = level_specs
         .iter()
         .enumerate()
@@ -354,6 +371,7 @@ pub(crate) fn convert_streaming_strategy(
     if emitted.is_empty() {
         return Err(ConvertError::NoData);
     }
+    warn_plan_skipped_levels(&skipped, num_features, emitted[0].gsd, emitted[0].zoom);
 
     // --- Writer setup (identical to the in-memory path). ---------------------
     let geom_name = geom_field.name().clone();
@@ -464,8 +482,10 @@ pub(crate) fn convert_streaming_strategy(
     let n = emitted.len();
     let hints: Vec<usize> = emitted.iter().map(|e| e.hint).collect();
 
-    // `(rows, vertices)` per level, in level order.
-    let level_stats: Vec<(usize, usize)> = match strategy {
+    // `(outcome, rows, vertices)` per emitted level, in level order. The
+    // outcome distinguishes a written level from one the writer skipped because
+    // every candidate collapsed during simplification (#211).
+    let level_stats: Vec<(LevelWriteOutcome, usize, usize)> = match strategy {
         // Reference: one in-order re-read per level (pre-#213 behavior).
         Pass2Strategy::Serial => ctxs
             .iter()
@@ -515,18 +535,46 @@ pub(crate) fn convert_streaming_strategy(
         }
     };
 
+    // Build reports for the written levels; a level whose every candidate
+    // collapsed during simplification was skipped by the writer (#211) — record
+    // it as a write-time omission. The writer renumbers the physical `level`
+    // column, and `level_reports.len()` mirrors that contiguous written index.
     let mut level_reports = Vec::with_capacity(emitted.len());
-    for (i, e) in emitted.iter().enumerate() {
-        let (rows, vertices) = level_stats[i];
-        level_reports.push(LevelReport {
-            level: i,
-            gsd: e.gsd,
-            zoom: e.zoom,
-            feature_count: rows,
-            vertex_count: vertices,
-            uncompressed_bytes: 0,
-            compressed_bytes: 0,
-        });
+    for (e, (outcome, rows, vertices)) in emitted.iter().zip(level_stats) {
+        match outcome {
+            // #211: the winner table promised rows but simplification dropped
+            // every one (pathological geometry, e.g. a huge-bbox sliver). The
+            // writer skipped the level; record it like a plan-time omission.
+            LevelWriteOutcome::SkippedEmpty => {
+                log::warn!(
+                    "level planned at GSD {:.2} m{} became empty after simplification \
+                     (all {} candidate feature(s) collapsed); omitted from the output pyramid",
+                    e.gsd,
+                    e.zoom.map_or_else(String::new, |z| format!(" (zoom {z})")),
+                    e.hint,
+                );
+                skipped.push(SkippedLevelReport {
+                    planned_level: e.orig as usize,
+                    gsd: e.gsd,
+                    zoom: e.zoom,
+                });
+            }
+            LevelWriteOutcome::Written => level_reports.push(LevelReport {
+                level: level_reports.len(),
+                gsd: e.gsd,
+                zoom: e.zoom,
+                feature_count: rows,
+                vertex_count: vertices,
+                uncompressed_bytes: 0,
+                compressed_bytes: 0,
+            }),
+        }
+    }
+    skipped.sort_by_key(|s| s.planned_level);
+    if level_reports.is_empty() {
+        // Every emitted level collapsed at write time: no valid overview file
+        // can be produced (`levels` MUST be non-empty, §3.3).
+        return Err(ConvertError::NoData);
     }
 
     log::debug!(
@@ -549,6 +597,7 @@ pub(crate) fn convert_streaming_strategy(
     Ok(ConvertReport {
         mode: options.mode,
         levels: level_reports,
+        skipped_empty_levels: skipped,
         input_features: num_features,
         total_rows,
         total_vertices,
@@ -1107,8 +1156,9 @@ pub(super) struct LevelStreamCtx<'a> {
     coalesce_table: Option<&'a CoalesceTable>,
 }
 
-/// Stream one level from the input file into the writer. Returns
-/// `(rows_written, vertex_count)`.
+/// Stream one level from the input file into the writer. Returns the writer
+/// outcome (a level whose every candidate collapses during simplification is
+/// skipped, #211) plus `(rows_written, vertex_count)`.
 fn write_level_streaming(
     writer: &mut OverviewWriter<File>,
     level_idx: usize,
@@ -1117,7 +1167,7 @@ fn write_level_streaming(
     read_batch_size: usize,
     row_groups: Option<&[usize]>,
     ctx: &LevelStreamCtx<'_>,
-) -> Result<(usize, usize), ConvertError> {
+) -> Result<(LevelWriteOutcome, usize, usize), ConvertError> {
     let mut builder = source.open()?.with_batch_size(read_batch_size.max(1));
     // Regional extract (#102): read the same bbox-selected row groups as
     // pass 1, so the winner tables' global row indices line up.
@@ -1167,7 +1217,7 @@ fn write_level_streaming(
     if let Some(e) = err.borrow_mut().take() {
         return Err(e); // stream error takes precedence over the writer's
     }
-    res?;
+    let outcome = res?;
     let total = t_level.elapsed().as_secs_f64();
     let read_s = Pass2Timers::secs(&timers.read);
     let decode_s = Pass2Timers::secs(&timers.decode);
@@ -1193,7 +1243,7 @@ fn write_level_streaming(
              resolution (invalid RDP candidate after all epsilon retries)"
         );
     }
-    Ok((rows.get(), vertices.get()))
+    Ok((outcome, rows.get(), vertices.get()))
 }
 
 /// Process one input batch for one level: select the level's members from the

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -74,9 +74,9 @@ use super::convert::{
     build_source_schema, class_ranking_provenance, coalesce_effective, coalesce_level_chains,
     count_vertices, extract_class_ranks, extract_sort_keys, feature_kind, fill_level_bytes,
     find_geometry_column, geometry_bbox, mixed_geometry_field, overture_road_ranking,
-    usable_geometry, validate_cluster_schema, validate_coalesce_schema, warn_plan_skipped_levels,
-    ClassRanking, CoalesceTable, ConvertError, ConvertOptions, ConvertReport, GroupInterner,
-    LevelReport, SkippedLevelReport, KNOWN_ROAD_CLASSES, ROAD_VOCAB_MIN_DISTINCT,
+    record_level_outcome, usable_geometry, validate_cluster_schema, validate_coalesce_schema,
+    warn_plan_skipped_levels, ClassRanking, CoalesceTable, ConvertError, ConvertOptions,
+    ConvertReport, GroupInterner, SkippedLevelReport, KNOWN_ROAD_CLASSES, ROAD_VOCAB_MIN_DISTINCT,
 };
 use super::level::{Crs, Mode, RankingProvenance};
 use super::pipeline;
@@ -535,40 +535,26 @@ pub(crate) fn convert_streaming_strategy(
         }
     };
 
-    // Build reports for the written levels; a level whose every candidate
-    // collapsed during simplification was skipped by the writer (#211) — record
-    // it as a write-time omission. The writer renumbers the physical `level`
-    // column, and `level_reports.len()` mirrors that contiguous written index.
+    // Fold each emitted level's write outcome into the shared bookkeeping
+    // (#211): `record_level_outcome` appends a renumbered `LevelReport` for a
+    // written level, or — for a level the writer omitted because every
+    // candidate collapsed during simplification — warns and records the plan in
+    // `skipped`, exactly like a plan-time omission.
     let mut level_reports = Vec::with_capacity(emitted.len());
     for (e, (outcome, rows, vertices)) in emitted.iter().zip(level_stats) {
-        match outcome {
-            // #211: the winner table promised rows but simplification dropped
-            // every one (pathological geometry, e.g. a huge-bbox sliver). The
-            // writer skipped the level; record it like a plan-time omission.
-            LevelWriteOutcome::SkippedEmpty => {
-                log::warn!(
-                    "level planned at GSD {:.2} m{} became empty after simplification \
-                     (all {} candidate feature(s) collapsed); omitted from the output pyramid",
-                    e.gsd,
-                    e.zoom.map_or_else(String::new, |z| format!(" (zoom {z})")),
-                    e.hint,
-                );
-                skipped.push(SkippedLevelReport {
-                    planned_level: e.orig as usize,
-                    gsd: e.gsd,
-                    zoom: e.zoom,
-                });
-            }
-            LevelWriteOutcome::Written => level_reports.push(LevelReport {
-                level: level_reports.len(),
+        record_level_outcome(
+            outcome,
+            SkippedLevelReport {
+                planned_level: e.orig as usize,
                 gsd: e.gsd,
                 zoom: e.zoom,
-                feature_count: rows,
-                vertex_count: vertices,
-                uncompressed_bytes: 0,
-                compressed_bytes: 0,
-            }),
-        }
+            },
+            e.hint,
+            rows,
+            vertices,
+            &mut level_reports,
+            &mut skipped,
+        );
     }
     skipped.sort_by_key(|s| s.planned_level);
     if level_reports.is_empty() {

--- a/crates/core/src/overview/writer.rs
+++ b/crates/core/src/overview/writer.rs
@@ -974,15 +974,24 @@ mod tests {
         {
             let mut writer =
                 OverviewWriter::create(tmp.path(), &schema, duplicating_options()).unwrap();
-            let _ = writer
-                .write_level(0, None, std::iter::once(make_batch(&[0, 3])))
-                .unwrap();
-            let _ = writer
-                .write_level(1, None, std::iter::once(make_batch(&[0, 1, 3])))
-                .unwrap();
-            let _ = writer
-                .write_level(2, None, std::iter::once(make_batch(&[0, 1, 2, 3])))
-                .unwrap();
+            assert_eq!(
+                writer
+                    .write_level(0, None, std::iter::once(make_batch(&[0, 3])))
+                    .unwrap(),
+                LevelWriteOutcome::Written
+            );
+            assert_eq!(
+                writer
+                    .write_level(1, None, std::iter::once(make_batch(&[0, 1, 3])))
+                    .unwrap(),
+                LevelWriteOutcome::Written
+            );
+            assert_eq!(
+                writer
+                    .write_level(2, None, std::iter::once(make_batch(&[0, 1, 2, 3])))
+                    .unwrap(),
+                LevelWriteOutcome::Written
+            );
             writer.finish().unwrap();
         }
 
@@ -1038,19 +1047,28 @@ mod tests {
         let written_meta = {
             let mut writer =
                 OverviewWriter::create(tmp.path(), &schema, duplicating_options()).unwrap();
-            let _ = writer
-                .write_level(0, None, std::iter::once(source_batch(&schema, &level0_ids)))
-                .unwrap();
-            let _ = writer
-                .write_level(1, None, std::iter::once(source_batch(&schema, &level1_ids)))
-                .unwrap();
-            let _ = writer
-                .write_level(
-                    2,
-                    None,
-                    std::iter::once(source_batch(&schema, &canonical_ids)),
-                )
-                .unwrap();
+            assert_eq!(
+                writer
+                    .write_level(0, None, std::iter::once(source_batch(&schema, &level0_ids)))
+                    .unwrap(),
+                LevelWriteOutcome::Written
+            );
+            assert_eq!(
+                writer
+                    .write_level(1, None, std::iter::once(source_batch(&schema, &level1_ids)))
+                    .unwrap(),
+                LevelWriteOutcome::Written
+            );
+            assert_eq!(
+                writer
+                    .write_level(
+                        2,
+                        None,
+                        std::iter::once(source_batch(&schema, &canonical_ids)),
+                    )
+                    .unwrap(),
+                LevelWriteOutcome::Written
+            );
             writer.finish().unwrap()
         };
 
@@ -1213,12 +1231,18 @@ mod tests {
 
         let written_meta = {
             let mut writer = OverviewWriter::create(tmp.path(), &schema, opts).unwrap();
-            let _ = writer
-                .write_level(0, None, std::iter::once(source_batch(&schema, &[0, 2])))
-                .unwrap();
-            let _ = writer
-                .write_level(1, None, std::iter::once(source_batch(&schema, &[1, 3, 5])))
-                .unwrap();
+            assert_eq!(
+                writer
+                    .write_level(0, None, std::iter::once(source_batch(&schema, &[0, 2])))
+                    .unwrap(),
+                LevelWriteOutcome::Written
+            );
+            assert_eq!(
+                writer
+                    .write_level(1, None, std::iter::once(source_batch(&schema, &[1, 3, 5])))
+                    .unwrap(),
+                LevelWriteOutcome::Written
+            );
             writer.finish().unwrap()
         };
 
@@ -1260,9 +1284,12 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let mut writer =
             OverviewWriter::create(tmp.path(), &schema, duplicating_options()).unwrap();
-        let _ = writer
-            .write_level(0, None, std::iter::once(source_batch(&schema, &[0, 3])))
-            .unwrap();
+        assert_eq!(
+            writer
+                .write_level(0, None, std::iter::once(source_batch(&schema, &[0, 3])))
+                .unwrap(),
+            LevelWriteOutcome::Written
+        );
         let err = writer.finish().unwrap_err();
         assert!(matches!(
             err,
@@ -1307,22 +1334,28 @@ mod tests {
         let meta = {
             let mut writer = OverviewWriter::create(tmp.path(), &schema, opts).unwrap();
             // Level 0: 3 rows (<= cap 4) -> single row group.
-            let _ = writer
-                .write_level(
-                    0,
-                    Some(3),
-                    std::iter::once(source_batch(&schema, &[0, 1, 2])),
-                )
-                .unwrap();
+            assert_eq!(
+                writer
+                    .write_level(
+                        0,
+                        Some(3),
+                        std::iter::once(source_batch(&schema, &[0, 1, 2])),
+                    )
+                    .unwrap(),
+                LevelWriteOutcome::Written
+            );
             // Level 1: 10 rows (> cap 4) -> ceil(10/4)=3 uniform row groups.
             let ids: Vec<i64> = (0..10).collect();
-            let _ = writer
-                .write_level(
-                    1,
-                    Some(ids.len()),
-                    std::iter::once(source_batch(&schema, &ids)),
-                )
-                .unwrap();
+            assert_eq!(
+                writer
+                    .write_level(
+                        1,
+                        Some(ids.len()),
+                        std::iter::once(source_batch(&schema, &ids)),
+                    )
+                    .unwrap(),
+                LevelWriteOutcome::Written
+            );
             writer.finish().unwrap()
         };
 
@@ -1389,20 +1422,26 @@ mod tests {
         let ids: Vec<i64> = (0..10).collect();
         let meta = {
             let mut writer = OverviewWriter::create(tmp.path(), &schema, opts).unwrap();
-            let _ = writer
-                .write_level(
-                    0,
-                    Some(ids.len()),
-                    std::iter::once(source_batch(&schema, &ids)),
-                )
-                .unwrap();
-            let _ = writer
-                .write_level(
-                    1,
-                    Some(ids.len()),
-                    std::iter::once(source_batch(&schema, &ids)),
-                )
-                .unwrap();
+            assert_eq!(
+                writer
+                    .write_level(
+                        0,
+                        Some(ids.len()),
+                        std::iter::once(source_batch(&schema, &ids)),
+                    )
+                    .unwrap(),
+                LevelWriteOutcome::Written
+            );
+            assert_eq!(
+                writer
+                    .write_level(
+                        1,
+                        Some(ids.len()),
+                        std::iter::once(source_batch(&schema, &ids)),
+                    )
+                    .unwrap(),
+                LevelWriteOutcome::Written
+            );
             writer.finish().unwrap()
         };
 
@@ -1452,23 +1491,32 @@ mod tests {
         let mut opts = duplicating_options();
         opts.full_column_stats = full_column_stats;
         let mut writer = OverviewWriter::create(path, &schema, opts).unwrap();
-        let _ = writer
-            .write_level(0, Some(2), std::iter::once(source_batch(&schema, &[0, 3])))
-            .unwrap();
-        let _ = writer
-            .write_level(
-                1,
-                Some(3),
-                std::iter::once(source_batch(&schema, &[0, 1, 3])),
-            )
-            .unwrap();
-        let _ = writer
-            .write_level(
-                2,
-                Some(4),
-                std::iter::once(source_batch(&schema, &[0, 1, 2, 3])),
-            )
-            .unwrap();
+        assert_eq!(
+            writer
+                .write_level(0, Some(2), std::iter::once(source_batch(&schema, &[0, 3])))
+                .unwrap(),
+            LevelWriteOutcome::Written
+        );
+        assert_eq!(
+            writer
+                .write_level(
+                    1,
+                    Some(3),
+                    std::iter::once(source_batch(&schema, &[0, 1, 3])),
+                )
+                .unwrap(),
+            LevelWriteOutcome::Written
+        );
+        assert_eq!(
+            writer
+                .write_level(
+                    2,
+                    Some(4),
+                    std::iter::once(source_batch(&schema, &[0, 1, 2, 3])),
+                )
+                .unwrap(),
+            LevelWriteOutcome::Written
+        );
         writer.finish().unwrap();
     }
 

--- a/crates/core/src/overview/writer.rs
+++ b/crates/core/src/overview/writer.rs
@@ -174,11 +174,15 @@ pub enum WriterError {
         /// Index the caller passed.
         got: usize,
     },
-    /// A level produced no row groups (empty level; §7.3).
-    #[error("level {level} is empty (produced no rows / row groups)")]
-    EmptyLevel {
-        /// The offending level index.
-        level: usize,
+    /// Every declared level was empty: nothing was written, so no valid
+    /// overview file can be produced (`levels` MUST be non-empty, §3.3).
+    #[error(
+        "all {expected} declared level(s) were empty — no output rows at any \
+         level (empty input, or every feature dropped at every scale)"
+    )]
+    AllLevelsEmpty {
+        /// Levels declared in the options.
+        expected: usize,
     },
     /// `finish` was called before all declared levels were written.
     #[error("finish called with {written} of {expected} levels written")]
@@ -188,6 +192,24 @@ pub enum WriterError {
         /// Levels declared in the options.
         expected: usize,
     },
+}
+
+/// Outcome of one [`OverviewWriter::write_level`] call.
+///
+/// A level whose batch stream yields zero rows is **omitted** from the output
+/// (and later levels are renumbered) rather than treated as an error: spec
+/// §7.3 forbids empty levels and requires the writer to omit-and-renumber.
+/// Callers use the outcome to keep their own level bookkeeping (reports,
+/// warnings) aligned with the physical file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[must_use = "an empty level is silently omitted; callers must renumber their own bookkeeping"]
+pub enum LevelWriteOutcome {
+    /// The level produced rows and was written (at least one row group).
+    Written,
+    /// The level produced no rows: nothing was written, the declared spec is
+    /// dropped from the footer, and subsequent levels shift down by one
+    /// physical index (§7.3).
+    SkippedEmpty,
 }
 
 /// A level-banded GeoParquet overview writer.
@@ -203,8 +225,12 @@ pub struct OverviewWriter<W: Write + Send> {
     /// bbox-covering struct columns whose name collides with the covering the
     /// encoder will generate (§4.4). See [`Self::try_new`].
     drop_indices: Vec<usize>,
-    /// `row_group_end` recorded for each completed level.
+    /// `row_group_end` recorded for each completed (non-empty) level.
     level_row_group_ends: Vec<i64>,
+    /// For each completed level, the index of its declared
+    /// [`LevelSpec`](OverviewWriterOptions::levels). Diverges from the
+    /// physical index once an empty level is skipped (§7.3).
+    written_spec_indices: Vec<usize>,
     /// Index of the next level expected by [`Self::write_level`].
     next_level_idx: usize,
 }
@@ -305,6 +331,7 @@ impl<W: Write + Send> OverviewWriter<W> {
             options,
             drop_indices,
             level_row_group_ends: Vec::new(),
+            written_spec_indices: Vec::new(),
             next_level_idx: 0,
         })
     }
@@ -330,12 +357,18 @@ impl<W: Write + Send> OverviewWriter<W> {
     /// splitting every `max_row_group_size` rows. Either way the level ends
     /// exactly on a row-group boundary and never shares a row group with another
     /// level (§4.2) — the RG-boundary-per-level invariant is exact.
+    ///
+    /// A level whose batches yield **zero rows** is skipped, not an error
+    /// (§7.3): nothing is written, the declared spec is dropped from the
+    /// footer, and subsequent levels are renumbered down by one physical
+    /// index (their `level` column values stay contiguous from 0). The
+    /// returned [`LevelWriteOutcome`] tells the caller which case occurred.
     pub fn write_level(
         &mut self,
         level_idx: usize,
         level_row_hint: Option<usize>,
         batches: impl Iterator<Item = RecordBatch>,
-    ) -> Result<(), WriterError> {
+    ) -> Result<LevelWriteOutcome, WriterError> {
         if level_idx != self.next_level_idx {
             return Err(WriterError::LevelOutOfOrder {
                 expected: self.next_level_idx,
@@ -360,9 +393,14 @@ impl<W: Write + Send> OverviewWriter<W> {
         // Rows accumulated into the current (not-yet-flushed) row group.
         let mut in_rg: usize = 0;
 
+        // The PHYSICAL level index this level will occupy in the output file:
+        // the count of levels actually written so far. It trails `level_idx`
+        // once an empty level has been skipped (§7.3 renumbering).
+        let physical_idx = self.level_row_group_ends.len();
+
         for batch in batches {
             let num_rows = batch.num_rows();
-            let level_array = Int32Array::from(vec![level_idx as i32; num_rows]);
+            let level_array = Int32Array::from(vec![physical_idx as i32; num_rows]);
 
             // Drop the colliding covering column(s) (§4.4), then append `level`.
             let mut columns: Vec<_> = batch
@@ -405,12 +443,17 @@ impl<W: Write + Send> OverviewWriter<W> {
 
         let rg_after = self.writer.flushed_row_groups().len();
         if rg_after <= rg_before {
-            return Err(WriterError::EmptyLevel { level: level_idx });
+            // Empty level: omit it entirely and renumber (§7.3). No rows were
+            // written (a partial row group would have been flushed above), so
+            // the file carries no trace of it; only the bookkeeping moves on.
+            self.next_level_idx += 1;
+            return Ok(LevelWriteOutcome::SkippedEmpty);
         }
 
         self.level_row_group_ends.push(rg_after as i64 - 1);
+        self.written_spec_indices.push(level_idx);
         self.next_level_idx += 1;
-        Ok(())
+        Ok(LevelWriteOutcome::Written)
     }
 
     /// Finalize the file: write the `geo` and `geo:overviews` footer keys (plus
@@ -420,6 +463,15 @@ impl<W: Write + Send> OverviewWriter<W> {
         if self.next_level_idx != self.options.levels.len() {
             return Err(WriterError::IncompleteLevels {
                 written: self.next_level_idx,
+                expected: self.options.levels.len(),
+            });
+        }
+
+        // Every level may legally be skipped-as-empty individually, but a
+        // file with NO levels is invalid (`levels` MUST be non-empty, §3.3):
+        // fail with an actionable error instead of writing garbage.
+        if self.level_row_group_ends.is_empty() {
+            return Err(WriterError::AllLevelsEmpty {
                 expected: self.options.levels.len(),
             });
         }
@@ -454,28 +506,46 @@ impl<W: Write + Send> OverviewWriter<W> {
     }
 
     fn build_meta(&self) -> OverviewsMeta {
+        // Only the levels actually written appear in the footer; skipped
+        // (empty) levels drop their declared spec too, keeping `levels`,
+        // `row_group_end`, and the physical `level` column aligned (§7.3).
         let levels: Vec<Level> = self
             .level_row_group_ends
             .iter()
-            .zip(self.options.levels.iter())
-            .map(|(&row_group_end, spec)| Level {
+            .zip(self.written_spec_indices.iter())
+            .map(|(&row_group_end, &spec_idx)| Level {
                 row_group_end,
-                gsd: spec.gsd,
-                zoom: spec.zoom,
+                gsd: self.options.levels[spec_idx].gsd,
+                zoom: self.options.levels[spec_idx].zoom,
             })
             .collect();
 
         let canonical_level = match self.options.mode {
-            Mode::Duplicating => Some(self.options.levels.len() as i64 - 1),
+            Mode::Duplicating => Some(levels.len() as i64 - 1),
             Mode::Partitioning => None,
         };
+
+        // The provenance `levels` array is parallel to the top-level `levels`
+        // (§3.5): drop the skipped entries there as well.
+        let generalization = self.options.generalization.clone().map(|mut g| {
+            if g.levels.len() == self.options.levels.len()
+                && self.written_spec_indices.len() != self.options.levels.len()
+            {
+                g.levels = self
+                    .written_spec_indices
+                    .iter()
+                    .map(|&i| g.levels[i].clone())
+                    .collect();
+            }
+            g
+        });
 
         OverviewsMeta {
             version: self.options.version.clone(),
             mode: Some(self.options.mode),
             canonical_level,
             levels,
-            generalization: self.options.generalization.clone(),
+            generalization,
         }
     }
 }
@@ -785,6 +855,68 @@ mod tests {
     }
 
     #[test]
+    fn empty_level_is_skipped_and_renumbered() {
+        let schema = Arc::new(source_schema());
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let mut writer =
+            OverviewWriter::create(tmp.path(), &schema, duplicating_options()).unwrap();
+
+        // Level 0 (z2) yields no rows: skipped, not an error (§7.3, #211).
+        let outcome = writer
+            .write_level(0, Some(0), std::iter::empty::<RecordBatch>())
+            .unwrap();
+        assert_eq!(outcome, LevelWriteOutcome::SkippedEmpty);
+        assert_eq!(
+            writer
+                .write_level(1, None, std::iter::once(source_batch(&schema, &[0, 1])))
+                .unwrap(),
+            LevelWriteOutcome::Written
+        );
+        assert_eq!(
+            writer
+                .write_level(
+                    2,
+                    None,
+                    std::iter::once(source_batch(&schema, &[0, 1, 2, 3]))
+                )
+                .unwrap(),
+            LevelWriteOutcome::Written
+        );
+        let meta = writer.finish().unwrap();
+
+        // Footer: two levels carrying the z4/z6 specs; canonical renumbered.
+        assert_eq!(meta.levels.len(), 2);
+        assert_eq!(meta.levels[0].zoom, Some(4));
+        assert_eq!(meta.levels[1].zoom, Some(6));
+        assert_eq!(meta.levels[0].gsd, gsd(4));
+        assert_eq!(meta.levels[1].gsd, gsd(6));
+        assert_eq!(meta.canonical_level, Some(1));
+
+        // The physical `level` column is renumbered contiguously from 0.
+        assert_eq!(read_level_column(tmp.path(), 0), vec![0, 0]);
+        assert_eq!(read_level_column(tmp.path(), 1), vec![1, 1, 1, 1]);
+    }
+
+    #[test]
+    fn finish_with_all_levels_empty_errors() {
+        let schema = Arc::new(source_schema());
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let mut writer =
+            OverviewWriter::create(tmp.path(), &schema, duplicating_options()).unwrap();
+        for level in 0..3 {
+            let outcome = writer
+                .write_level(level, Some(0), std::iter::empty::<RecordBatch>())
+                .unwrap();
+            assert_eq!(outcome, LevelWriteOutcome::SkippedEmpty);
+        }
+        let err = writer.finish().unwrap_err();
+        assert!(
+            matches!(err, WriterError::AllLevelsEmpty { expected: 3 }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
     fn preexisting_bbox_covering_is_not_duplicated() {
         use arrow_array::{Float64Array, StructArray};
         use arrow_schema::Fields;
@@ -842,13 +974,13 @@ mod tests {
         {
             let mut writer =
                 OverviewWriter::create(tmp.path(), &schema, duplicating_options()).unwrap();
-            writer
+            let _ = writer
                 .write_level(0, None, std::iter::once(make_batch(&[0, 3])))
                 .unwrap();
-            writer
+            let _ = writer
                 .write_level(1, None, std::iter::once(make_batch(&[0, 1, 3])))
                 .unwrap();
-            writer
+            let _ = writer
                 .write_level(2, None, std::iter::once(make_batch(&[0, 1, 2, 3])))
                 .unwrap();
             writer.finish().unwrap();
@@ -906,13 +1038,13 @@ mod tests {
         let written_meta = {
             let mut writer =
                 OverviewWriter::create(tmp.path(), &schema, duplicating_options()).unwrap();
-            writer
+            let _ = writer
                 .write_level(0, None, std::iter::once(source_batch(&schema, &level0_ids)))
                 .unwrap();
-            writer
+            let _ = writer
                 .write_level(1, None, std::iter::once(source_batch(&schema, &level1_ids)))
                 .unwrap();
-            writer
+            let _ = writer
                 .write_level(
                     2,
                     None,
@@ -1081,10 +1213,10 @@ mod tests {
 
         let written_meta = {
             let mut writer = OverviewWriter::create(tmp.path(), &schema, opts).unwrap();
-            writer
+            let _ = writer
                 .write_level(0, None, std::iter::once(source_batch(&schema, &[0, 2])))
                 .unwrap();
-            writer
+            let _ = writer
                 .write_level(1, None, std::iter::once(source_batch(&schema, &[1, 3, 5])))
                 .unwrap();
             writer.finish().unwrap()
@@ -1128,7 +1260,7 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let mut writer =
             OverviewWriter::create(tmp.path(), &schema, duplicating_options()).unwrap();
-        writer
+        let _ = writer
             .write_level(0, None, std::iter::once(source_batch(&schema, &[0, 3])))
             .unwrap();
         let err = writer.finish().unwrap_err();
@@ -1175,7 +1307,7 @@ mod tests {
         let meta = {
             let mut writer = OverviewWriter::create(tmp.path(), &schema, opts).unwrap();
             // Level 0: 3 rows (<= cap 4) -> single row group.
-            writer
+            let _ = writer
                 .write_level(
                     0,
                     Some(3),
@@ -1184,7 +1316,7 @@ mod tests {
                 .unwrap();
             // Level 1: 10 rows (> cap 4) -> ceil(10/4)=3 uniform row groups.
             let ids: Vec<i64> = (0..10).collect();
-            writer
+            let _ = writer
                 .write_level(
                     1,
                     Some(ids.len()),
@@ -1257,14 +1389,14 @@ mod tests {
         let ids: Vec<i64> = (0..10).collect();
         let meta = {
             let mut writer = OverviewWriter::create(tmp.path(), &schema, opts).unwrap();
-            writer
+            let _ = writer
                 .write_level(
                     0,
                     Some(ids.len()),
                     std::iter::once(source_batch(&schema, &ids)),
                 )
                 .unwrap();
-            writer
+            let _ = writer
                 .write_level(
                     1,
                     Some(ids.len()),
@@ -1320,17 +1452,17 @@ mod tests {
         let mut opts = duplicating_options();
         opts.full_column_stats = full_column_stats;
         let mut writer = OverviewWriter::create(path, &schema, opts).unwrap();
-        writer
+        let _ = writer
             .write_level(0, Some(2), std::iter::once(source_batch(&schema, &[0, 3])))
             .unwrap();
-        writer
+        let _ = writer
             .write_level(
                 1,
                 Some(3),
                 std::iter::once(source_batch(&schema, &[0, 1, 3])),
             )
             .unwrap();
-        writer
+        let _ = writer
             .write_level(
                 2,
                 Some(4),

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -165,6 +165,15 @@ fn convert_report_to_dict(py: Python<'_>, report: &ConvertReport) -> PyResult<Py
         levels.append(d)?;
     }
     dict.set_item("levels", levels)?;
+    let skipped = PyList::empty(py);
+    for s in &report.skipped_empty_levels {
+        let d = PyDict::new(py);
+        d.set_item("planned_level", s.planned_level)?;
+        d.set_item("gsd", s.gsd)?;
+        d.set_item("zoom", s.zoom)?;
+        skipped.append(d)?;
+    }
+    dict.set_item("skipped_empty_levels", skipped)?;
     dict.set_item("input_features", report.input_features)?;
     dict.set_item("total_rows", report.total_rows)?;
     dict.set_item("total_vertices", report.total_vertices)?;
@@ -305,7 +314,10 @@ fn convert_report_to_dict(py: Python<'_>, report: &ConvertReport) -> PyResult<Py
 /// Returns:
 ///     dict: Conversion report with keys "mode", "levels" (list of dicts with
 ///     "level", "gsd", "zoom", "feature_count", "vertex_count",
-///     "uncompressed_bytes", "compressed_bytes"), "input_features",
+///     "uncompressed_bytes", "compressed_bytes"), "skipped_empty_levels"
+///     (list of dicts with "planned_level", "gsd", "zoom": planned levels
+///     omitted because no feature is visible at their scale — the written
+///     pyramid is auto-clamped to the non-empty levels), "input_features",
 ///     "total_rows", "total_vertices", "total_compressed_bytes",
 ///     "row_groups_total", "row_groups_read", "duration_secs", and
 ///     "remote_fetch" (None for local inputs; for remote URLs a dict with

--- a/crates/python/tests/test_overview.py
+++ b/crates/python/tests/test_overview.py
@@ -210,20 +210,23 @@ class TestOverviewIntegration:
                 assert lvl["vertex_count"] >= 0
             assert report["levels"][-1]["zoom"] == 6
             assert report["levels"][-1]["feature_count"] == report["input_features"]
-            # Auto-clamp accounting (#211): written + skipped == planned (z0..z6),
-            # and every skipped entry names its planned level, GSD, and zoom.
-            skipped = report["skipped_empty_levels"]
-            assert len(report["levels"]) + len(skipped) == 7
-            for entry in skipped:
-                assert 0 <= entry["planned_level"] < 7
-                assert entry["gsd"] > 0
-                assert entry["zoom"] == entry["planned_level"]
 
             # Output must pass the spec conformance checklist.
             result = gpq_tiles.validate(str(out))
             assert result["valid"] is True
             assert len(result["checks"]) > 0
             assert all(c["passed"] for c in result["checks"])
+
+    def test_overview_report_clamp_accounting(self):
+        """Auto-clamp accounting (#211): written + skipped == planned (z0..z6),
+        and every skipped entry names its planned level, GSD, and zoom."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _, report = self._overview(tmpdir)
+            skipped = report["skipped_empty_levels"]
+            assert len(report["levels"]) + len(skipped) == 7
+            assert all(0 <= s["planned_level"] < 7 for s in skipped)
+            assert all(s["gsd"] > 0 for s in skipped)
+            assert all(s["zoom"] == s["planned_level"] for s in skipped)
 
     def test_overview_zoom_range(self):
         """Fine zooms suit the small building footprints: all levels survive."""

--- a/crates/python/tests/test_overview.py
+++ b/crates/python/tests/test_overview.py
@@ -210,6 +210,14 @@ class TestOverviewIntegration:
                 assert lvl["vertex_count"] >= 0
             assert report["levels"][-1]["zoom"] == 6
             assert report["levels"][-1]["feature_count"] == report["input_features"]
+            # Auto-clamp accounting (#211): written + skipped == planned (z0..z6),
+            # and every skipped entry names its planned level, GSD, and zoom.
+            skipped = report["skipped_empty_levels"]
+            assert len(report["levels"]) + len(skipped) == 7
+            for entry in skipped:
+                assert 0 <= entry["planned_level"] < 7
+                assert entry["gsd"] > 0
+                assert entry["zoom"] == entry["planned_level"]
 
             # Output must pass the spec conformance checklist.
             result = gpq_tiles.validate(str(out))

--- a/docs/OVERVIEW_TUNING.md
+++ b/docs/OVERVIEW_TUNING.md
@@ -137,6 +137,34 @@ level coarser purely because the GSD (and therefore the gate) doubled. This is a
 *hard drop*, distinct from thinning's *one-per-cell* competition: a feature can
 be gated out even if its cell is otherwise empty.
 
+### Empty coarse levels: the auto-clamp
+
+When **every** feature is culled at a coarse level — the normal outcome for
+datasets of small features at world zooms (e.g. country-scale buildings with
+`--min-zoom 0`: no building's bbox clears `4 × gsd(z0)` ≈ 156 km) — that level
+is **omitted from the output and the remaining levels are renumbered** (spec
+§7.3), instead of failing the conversion. You will see a `WARN` like:
+
+```
+omitting 4 empty level(s) [0, 1, 2, 3] spanning GSD 39135.76–4891.97 m: none of
+the 59032924 input feature(s) are visible at those scales (visibility gates /
+density budget); the output pyramid starts at GSD 2445.98 m (zoom 4)
+```
+
+plus a `note:` line under the CLI level table, and the omitted levels are
+recorded in the report's `skipped_empty_levels` (planned level index, GSD,
+zoom) — the written `levels` array is the effective range. The same clamp
+applies when a level empties late, during simplification (a pathological
+feature whose bbox clears the gate but whose geometry collapses below the
+level tolerance). PMTiles export of a clamped file starts at the coarsest
+*written* level's zoom.
+
+This is expected behavior, not data loss: the features are simply not
+representable at those scales. To *force* coarse levels to be populated,
+lower the gates (`--polygon-visibility` / `--line-visibility`) or coarsen the
+ladder (`--gsd-base`). If **no** level has any rows at all (empty input, or an
+empty `--bbox` selection), the conversion still fails with a hard error.
+
 ---
 
 ## Per-feature simplification: `--simplify-factor`


### PR DESCRIPTION
Closes #211

## Problem

`gpq-tiles overview --mode duplicating --min-zoom 0 --max-zoom 14` on Overture Germany buildings (59,032,924 features, 6.99 GB) failed after ~76 s with:

```
Error: overview conversion failed: writer error: level 0 is empty (produced no rows / row groups)
```

Root cause (confirmed on the real data): the streaming pipeline already omitted plan-time-empty levels (z0–z2 here), but the winner table said z3–z5 each had **one** candidate — a pathological huge-bbox feature that passes the assign visibility gate (whole-feature bbox diagonal) and then collapses during per-level simplification. Pass 2 then wrote zero rows for the level and the writer's `EmptyLevel` invariant took the whole conversion down.

## Fix (Option 1 from the issue: auto-clamp)

- **Writer** (`writer.rs`): `write_level` now returns `LevelWriteOutcome::{Written, SkippedEmpty}`. An empty level is omitted and everything renumbers per spec §7.3: physical `level` column values stay contiguous from 0, the skipped `LevelSpec` is dropped from the footer, `canonical_level` tracks the written count, and the `generalization.levels` provenance array is filtered in parallel. `finish()` hard-errors with the new `WriterError::AllLevelsEmpty` if **no** level was written (`levels` MUST be non-empty, §3.3).
- **Both pipelines, both modes**: plan-time skips (in-memory `convert.rs` + streaming `stream.rs`, duplicating + partitioning) and write-time skips (streaming pass 2) are recorded identically.
- **Report**: new `ConvertReport::skipped_empty_levels` (`planned_level`, `gsd`, `zoom`), flowing into the CLI `--report` JSON automatically, a human-readable `note:` line under the CLI level table, and the Python report dict (docstring updated; `.pyi` unchanged — the return type is `dict[str, Any]` and no signature changed).
- **WARN logs**: one summary WARN for the plan-time-empty coarse prefix (levels, GSD span, feature count, where the pyramid starts) and one per write-time collapse.
- **Degenerate extreme**: zero output rows anywhere is still a hard error (`ConvertError::NoData` / `WriterError::AllLevelsEmpty`), with actionable messages.

## Spec decision

`context/OVERVIEWS_SPEC.md` §7.3 already **mandates** omit-or-merge + renumbering for empty levels — the old write-time hard error was the spec violation, not the clamp. §3.3 puts no floor on the coarsest level's zoom/GSD (the §3.6 example already starts at z2). Added one clarifying bullet to §7.3: empty coarse levels are expected and normal; readers MUST NOT assume level 0 corresponds to any particular zoom/GSD.

## Tests (TDD)

Red first (`write_time_empty_level_skipped_streaming` reproduced the exact `Writer(EmptyLevel)` failure), then green:

- `overview::convert::tests::write_time_empty_level_skipped_streaming` — #211 regression (huge-bbox MultiPolygon that passes the gate and collapses in simplify)
- `overview::convert::tests::empty_coarse_levels_clamped_{duplicating,partitioning}_{memory,streaming}` — 4 variants: clamp, report contents, `validate_file` clean, PMTiles export starts at the clamped zoom
- `overview::convert::tests::all_levels_empty_is_hard_error` — both pipelines, `ConvertError::NoData`
- `overview::writer::tests::empty_level_is_skipped_and_renumbered` — footer specs, `level` column renumbering, `canonical_level`
- `overview::writer::tests::finish_with_all_levels_empty_errors` — `AllLevelsEmpty`
- Python: `test_overview_defaults_and_report` extended with clamp accounting (written + skipped == planned)

Also green: `overview::convert::` (51), `overview::writer::` (15), `overview::check::` (20), `overview::export::` (11), `overview::hostile::` (30), streaming-parity tests, `cargo clippy --workspace --all-targets -- -D warnings`.

## Real-repro validation

Machine note: run in the foreground under a ~10-minute shell limit, so the zoom range was reduced from the issue's `--max-zoom 14` to `--max-zoom 6` — the empty coarse levels (the bug's subject) are identical in either range; deep zooms only add pass-2 scans.

```
/usr/bin/time -v gpq-tiles overview \
  corpus/data/bigbench/gpio/overture-germany-buildings.parquet out.parquet \
  --mode duplicating --min-zoom 0 --max-zoom 6 --report report.json
```

- **Before this fix** the same file failed at ~1:16 with `level 0 is empty`.
- **Now**: exit 0, wall **3:06.38**, peak RSS **8.47 GB**, 59,032,924 in → 59,032,924 rows.
- **Effective level range**: planned z0–z6 → written pyramid is a single canonical level at **z6** (GSD 611.50 m). `skipped_empty_levels` records z0–z2 (plan-time: no feature passes the 4×GSD polygon gate) **and** z3–z5 (write-time: exactly 1 pathological candidate per level collapsed during simplification — the precise #211 mechanism, observed in the wild).
- `gpq-tiles validate` on the clamped output: **12/12 checks pass**.

## Docs

- `docs/OVERVIEW_TUNING.md`: new "Empty coarse levels: the auto-clamp" subsection (when you'll see it, the WARN/report surface, how to force coarse levels instead).
- `context/OVERVIEWS_SPEC.md` §7.3 clarifying bullet (above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)