### PR TITLE
feat: remote input support — convert directly from s3://, https://, gs:// (object_store)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,17 @@
+# cargo-audit configuration — keep in sync with deny.toml's
+# [advisories].ignore list (cargo-audit does not read deny.toml).
+# CI: Security Audit job runs `cargo audit` AND `cargo deny check`;
+# an exception must be recorded in BOTH files, with the full
+# justification living in deny.toml next to the entry.
+
+[advisories]
+ignore = [
+    # quick-xml < 0.41 XML-parsing DoS pathologies; transitive via
+    # object_store's S3/GCS support (remote input, #210). quick-xml there
+    # only parses XML responses from the configured storage endpoint, not
+    # attacker-supplied documents. No object_store release reaches the
+    # quick-xml >=0.41 fix (0.14.0 pins ^0.40.1). See deny.toml for the
+    # full rationale; re-evaluate on object_store bump.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
+]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Fast GeoParquet → PMTiles converter in Rust.
 - One-shot GeoParquet → PMTiles (`gpq-tiles tiles`, or the bare form)
 - Quality ladder tuned against tippecanoe: class ranking (Overture auto-detect), visibility gates, density budget, point clustering, line coalescing
 - Memory-bounded streaming conversion (632k-polygon / 38M-vertex file: ~55 s, ~320 MB peak RSS)
+- Remote inputs (`s3://`, `https://`, `gs://`) read via byte-range requests — with `--bbox`, extract a city from a remote country-scale file while downloading only the matching row groups ([Remote Reads](docs/remote-reads.md))
 - Spec validation (`gpq-tiles validate`)
 - PMTiles → GeoParquet decoding (`gpq-tiles decode`) — tippecanoe-decode
   semantics, any PMTiles v3 MVT archive
@@ -98,7 +99,7 @@ convert("input.parquet", "output.pmtiles", min_zoom=0, max_zoom=14)
 - **[Decoding PMTiles](docs/decode.md)** — PMTiles → GeoParquet, limitations included
 - **[API Reference](docs/api-reference.md)** — CLI flags, Python API, Rust API
 - **[Advanced Usage](docs/advanced-usage.md)** — Input optimization, memory, remote reads, CI/CD
-- **[Remote Reads](docs/remote-reads.md)** — Querying overview files on object storage with DuckDB
+- **[Remote Reads](docs/remote-reads.md)** — Converting directly from s3://, https://, gs:// inputs, and querying overview files in place with DuckDB
 - **[Format Spec (draft)](context/OVERVIEWS_SPEC.md)** — The `geo:overviews` format contract
 
 ## Development

--- a/context/ARCHITECTURE.md
+++ b/context/ARCHITECTURE.md
@@ -217,6 +217,8 @@ crates/core/src/
 │   ├── simplify.rs     #   World-space RDP simplification (GSD tolerance)
 │   ├── stream.rs       #   Two-pass bounded-memory streaming pipeline
 │   └── writer.rs       #   Level-banded GeoParquet writer
+├── input.rs            # Input source abstraction: local file or remote
+│                       # object (s3/https/gs) via byte-range reads (#210)
 ├── batch_processor.rs  # GeoArrow batch → geo::Geometry decoding
 ├── clip.rs             # Geometry clipping (dispatcher)
 ├── ioverlay_clip.rs    # i_overlay-based robust polygon clipping

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,7 +21,7 @@ name = "gpq-tiles"
 path = "src/main.rs"
 
 [dependencies]
-gpq-tiles-core = { workspace = true }
+gpq-tiles-core = { workspace = true, features = ["remote"] }
 clap = { workspace = true }
 anyhow = { workspace = true }
 env_logger = { workspace = true }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -178,7 +178,10 @@ struct ExportPmtilesArgs {
 /// Arguments for `gpq-tiles overview`.
 #[derive(Parser, Debug)]
 struct OverviewArgs {
-    /// Input GeoParquet file (EPSG:4326 or EPSG:3857).
+    /// Input GeoParquet file (EPSG:4326 or EPSG:3857): a local path or a
+    /// remote URL (s3://, https://, gs://). Remote inputs are read with
+    /// byte-range requests; with --bbox, only the matching row groups are
+    /// ever downloaded.
     #[arg(value_name = "INPUT")]
     input: PathBuf,
 
@@ -533,7 +536,9 @@ struct ValidateArgs {
 /// to run was removed (see issue #177).
 #[derive(Parser, Debug)]
 struct TilesArgs {
-    /// Input GeoParquet file (EPSG:4326 or EPSG:3857).
+    /// Input GeoParquet file (EPSG:4326 or EPSG:3857): a local path or a
+    /// remote URL (s3://, https://, gs://); remote inputs are read with
+    /// byte-range requests.
     #[arg(value_name = "INPUT")]
     input: PathBuf,
 
@@ -1007,10 +1012,27 @@ fn run_validate(args: ValidateArgs) -> Result<()> {
     }
 }
 
+/// Remote (URL) inputs are supported only where the converter reads them
+/// (`overview`, `tiles`); give the other subcommands a helpful error
+/// instead of a confusing `No such file or directory`.
+fn reject_remote_input(input: &std::path::Path, subcommand: &str) -> Result<()> {
+    if input.to_str().is_some_and(|s| s.contains("://")) {
+        anyhow::bail!(
+            "`gpq-tiles {subcommand}` does not support remote inputs (got {}); \
+             remote URLs (s3://, https://, gs://) are supported by the `overview` \
+             and `tiles` subcommands — download the file first (e.g. `aws s3 cp`)",
+            input.display()
+        );
+    }
+    Ok(())
+}
+
 fn run_export_pmtiles(args: ExportPmtilesArgs) -> Result<()> {
     use gpq_tiles_core::overview::export::{export_pmtiles, ExportOptions};
 
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    reject_remote_input(&args.input, "export-pmtiles")?;
 
     let opts = ExportOptions {
         layer_name: args.layer_name,
@@ -1069,6 +1091,8 @@ fn run_decode(args: DecodeArgs) -> Result<()> {
     use gpq_tiles_core::decode::{decode_pmtiles, DecodeOptions};
 
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    reject_remote_input(&args.input, "decode")?;
 
     // `--zoom N` is shorthand for `--min-zoom N --max-zoom N` (clap already
     // rejects combining them).

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,6 +15,17 @@ categories.workspace = true
 [features]
 default = []
 dhat-heap = ["dhat"]
+# Remote input support: read GeoParquet directly from s3://, https://,
+# and gs:// URLs via range requests (issue #210). Off by default to keep
+# the pure-local library build dependency-light; the CLI enables it.
+remote = [
+    "dep:object_store",
+    "dep:tokio",
+    "dep:aws-config",
+    "dep:aws-credential-types",
+    "dep:async-trait",
+    "dep:url",
+]
 
 [dependencies]
 dhat = { version = "0.3", optional = true }
@@ -41,6 +52,13 @@ serde = { workspace = true }
 serde_json = "1"
 i_overlay = "7"
 tempfile = "3"
+object_store = { version = "0.12", features = ["aws", "gcp", "http"], optional = true }
+tokio = { version = "1", default-features = false, features = ["rt-multi-thread"], optional = true }
+aws-config = { version = "1", optional = true }
+aws-credential-types = { version = "1", optional = true }
+async-trait = { version = "0.1", optional = true }
+url = { version = "2", optional = true }
+bytes = "1"
 
 [build-dependencies]
 prost-build = { workspace = true }

--- a/crates/core/src/input.rs
+++ b/crates/core/src/input.rs
@@ -1,0 +1,959 @@
+//! Input-source abstraction: local files or remote objects (issue #210).
+//!
+//! The overview converter historically opened its input with
+//! [`std::fs::File`]. This module generalizes that to an [`InputSource`]
+//! that can also point at an object in remote storage (`s3://`, `https://`,
+//! `http://`, `gs://`), served to the existing *synchronous* parquet reader
+//! plumbing through the [`parquet::file::reader::ChunkReader`] trait:
+//!
+//! - the parquet footer is fetched with range requests,
+//! - each column chunk of each *selected* row group is fetched as ONE byte
+//!   range, the first time the sync reader touches it (the buffered
+//!   range-fetch adapter: the page reader's many small header/page reads
+//!   are served from the whole-chunk buffer).
+//!
+//! Fetches never extend past a column chunk **by design**: only chunks the
+//! parquet reader actually touches are requested. This is what makes the
+//! composition with `--bbox` row-group pruning (#102 / PR #207) the headline
+//! feature — pruned row groups are never requested at all, so a city-scale
+//! extract from a country-scale remote file moves only a fraction of the
+//! object's bytes. [`InputSource::fetch_stats`] exposes request/byte
+//! counters so callers (and tests) can verify that property.
+//!
+//! The streaming pipeline re-reads the input once per pass/level. Each
+//! [`InputSource::open`] of a remote source reuses a cached parsed footer,
+//! and fetched column chunks stay in a bounded LRU-ish cache
+//! ([`remote::CHUNK_CACHE_MAX_BYTES`], insertion-order eviction), so those
+//! re-reads are refetch-free while the selected data fits the cache. See
+//! `docs/remote-reads.md` for the fetch-count implications.
+//!
+//! Remote support is compiled behind the `remote` cargo feature; the CLI and
+//! Python bindings enable it by default. Without the feature, URL inputs
+//! fail with a clear [`InputError::RemoteDisabled`] error.
+
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use bytes::Bytes;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::errors::ParquetError;
+use parquet::file::reader::{ChunkReader, Length};
+use serde::Serialize;
+
+/// Schemes recognized as remote inputs (when the `remote` feature is on).
+const REMOTE_SCHEMES: &[&str] = &["s3", "s3a", "http", "https", "gs"];
+
+/// Errors from opening or reading an [`InputSource`].
+#[derive(Debug, thiserror::Error)]
+pub enum InputError {
+    /// Local I/O error.
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    /// Parquet error (footer parse, reader construction).
+    #[error("parquet error: {0}")]
+    Parquet(#[from] ParquetError),
+    /// The input looks like a URL but uses a scheme we do not support.
+    #[error(
+        "unsupported input URL scheme `{scheme}://` in {url:?}: supported inputs are \
+         local paths and s3://, https://, http://, gs:// URLs"
+    )]
+    UnsupportedScheme {
+        /// The unrecognized scheme.
+        scheme: String,
+        /// The full input string.
+        url: String,
+    },
+    /// A remote URL was supplied but the crate was built without `remote`.
+    #[cfg(not(feature = "remote"))]
+    #[error(
+        "remote input {0:?} requires gpq-tiles-core's `remote` feature (the official \
+         CLI and Python builds enable it; rebuild with `--features remote`)"
+    )]
+    RemoteDisabled(String),
+    /// The remote object store rejected a request.
+    #[cfg(feature = "remote")]
+    #[error("remote input error for {url}: {source}")]
+    Remote {
+        /// The input URL.
+        url: String,
+        /// The underlying object-store error.
+        #[source]
+        source: object_store::Error,
+    },
+    /// Remote configuration problem (bad URL, missing region, ...).
+    #[cfg(feature = "remote")]
+    #[error("{0}")]
+    RemoteConfig(String),
+}
+
+/// Byte/request counters for a remote input. `Serialize` so conversion
+/// reports can carry it (benchmark tasks).
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Default)]
+pub struct FetchStats {
+    /// Number of range GET requests issued (HEAD not included).
+    pub requests: u64,
+    /// Total bytes fetched across all range requests.
+    pub bytes_fetched: u64,
+    /// Total size of the remote object in bytes.
+    pub object_size: u64,
+}
+
+/// A conversion input: a local parquet file or a remote parquet object.
+#[derive(Debug)]
+pub enum InputSource {
+    /// A local filesystem path (the historical behavior).
+    Local(PathBuf),
+    /// A remote object read over range requests.
+    #[cfg(feature = "remote")]
+    Remote(remote::RemoteSource),
+}
+
+impl InputSource {
+    /// Classify a CLI-style input path. Anything shaped like `scheme://...`
+    /// is treated as a URL (`file://` maps back to a local path); everything
+    /// else is a local path.
+    pub fn from_path(path: &Path) -> Result<Self, InputError> {
+        let Some(s) = path.to_str() else {
+            // Non-UTF-8 paths cannot be URLs; treat as local.
+            return Ok(InputSource::Local(path.to_path_buf()));
+        };
+        Self::from_str_input(s)
+    }
+
+    /// [`InputSource::from_path`] for string inputs.
+    pub fn from_str_input(input: &str) -> Result<Self, InputError> {
+        let Some(scheme) = url_scheme(input) else {
+            return Ok(InputSource::Local(PathBuf::from(input)));
+        };
+        if scheme.eq_ignore_ascii_case("file") {
+            let rest = &input[scheme.len() + 3..];
+            return Ok(InputSource::Local(PathBuf::from(rest)));
+        }
+        if !REMOTE_SCHEMES
+            .iter()
+            .any(|s| scheme.eq_ignore_ascii_case(s))
+        {
+            return Err(InputError::UnsupportedScheme {
+                scheme: scheme.to_string(),
+                url: input.to_string(),
+            });
+        }
+        #[cfg(feature = "remote")]
+        {
+            Ok(InputSource::Remote(remote::RemoteSource::connect(input)?))
+        }
+        #[cfg(not(feature = "remote"))]
+        {
+            Err(InputError::RemoteDisabled(input.to_string()))
+        }
+    }
+
+    /// Whether this source is remote.
+    pub fn is_remote(&self) -> bool {
+        match self {
+            InputSource::Local(_) => false,
+            #[cfg(feature = "remote")]
+            InputSource::Remote(_) => true,
+        }
+    }
+
+    /// Human-readable name of the input (path or URL).
+    pub fn display_name(&self) -> String {
+        match self {
+            InputSource::Local(p) => p.display().to_string(),
+            #[cfg(feature = "remote")]
+            InputSource::Remote(r) => r.url().to_string(),
+        }
+    }
+
+    /// Open a parquet reader builder over this input.
+    ///
+    /// Local: opens the file and parses the footer (cheap, OS page cache).
+    /// Remote: reuses a cached parsed footer after the first open, so the
+    /// multi-pass streaming pipeline pays the footer fetch only once.
+    pub fn open(&self) -> Result<ParquetRecordBatchReaderBuilder<InputReader>, InputError> {
+        match self {
+            InputSource::Local(p) => {
+                let file = File::open(p)?;
+                Ok(ParquetRecordBatchReaderBuilder::try_new(
+                    InputReader::Local(file),
+                )?)
+            }
+            #[cfg(feature = "remote")]
+            InputSource::Remote(r) => r.open_builder(),
+        }
+    }
+
+    /// Fetch counters for a remote source (`None` for local inputs).
+    pub fn fetch_stats(&self) -> Option<FetchStats> {
+        match self {
+            InputSource::Local(_) => None,
+            #[cfg(feature = "remote")]
+            InputSource::Remote(r) => Some(r.fetch_stats()),
+        }
+    }
+
+    /// The byte ranges fetched so far from a remote source (`None` for
+    /// local inputs). Ordered by request time; used by tests to prove that
+    /// bbox-pruned row groups are never downloaded.
+    pub fn fetched_ranges(&self) -> Option<Vec<std::ops::Range<u64>>> {
+        match self {
+            InputSource::Local(_) => None,
+            #[cfg(feature = "remote")]
+            InputSource::Remote(r) => Some(r.fetched_ranges()),
+        }
+    }
+}
+
+/// Return the URL scheme of `input` if it is shaped like `scheme://rest`.
+fn url_scheme(input: &str) -> Option<&str> {
+    let (scheme, _) = input.split_once("://")?;
+    if scheme.is_empty() {
+        return None;
+    }
+    let mut chars = scheme.chars();
+    let first = chars.next()?;
+    if !first.is_ascii_alphabetic() {
+        return None;
+    }
+    if chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.')) {
+        Some(scheme)
+    } else {
+        None
+    }
+}
+
+/// A [`ChunkReader`] over an [`InputSource`]: the type the parquet reader
+/// plumbing is instantiated with.
+#[derive(Debug)]
+pub enum InputReader {
+    /// Local file (delegates to parquet's own `File` impl).
+    Local(File),
+    /// Remote object; every `get_bytes` is one range request.
+    #[cfg(feature = "remote")]
+    Remote(remote::RemoteReader),
+}
+
+impl Length for InputReader {
+    fn len(&self) -> u64 {
+        match self {
+            InputReader::Local(f) => f.len(),
+            #[cfg(feature = "remote")]
+            InputReader::Remote(r) => r.object_size(),
+        }
+    }
+}
+
+impl ChunkReader for InputReader {
+    type T = Box<dyn Read + Send>;
+
+    fn get_read(&self, start: u64) -> Result<Self::T, ParquetError> {
+        match self {
+            InputReader::Local(f) => Ok(Box::new(f.get_read(start)?)),
+            #[cfg(feature = "remote")]
+            InputReader::Remote(r) => Ok(Box::new(r.sequential_reader(start))),
+        }
+    }
+
+    fn get_bytes(&self, start: u64, length: usize) -> Result<Bytes, ParquetError> {
+        match self {
+            InputReader::Local(f) => f.get_bytes(start, length),
+            #[cfg(feature = "remote")]
+            InputReader::Remote(r) => r.get_bytes_range(start, length),
+        }
+    }
+}
+
+#[cfg(feature = "remote")]
+pub(crate) mod remote {
+    //! Remote object-store backend (`remote` feature).
+
+    use std::ops::Range;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Arc, Mutex, OnceLock};
+
+    use bytes::Bytes;
+    use object_store::aws::{AmazonS3Builder, AwsCredential};
+    use object_store::gcp::GoogleCloudStorageBuilder;
+    use object_store::http::HttpBuilder;
+    use object_store::path::Path as ObjectPath;
+    use object_store::{CredentialProvider, ObjectStore, ObjectStoreScheme};
+    use parquet::arrow::arrow_reader::{
+        ArrowReaderMetadata, ArrowReaderOptions, ParquetRecordBatchReaderBuilder,
+    };
+    use parquet::errors::ParquetError;
+    use url::Url;
+
+    use super::{FetchStats, InputError, InputReader};
+
+    /// Readahead for the *sequential* read path
+    /// ([`parquet::file::reader::ChunkReader::get_read`]). The page reader
+    /// uses `get_read` only to thrift-decode page *headers* (tens of bytes;
+    /// page data goes through exact-range `get_bytes`), so keep this small —
+    /// and always clamp it to the surrounding column chunk (see
+    /// [`SharedState::clamp_to_chunk`]) so a header read near a chunk
+    /// boundary can never pull bytes from a bbox-pruned row group.
+    const SEQUENTIAL_CHUNK: u64 = 8 * 1024;
+
+    /// Shared tokio runtime driving object_store's async I/O from our
+    /// synchronous reader plumbing. Two worker threads: requests are issued
+    /// one at a time per reader, so this only needs to run the HTTP client.
+    fn runtime() -> &'static tokio::runtime::Runtime {
+        static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+        RT.get_or_init(|| {
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(2)
+                .thread_name("gpq-remote-io")
+                .enable_all()
+                .build()
+                .expect("failed to build tokio runtime for remote input")
+        })
+    }
+
+    /// State shared by all readers of one source: request/byte counters, the
+    /// fetched-range log, and (once the footer is parsed) the column-chunk
+    /// byte ranges used to clamp sequential readahead.
+    #[derive(Debug, Default)]
+    struct SharedState {
+        requests: AtomicU64,
+        bytes: AtomicU64,
+        ranges: Mutex<Vec<Range<u64>>>,
+        /// Byte ranges of every column chunk, sorted by start; populated
+        /// from the parsed footer on first open.
+        chunk_ranges: OnceLock<Vec<Range<u64>>>,
+    }
+
+    impl SharedState {
+        /// Clamp a readahead starting at `start` so it never crosses out of
+        /// the column chunk containing `start` (a page-header read must not
+        /// bleed into a neighboring — possibly bbox-pruned — row group).
+        fn clamp_to_chunk(&self, start: u64, want_end: u64) -> u64 {
+            let Some(chunks) = self.chunk_ranges.get() else {
+                return want_end;
+            };
+            // Last chunk starting at or before `start`.
+            let idx = chunks.partition_point(|r| r.start <= start);
+            if idx == 0 {
+                return want_end;
+            }
+            let chunk = &chunks[idx - 1];
+            if start < chunk.end {
+                want_end.min(chunk.end)
+            } else {
+                want_end
+            }
+        }
+    }
+
+    /// A remote parquet object: store handle, resolved location, object
+    /// size, fetch counters, and (after the first open) the parsed footer.
+    #[derive(Debug)]
+    pub struct RemoteSource {
+        url: String,
+        store: Arc<dyn ObjectStore>,
+        location: ObjectPath,
+        size: u64,
+        shared: Arc<SharedState>,
+        metadata: OnceLock<ArrowReaderMetadata>,
+        cache: Arc<Mutex<ChunkCache>>,
+    }
+
+    impl RemoteSource {
+        /// Connect to `url`, resolving the backing store from the scheme
+        /// and HEAD-ing the object for its size.
+        pub(crate) fn connect(url_str: &str) -> Result<Self, InputError> {
+            let url = Url::parse(url_str)
+                .map_err(|e| InputError::RemoteConfig(format!("invalid URL {url_str:?}: {e}")))?;
+            let (scheme, location) = ObjectStoreScheme::parse(&url).map_err(|e| {
+                InputError::RemoteConfig(format!("cannot interpret URL {url_str:?}: {e}"))
+            })?;
+            let store: Arc<dyn ObjectStore> = match scheme {
+                ObjectStoreScheme::AmazonS3 => build_s3(&url)?,
+                ObjectStoreScheme::GoogleCloudStorage => Arc::new(
+                    GoogleCloudStorageBuilder::from_env()
+                        .with_url(url_str)
+                        .build()
+                        .map_err(|e| store_error(url_str, e))?,
+                ),
+                ObjectStoreScheme::Http => {
+                    let origin = &url[..url::Position::BeforePath];
+                    Arc::new(
+                        HttpBuilder::new()
+                            .with_url(origin)
+                            .build()
+                            .map_err(|e| store_error(url_str, e))?,
+                    )
+                }
+                _ => {
+                    return Err(InputError::UnsupportedScheme {
+                        scheme: url.scheme().to_string(),
+                        url: url_str.to_string(),
+                    })
+                }
+            };
+            Self::from_store(store, location, url_str.to_string())
+        }
+
+        /// Build a source over an explicit store + location (also the test
+        /// seam: unit tests inject [`object_store::memory::InMemory`]).
+        pub fn from_store(
+            store: Arc<dyn ObjectStore>,
+            location: ObjectPath,
+            url: String,
+        ) -> Result<Self, InputError> {
+            let head = runtime()
+                .block_on(store.head(&location))
+                .map_err(|e| store_error(&url, e))?;
+            Ok(Self {
+                url,
+                store,
+                location,
+                size: head.size,
+                shared: Arc::new(SharedState::default()),
+                metadata: OnceLock::new(),
+                cache: Arc::new(Mutex::new(ChunkCache::default())),
+            })
+        }
+
+        /// The input URL.
+        pub fn url(&self) -> &str {
+            &self.url
+        }
+
+        /// Open a parquet reader builder; the parsed footer is cached across
+        /// opens so multi-pass pipelines fetch it once.
+        pub(crate) fn open_builder(
+            &self,
+        ) -> Result<ParquetRecordBatchReaderBuilder<InputReader>, InputError> {
+            let reader = InputReader::Remote(self.reader());
+            let metadata = match self.metadata.get() {
+                Some(md) => md.clone(),
+                None => {
+                    let md = ArrowReaderMetadata::load(&reader, ArrowReaderOptions::new())?;
+                    // A concurrent open may have won the race; either copy
+                    // is equivalent.
+                    let _ = self.metadata.set(md.clone());
+                    md
+                }
+            };
+            // Column-chunk byte ranges (sorted) for readahead clamping.
+            self.shared.chunk_ranges.get_or_init(|| {
+                let mut ranges: Vec<Range<u64>> = metadata
+                    .metadata()
+                    .row_groups()
+                    .iter()
+                    .flat_map(|rg| {
+                        rg.columns().iter().map(|col| {
+                            let (start, len) = col.byte_range();
+                            start..start + len
+                        })
+                    })
+                    .collect();
+                ranges.sort_by_key(|r| r.start);
+                ranges
+            });
+            Ok(ParquetRecordBatchReaderBuilder::new_with_metadata(
+                reader, metadata,
+            ))
+        }
+
+        /// A cheap handle for issuing counted range requests.
+        pub(crate) fn reader(&self) -> RemoteReader {
+            RemoteReader {
+                store: Arc::clone(&self.store),
+                location: self.location.clone(),
+                size: self.size,
+                shared: Arc::clone(&self.shared),
+                cache: Arc::clone(&self.cache),
+            }
+        }
+
+        /// Snapshot of the fetch counters.
+        pub fn fetch_stats(&self) -> FetchStats {
+            FetchStats {
+                requests: self.shared.requests.load(Ordering::Relaxed),
+                bytes_fetched: self.shared.bytes.load(Ordering::Relaxed),
+                object_size: self.size,
+            }
+        }
+
+        /// The byte ranges fetched so far, in request order.
+        pub fn fetched_ranges(&self) -> Vec<Range<u64>> {
+            self.shared.ranges.lock().expect("ranges lock").clone()
+        }
+    }
+
+    /// Map an object-store error, attaching the input URL.
+    fn store_error(url: &str, source: object_store::Error) -> InputError {
+        InputError::Remote {
+            url: url.to_string(),
+            source,
+        }
+    }
+
+    /// Build an S3 store for `url` with the standard AWS credential chain
+    /// (env, shared config/credentials incl. `AWS_PROFILE`, SSO, IMDS —
+    /// what DuckDB's `credential_chain` provider and gpio users expect).
+    /// If the chain resolves no credentials the store falls back to
+    /// unsigned requests, so public buckets work anonymously.
+    fn build_s3(url: &Url) -> Result<Arc<dyn ObjectStore>, InputError> {
+        use aws_credential_types::provider::ProvideCredentials;
+
+        // `from_env` honors explicit AWS_* env overrides (region, endpoint,
+        // static keys); `with_url` extracts the bucket (and, for
+        // virtual-hosted https URLs, the region embedded in the host).
+        let mut builder = AmazonS3Builder::from_env().with_url(url.to_string());
+
+        let sdk_config =
+            runtime().block_on(aws_config::defaults(aws_config::BehaviorVersion::latest()).load());
+
+        // Region: explicit env (AWS_REGION / AWS_DEFAULT_REGION) wins, then
+        // the profile/IMDS-resolved region from the SDK chain.
+        let env_region = std::env::var("AWS_REGION")
+            .or_else(|_| std::env::var("AWS_DEFAULT_REGION"))
+            .ok();
+        match (&env_region, sdk_config.region()) {
+            (Some(r), _) => builder = builder.with_region(r.clone()),
+            (None, Some(r)) => builder = builder.with_region(r.as_ref()),
+            (None, None) => {
+                return Err(InputError::RemoteConfig(format!(
+                    "no AWS region configured for {url}: set AWS_REGION (e.g. \
+                     AWS_REGION=us-east-2) or add a region to your AWS profile"
+                )));
+            }
+        }
+
+        // Credentials: probe the chain once; if it resolves, install a
+        // refreshing bridge provider (SSO/STS credentials expire), else go
+        // unsigned for public buckets.
+        let mut anonymous = true;
+        if let Some(provider) = sdk_config.credentials_provider() {
+            match runtime().block_on(provider.provide_credentials()) {
+                Ok(_) => {
+                    builder = builder.with_credentials(Arc::new(SdkCredentialBridge(provider)));
+                    anonymous = false;
+                }
+                Err(e) => {
+                    log::warn!(
+                        "no AWS credentials resolved ({e}); \
+                         falling back to unsigned (anonymous) S3 requests"
+                    );
+                }
+            }
+        }
+        if anonymous {
+            builder = builder.with_skip_signature(true);
+        }
+
+        Ok(Arc::new(builder.build().map_err(|e| {
+            InputError::RemoteConfig(format!("cannot configure S3 store for {url}: {e}"))
+        })?))
+    }
+
+    /// Bridges the AWS SDK credential chain (profiles, SSO, IMDS, ...) into
+    /// object_store's credential provider, re-resolving on each request so
+    /// expiring credentials refresh (the SDK chain caches internally).
+    #[derive(Debug)]
+    struct SdkCredentialBridge(aws_credential_types::provider::SharedCredentialsProvider);
+
+    #[async_trait::async_trait]
+    impl CredentialProvider for SdkCredentialBridge {
+        type Credential = AwsCredential;
+
+        async fn get_credential(&self) -> object_store::Result<Arc<AwsCredential>> {
+            use aws_credential_types::provider::ProvideCredentials;
+            let creds =
+                self.0
+                    .provide_credentials()
+                    .await
+                    .map_err(|e| object_store::Error::Generic {
+                        store: "S3",
+                        source: Box::new(e),
+                    })?;
+            Ok(Arc::new(AwsCredential {
+                key_id: creds.access_key_id().to_string(),
+                secret_key: creds.secret_access_key().to_string(),
+                token: creds.session_token().map(str::to_string),
+            }))
+        }
+    }
+
+    /// Upper bound on the per-reader column-chunk fetch cache. The working
+    /// set is one row group's compressed column chunks (the arrow reader
+    /// interleaves the columns of the row group it is decoding), so this cap
+    /// is a hard safety net, not the expected occupancy.
+    const CHUNK_CACHE_MAX_BYTES: u64 = 256 * 1024 * 1024;
+
+    /// Per-reader cache of whole column chunks, insertion-ordered for
+    /// eviction. This is the "buffered range-fetch adapter": the page reader
+    /// asks for a column chunk's bytes in many small pieces (a thrift page
+    /// header via `get_read`, then each page via `get_bytes`); fetching the
+    /// whole chunk on first touch turns that into ONE range request per
+    /// selected column chunk. Chunks of bbox-pruned row groups are never
+    /// touched, so they are still never fetched.
+    #[derive(Debug, Default)]
+    struct ChunkCache {
+        entries: std::collections::HashMap<u64, (Range<u64>, Bytes)>,
+        order: std::collections::VecDeque<u64>,
+        total: u64,
+    }
+
+    /// Range-request reader over one remote object. Cloneable; all clones
+    /// share the source's counters (the chunk cache too — it lives per
+    /// source, so multi-pass pipelines could reuse it, though in practice
+    /// eviction keeps it near one row group).
+    #[derive(Debug, Clone)]
+    pub struct RemoteReader {
+        store: Arc<dyn ObjectStore>,
+        location: ObjectPath,
+        size: u64,
+        shared: Arc<SharedState>,
+        cache: Arc<Mutex<ChunkCache>>,
+    }
+
+    impl RemoteReader {
+        /// Total object size (the [`parquet::file::reader::Length`] answer).
+        pub(crate) fn object_size(&self) -> u64 {
+            self.size
+        }
+
+        /// One counted range GET.
+        fn fetch(&self, range: Range<u64>) -> Result<Bytes, ParquetError> {
+            let bytes = runtime()
+                .block_on(self.store.get_range(&self.location, range.clone()))
+                .map_err(|e| ParquetError::External(Box::new(e)))?;
+            self.shared.requests.fetch_add(1, Ordering::Relaxed);
+            self.shared
+                .bytes
+                .fetch_add(bytes.len() as u64, Ordering::Relaxed);
+            self.shared.ranges.lock().expect("ranges lock").push(range);
+            Ok(bytes)
+        }
+
+        /// The column chunk containing `start..end`, if the footer is parsed
+        /// and the range falls entirely inside one chunk.
+        fn chunk_containing(&self, start: u64, end: u64) -> Option<Range<u64>> {
+            let chunks = self.shared.chunk_ranges.get()?;
+            let idx = chunks.partition_point(|r| r.start <= start);
+            let chunk = chunks.get(idx.checked_sub(1)?)?;
+            (start >= chunk.start && end <= chunk.end).then(|| chunk.clone())
+        }
+
+        /// Bytes of a whole column chunk, from cache or one range request.
+        fn chunk_data(&self, chunk: &Range<u64>) -> Result<Bytes, ParquetError> {
+            {
+                let cache = self.cache.lock().expect("chunk cache lock");
+                if let Some((_, data)) = cache.entries.get(&chunk.start) {
+                    return Ok(data.clone());
+                }
+            }
+            let data = self.fetch(chunk.clone())?;
+            let mut cache = self.cache.lock().expect("chunk cache lock");
+            if !cache.entries.contains_key(&chunk.start) {
+                cache.total += data.len() as u64;
+                cache
+                    .entries
+                    .insert(chunk.start, (chunk.clone(), data.clone()));
+                cache.order.push_back(chunk.start);
+                while cache.total > CHUNK_CACHE_MAX_BYTES {
+                    let Some(oldest) = cache.order.pop_front() else {
+                        break;
+                    };
+                    if let Some((_, evicted)) = cache.entries.remove(&oldest) {
+                        cache.total -= evicted.len() as u64;
+                    }
+                }
+            }
+            Ok(data)
+        }
+
+        /// Exact-range read for [`parquet::file::reader::ChunkReader::get_bytes`].
+        pub(crate) fn get_bytes_range(
+            &self,
+            start: u64,
+            length: usize,
+        ) -> Result<Bytes, ParquetError> {
+            let end = start
+                .checked_add(length as u64)
+                .filter(|end| *end <= self.size)
+                .ok_or_else(|| {
+                    ParquetError::EOF(format!(
+                        "range {start}..{} beyond object size {} for {}",
+                        start as u128 + length as u128,
+                        self.size,
+                        self.location
+                    ))
+                })?;
+            if length == 0 {
+                return Ok(Bytes::new());
+            }
+            // Page reads land inside a column chunk: serve them from the
+            // whole-chunk buffer (one request per chunk). Everything else
+            // (footer tail, metadata) is fetched exactly.
+            if let Some(chunk) = self.chunk_containing(start, end) {
+                let data = self.chunk_data(&chunk)?;
+                let offset = (start - chunk.start) as usize;
+                return Ok(data.slice(offset..offset + length));
+            }
+            self.fetch(start..end)
+        }
+
+        /// Chunked sequential reader for
+        /// [`parquet::file::reader::ChunkReader::get_read`] (not used by the
+        /// arrow reader path, provided for trait completeness).
+        pub(crate) fn sequential_reader(&self, start: u64) -> SequentialRemoteRead {
+            SequentialRemoteRead {
+                reader: self.clone(),
+                pos: start,
+                buf: Bytes::new(),
+                buf_offset: 0,
+            }
+        }
+    }
+
+    /// `Read` adapter fetching forward in [`SEQUENTIAL_CHUNK`] steps, each
+    /// step clamped to the column chunk containing the read position.
+    pub struct SequentialRemoteRead {
+        reader: RemoteReader,
+        pos: u64,
+        buf: Bytes,
+        buf_offset: usize,
+    }
+
+    impl std::io::Read for SequentialRemoteRead {
+        fn read(&mut self, out: &mut [u8]) -> std::io::Result<usize> {
+            if self.buf_offset >= self.buf.len() {
+                let remaining = self.reader.size.saturating_sub(self.pos);
+                if remaining == 0 {
+                    return Ok(0);
+                }
+                // Inside a column chunk (the page-header read path): serve
+                // the rest of the chunk from the whole-chunk buffer.
+                if let Some(chunk) = self.reader.chunk_containing(self.pos, self.pos + 1) {
+                    let data = self
+                        .reader
+                        .chunk_data(&chunk)
+                        .map_err(std::io::Error::other)?;
+                    let offset = (self.pos - chunk.start) as usize;
+                    self.buf = data.slice(offset..);
+                    self.buf_offset = 0;
+                    self.pos = chunk.end;
+                } else {
+                    let want_end = self.pos + remaining.min(SEQUENTIAL_CHUNK);
+                    // Never read across a column-chunk boundary: bytes past
+                    // it may belong to a bbox-pruned row group that must not
+                    // be downloaded.
+                    let end = self.reader.shared.clamp_to_chunk(self.pos, want_end);
+                    self.buf = self
+                        .reader
+                        .fetch(self.pos..end)
+                        .map_err(std::io::Error::other)?;
+                    self.buf_offset = 0;
+                    self.pos = end;
+                }
+            }
+            let n = out.len().min(self.buf.len() - self.buf_offset);
+            out[..n].copy_from_slice(&self.buf[self.buf_offset..self.buf_offset + n]);
+            self.buf_offset += n;
+            Ok(n)
+        }
+    }
+}
+
+/// Test-only: an [`InputSource`] over an in-memory object store seeded with
+/// `bytes` — the seam remote tests (here and in `overview::convert`) inject
+/// data through without touching the network.
+#[cfg(all(test, feature = "remote"))]
+pub(crate) fn test_memory_source(bytes: Vec<u8>, name: &str) -> InputSource {
+    use object_store::memory::InMemory;
+    use object_store::path::Path as ObjectPath;
+    use object_store::ObjectStore;
+    use std::sync::Arc;
+
+    let store = Arc::new(InMemory::new());
+    let location = ObjectPath::from(name);
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(store.put(&location, bytes.into())).unwrap();
+    InputSource::Remote(
+        remote::RemoteSource::from_store(store, location, format!("memory://{name}")).unwrap(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_path_is_local() {
+        let s = InputSource::from_path(Path::new("/tmp/foo.parquet")).unwrap();
+        assert!(!s.is_remote());
+        assert!(s.fetch_stats().is_none());
+    }
+
+    #[test]
+    fn relative_path_is_local() {
+        let s = InputSource::from_str_input("data/foo.parquet").unwrap();
+        assert!(!s.is_remote());
+    }
+
+    #[test]
+    fn file_url_maps_to_local() {
+        let s = InputSource::from_str_input("file:///tmp/foo.parquet").unwrap();
+        match s {
+            InputSource::Local(p) => assert_eq!(p, PathBuf::from("/tmp/foo.parquet")),
+            #[cfg(feature = "remote")]
+            InputSource::Remote(_) => panic!("file:// must be local"),
+        }
+    }
+
+    #[test]
+    fn unsupported_scheme_is_a_helpful_error() {
+        let err = InputSource::from_str_input("ftp://example.com/foo.parquet").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("ftp"), "message names the scheme: {msg}");
+        assert!(msg.contains("s3://"), "message lists alternatives: {msg}");
+    }
+
+    #[test]
+    fn windows_style_drive_is_local() {
+        // `C:\...` has a colon but no `://`; must not be parsed as a URL.
+        let s = InputSource::from_str_input(r"C:\data\foo.parquet").unwrap();
+        assert!(!s.is_remote());
+    }
+
+    #[cfg(not(feature = "remote"))]
+    #[test]
+    fn remote_url_without_feature_is_a_clear_error() {
+        let err = InputSource::from_str_input("s3://bucket/key.parquet").unwrap_err();
+        assert!(err.to_string().contains("remote"), "err: {err}");
+    }
+
+    #[cfg(feature = "remote")]
+    mod remote_tests {
+        use super::super::*;
+
+        use super::super::test_memory_source as memory_source;
+
+        /// Minimal single-column parquet bytes for reader plumbing tests.
+        fn tiny_parquet() -> Vec<u8> {
+            use arrow_array::{Int64Array, RecordBatch};
+            use parquet::arrow::ArrowWriter;
+            use std::sync::Arc as SArc;
+
+            let batch = RecordBatch::try_from_iter([(
+                "v",
+                SArc::new(Int64Array::from(vec![1i64, 2, 3])) as _,
+            )])
+            .unwrap();
+            let mut buf = Vec::new();
+            let mut w = ArrowWriter::try_new(&mut buf, batch.schema(), None).unwrap();
+            w.write(&batch).unwrap();
+            w.close().unwrap();
+            buf
+        }
+
+        #[test]
+        fn remote_reader_roundtrips_parquet() {
+            let bytes = tiny_parquet();
+            let total = bytes.len() as u64;
+            let source = memory_source(bytes, "tiny.parquet");
+            assert!(source.is_remote());
+
+            let builder = source.open().unwrap();
+            let reader = builder.build().unwrap();
+            let rows: usize = reader.map(|b| b.unwrap().num_rows()).sum();
+            assert_eq!(rows, 3);
+
+            let stats = source.fetch_stats().unwrap();
+            assert_eq!(stats.object_size, total);
+            assert!(stats.requests >= 2, "footer + data: {stats:?}");
+            assert!(stats.bytes_fetched > 0);
+            // Every individual range stays within the object (requests may
+            // overlap each other: footer suffix then full footer).
+            for r in source.fetched_ranges().unwrap() {
+                assert!(r.end <= total, "range {r:?} beyond object size {total}");
+            }
+        }
+
+        #[test]
+        fn footer_is_cached_across_opens() {
+            let source = memory_source(tiny_parquet(), "tiny.parquet");
+            let _ = source.open().unwrap();
+            let after_first = source.fetch_stats().unwrap();
+            let _ = source.open().unwrap();
+            let after_second = source.fetch_stats().unwrap();
+            assert_eq!(
+                after_first.requests, after_second.requests,
+                "second open must not re-fetch the footer"
+            );
+        }
+
+        #[test]
+        fn sequential_read_matches_object_bytes() {
+            use parquet::file::reader::ChunkReader;
+            use std::io::Read;
+
+            let bytes = tiny_parquet();
+            let source = memory_source(bytes.clone(), "tiny.parquet");
+            let InputSource::Remote(ref r) = source else {
+                unreachable!()
+            };
+            let reader = InputReader::Remote(r.reader());
+            let mut out = Vec::new();
+            reader.get_read(4).unwrap().read_to_end(&mut out).unwrap();
+            assert_eq!(out, &bytes[4..]);
+        }
+
+        /// Anonymous HTTPS against a public object (a GitHub release asset,
+        /// which serves range requests): the footer must be readable with a
+        /// partial fetch and no credentials. Skips (passing trivially,
+        /// loudly) when the network is unavailable.
+        #[test]
+        fn https_public_object_integration() {
+            const URL: &str = "https://github.com/geoparquet-io/gpq-tiles/releases/download/fixtures-v1/fieldmaps-boundaries.parquet";
+            let source = match InputSource::from_str_input(URL) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!("SKIP https_public_object_integration (no network?): {e}");
+                    return;
+                }
+            };
+            let builder = match source.open() {
+                Ok(b) => b,
+                Err(e) => {
+                    eprintln!("SKIP https_public_object_integration (no network?): {e}");
+                    return;
+                }
+            };
+            assert!(
+                builder
+                    .schema()
+                    .fields()
+                    .iter()
+                    .any(|f| f.name() == "geometry"),
+                "public GeoParquet fixture has a geometry column"
+            );
+            let stats = source.fetch_stats().unwrap();
+            assert!(stats.bytes_fetched > 0);
+            assert!(
+                stats.bytes_fetched < stats.object_size,
+                "footer open must be a partial fetch: {stats:?}"
+            );
+        }
+
+        #[test]
+        fn out_of_bounds_range_is_an_error() {
+            let source = memory_source(tiny_parquet(), "tiny.parquet");
+            let InputSource::Remote(ref r) = source else {
+                unreachable!()
+            };
+            let reader = r.reader();
+            let size = reader.object_size();
+            assert!(reader.get_bytes_range(size - 1, 2).is_err());
+        }
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -44,6 +44,7 @@ pub mod compression;
 pub mod covering;
 pub mod decode;
 pub mod dedup;
+pub mod input;
 pub mod ioverlay_clip;
 pub mod mvt;
 pub mod overview;

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -44,6 +44,8 @@ use geoarrow::array::{from_arrow_array, GeometryBuilder};
 use geoarrow::datatypes::GeometryType;
 use geoarrow_array::GeoArrowArray;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+use crate::input::InputSource;
 use serde::Serialize;
 
 use crate::batch_processor::extract_geometries_opt_from_array;
@@ -457,6 +459,11 @@ pub struct ConvertReport {
     pub antimeridian_suspect_features: usize,
     /// Wall-clock conversion duration in seconds.
     pub duration_secs: f64,
+    /// Remote-input fetch counters (#210): range requests issued and bytes
+    /// downloaded, against the total object size. `None` for local inputs.
+    /// With [`ConvertOptions::bbox`], `bytes_fetched / object_size` is the
+    /// fraction of the remote file actually moved.
+    pub remote_fetch: Option<crate::input::FetchStats>,
 }
 
 /// Errors from [`convert_to_overviews`].
@@ -465,6 +472,9 @@ pub enum ConvertError {
     /// I/O error.
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+    /// Opening the input failed (bad URL scheme, remote store error, ...).
+    #[error("input error: {0}")]
+    Input(#[from] crate::input::InputError),
     /// Underlying parquet error (reading the input).
     #[error("parquet error: {0}")]
     Parquet(#[from] parquet::errors::ParquetError),
@@ -642,6 +652,22 @@ pub fn convert_to_overviews(
     output_path: impl AsRef<Path>,
     options: &ConvertOptions,
 ) -> Result<ConvertReport, ConvertError> {
+    // Local path or remote URL (s3://, https://, gs:// — #210): remote
+    // objects are read with byte-range requests through the same sync
+    // parquet plumbing, composing with the bbox row-group pruning below so
+    // pruned row groups are never downloaded at all.
+    let source = InputSource::from_path(input_path.as_ref())?;
+    convert_to_overviews_source(&source, output_path.as_ref(), options)
+}
+
+/// [`convert_to_overviews`] over an already-resolved [`InputSource`] — the
+/// entry point for callers that construct the source themselves (custom
+/// object stores, tests over in-memory stores).
+pub fn convert_to_overviews_source(
+    source: &InputSource,
+    output_path: &Path,
+    options: &ConvertOptions,
+) -> Result<ConvertReport, ConvertError> {
     // Knob sanity (H4), shared by both pipelines.
     validate_options(options)?;
     // Clustering option sanity (Q4), shared by both pipelines: partitioning
@@ -679,16 +705,10 @@ pub fn convert_to_overviews(
     // Two-pass bounded-memory pipeline (H3, default). The in-memory path below
     // is kept as the reference implementation (`streaming: false`).
     if options.streaming {
-        return super::stream::convert_streaming(
-            input_path.as_ref(),
-            output_path.as_ref(),
-            options,
-        );
+        return super::stream::convert_streaming(source, output_path, options);
     }
 
     let start = Instant::now();
-    let input_path = input_path.as_ref();
-    let output_path = output_path.as_ref();
 
     // A numeric sort key and a categorical class ranking are mutually
     // exclusive (Q1): they would both drive `AssignFeature::sort_key`.
@@ -696,13 +716,13 @@ pub fn convert_to_overviews(
         return Err(ConvertError::RankingConflict);
     }
 
-    // --- CRS detection + rejection (spec Q3). --------------------------------
-    let crs = detect_crs(input_path)?;
-
-    // --- Read the whole input, preserving the full property schema. ----------
-    let file = std::fs::File::open(input_path)?;
-    let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
+    // --- Read the input footer, preserving the full property schema. ---------
+    // (For a remote source, the footer is range-fetched once and cached.)
+    let builder = source.open()?;
     let input_schema = builder.schema().clone();
+
+    // --- CRS detection + rejection (spec Q3) — footer metadata only. ---------
+    let crs = detect_crs_from_kv(builder.metadata().file_metadata().key_value_metadata())?;
 
     // Reject an input that already carries a `level` column (§4.1).
     // Case-insensitive: DuckDB resolves identifiers case-insensitively,
@@ -1093,17 +1113,40 @@ pub fn convert_to_overviews(
         row_groups_read,
         antimeridian_suspect_features,
         duration_secs: start.elapsed().as_secs_f64(),
+        remote_fetch: log_remote_fetch(source),
     })
+}
+
+/// Snapshot (and `log::info!`) the remote fetch counters at the end of a
+/// conversion; `None` (and silent) for local inputs.
+pub(super) fn log_remote_fetch(source: &InputSource) -> Option<crate::input::FetchStats> {
+    let stats = source.fetch_stats()?;
+    let pct = if stats.object_size > 0 {
+        100.0 * stats.bytes_fetched as f64 / stats.object_size as f64
+    } else {
+        0.0
+    };
+    log::info!(
+        "remote input: {} range requests, {:.2} MiB fetched of a {:.2} MiB object ({:.1}%)",
+        stats.requests,
+        stats.bytes_fetched as f64 / (1024.0 * 1024.0),
+        stats.object_size as f64 / (1024.0 * 1024.0),
+        pct
+    );
+    Some(stats)
 }
 
 // ============================================================================
 // Helpers
 // ============================================================================
 
-/// Detect the input CRS and map it to [`Crs`], rejecting anything that is not
-/// EPSG:4326 or EPSG:3857 (spec Q3).
-pub(super) fn detect_crs(path: &Path) -> Result<Crs, ConvertError> {
-    let info = crate::quality::extract_crs(path)?;
+/// Detect the input CRS from parsed parquet key-value metadata and map it to
+/// [`Crs`], rejecting anything that is not EPSG:4326 or EPSG:3857 (spec Q3).
+/// Metadata-only so remote inputs (#210) pay no extra footer fetch.
+pub(super) fn detect_crs_from_kv(
+    kv: Option<&Vec<parquet::file::metadata::KeyValue>>,
+) -> Result<Crs, ConvertError> {
+    let info = crate::quality::crs_info_from_kv_metadata(kv)?;
     if info.is_wgs84 {
         return Ok(Crs::Epsg4326);
     }
@@ -4346,5 +4389,215 @@ mod tests {
         let reader_bbox = OverviewReader::open(tout_bbox.path()).unwrap();
         let ids_bbox = read_all_ids(&reader_bbox);
         assert_eq!(ids_bbox, ids_full);
+    }
+
+    // ========================================================================
+    // Remote input tests (#210)
+    // ========================================================================
+
+    #[cfg(feature = "remote")]
+    mod remote_input {
+        use super::*;
+        use crate::input::{test_memory_source, InputSource};
+
+        /// Byte span `[start, end)` of each row group's data pages.
+        fn row_group_spans(bytes: &[u8]) -> Vec<std::ops::Range<u64>> {
+            let builder =
+                ParquetRecordBatchReaderBuilder::try_new(bytes::Bytes::from(bytes.to_vec()))
+                    .unwrap();
+            builder
+                .metadata()
+                .row_groups()
+                .iter()
+                .map(|rg| {
+                    let mut start = u64::MAX;
+                    let mut end = 0u64;
+                    for col in rg.columns() {
+                        let (s, len) = col.byte_range();
+                        start = start.min(s);
+                        end = end.max(s + len);
+                    }
+                    start..end
+                })
+                .collect()
+        }
+
+        /// THE #210 headline property: a `--bbox` extract from a remote file
+        /// must fetch byte ranges ONLY from the bbox-selected row groups (plus
+        /// the footer) — pruned row groups are never downloaded at all.
+        fn assert_bbox_extract_fetches_only_selected(streaming: bool) {
+            // 4 single-point row groups at (0,0), (10,10), (20,20), (30,30)
+            // with covering stats; a bbox around (10,10) selects only rg 1.
+            let coords = vec![(0.0, 0.0), (10.0, 10.0), (20.0, 20.0), (30.0, 30.0)];
+            let tin = tempfile::NamedTempFile::new().unwrap();
+            write_multi_rg_input(tin.path(), &coords, true);
+            let bytes = std::fs::read(tin.path()).unwrap();
+            let spans = row_group_spans(&bytes);
+            assert_eq!(spans.len(), 4);
+
+            let source = test_memory_source(bytes, "multi.parquet");
+            let tout = tempfile::NamedTempFile::new().unwrap();
+            let opts = ConvertOptions {
+                mode: Mode::Duplicating,
+                levels: LevelPlan::ZoomRange {
+                    min_zoom: 6,
+                    max_zoom: 6,
+                },
+                bbox: Some([9.0, 9.0, 11.0, 11.0]),
+                streaming,
+                ..Default::default()
+            };
+            let report = convert_to_overviews_source(&source, tout.path(), &opts).unwrap();
+
+            assert_eq!(report.row_groups_total, 4);
+            assert_eq!(report.row_groups_read, 1, "bbox pruning must fire");
+            let ids = read_all_ids(&OverviewReader::open(tout.path()).unwrap());
+            assert_eq!(ids, vec![1], "only the (10,10) feature survives");
+
+            // No fetched range may touch a pruned row group's data pages.
+            let fetched = source.fetched_ranges().unwrap();
+            assert!(!fetched.is_empty());
+            for (i, span) in spans.iter().enumerate() {
+                if i == 1 {
+                    continue;
+                }
+                for r in &fetched {
+                    assert!(
+                        r.end <= span.start || r.start >= span.end,
+                        "fetched range {r:?} overlaps PRUNED row group {i} ({span:?})"
+                    );
+                }
+            }
+            // ... while the selected row group's data pages WERE fetched.
+            assert!(
+                fetched
+                    .iter()
+                    .any(|r| r.start >= spans[1].start && r.end <= spans[1].end),
+                "selected row group 1 ({:?}) never fetched: {fetched:?}",
+                spans[1]
+            );
+
+            // And the report carries the savings.
+            let stats = report.remote_fetch.expect("remote stats in report");
+            assert!(stats.requests as usize >= fetched.len());
+            assert!(
+                stats.bytes_fetched < stats.object_size,
+                "bbox extract must move fewer bytes than the object: {stats:?}"
+            );
+        }
+
+        #[test]
+        fn bbox_extract_streaming_fetches_only_selected_row_groups() {
+            assert_bbox_extract_fetches_only_selected(true);
+        }
+
+        #[test]
+        fn bbox_extract_in_memory_fetches_only_selected_row_groups() {
+            assert_bbox_extract_fetches_only_selected(false);
+        }
+
+        /// A full (no-bbox) remote conversion must produce the same result as
+        /// the same conversion over the local file.
+        #[test]
+        fn remote_convert_matches_local_convert() {
+            let geoms = synthetic_geometries();
+            let tin = tempfile::NamedTempFile::new().unwrap();
+            write_input(tin.path(), &geoms, false, None);
+            let opts = ConvertOptions::default();
+
+            let tout_local = tempfile::NamedTempFile::new().unwrap();
+            let report_local = convert_to_overviews(tin.path(), tout_local.path(), &opts).unwrap();
+            assert!(report_local.remote_fetch.is_none(), "local input: no stats");
+
+            let source = test_memory_source(std::fs::read(tin.path()).unwrap(), "in.parquet");
+            let tout_remote = tempfile::NamedTempFile::new().unwrap();
+            let report_remote =
+                convert_to_overviews_source(&source, tout_remote.path(), &opts).unwrap();
+
+            assert_eq!(report_remote.input_features, report_local.input_features);
+            assert_eq!(report_remote.total_rows, report_local.total_rows);
+            assert_eq!(
+                read_all_ids(&OverviewReader::open(tout_remote.path()).unwrap()),
+                read_all_ids(&OverviewReader::open(tout_local.path()).unwrap()),
+            );
+            assert!(report_remote.remote_fetch.is_some());
+        }
+
+        /// A URL with an unsupported scheme surfaces a helpful error through
+        /// the public `convert_to_overviews` path.
+        #[test]
+        fn unsupported_scheme_errors_through_convert() {
+            let tout = tempfile::NamedTempFile::new().unwrap();
+            let err = convert_to_overviews(
+                Path::new("ftp://example.com/x.parquet"),
+                tout.path(),
+                &ConvertOptions::default(),
+            )
+            .unwrap_err();
+            assert!(matches!(err, ConvertError::Input(_)), "got: {err}");
+            assert!(err.to_string().contains("s3://"), "helpful message: {err}");
+        }
+
+        /// Network integration test against the bench bucket (issue #210):
+        /// a full remote city extract must move only a fraction of the
+        /// object's bytes. Skips (passing trivially, loudly) when
+        /// credentials or network are unavailable — CI has neither.
+        ///
+        /// Locally: `AWS_PROFILE=<profile> AWS_REGION=us-east-2 cargo test
+        /// --features remote remote_s3_city_extract -- --nocapture`
+        #[test]
+        fn remote_s3_city_extract_integration() {
+            // gpio-optimized (Hilbert-sorted, bbox covering, 20k-row row
+            // groups) copy of the NYC corpus input; row-group granularity
+            // bounds the minimum fetch, so finer groups mean bigger savings.
+            const URL: &str = "s3://gpq-tiles-bench/corpus/points-nyc-medium.rg20k.parquet";
+            let source = match InputSource::from_str_input(URL) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!(
+                        "SKIP remote_s3_city_extract_integration (no credentials/network): {e}"
+                    );
+                    return;
+                }
+            };
+            let tout = tempfile::NamedTempFile::new().unwrap();
+            // A ~1 km neighborhood window inside the NYC dataset (the input
+            // is Hilbert-sorted, so a small window prunes most row groups).
+            // Default (streaming) pipeline: its per-pass/per-level re-reads
+            // must be absorbed by the column-chunk cache, so the byte
+            // assertion below also guards the multi-pass refetch behavior.
+            let opts = ConvertOptions {
+                bbox: Some([-73.99, 40.72, -73.98, 40.73]),
+                ..Default::default()
+            };
+            let report = match convert_to_overviews_source(&source, tout.path(), &opts) {
+                Ok(r) => r,
+                Err(e) => {
+                    eprintln!("SKIP remote_s3_city_extract_integration (network flake?): {e}");
+                    return;
+                }
+            };
+            assert!(report.input_features > 0, "bbox should select features");
+            assert!(
+                report.row_groups_read < report.row_groups_total,
+                "row-group pruning should fire on the Hilbert-sorted input \
+                 ({}/{} read)",
+                report.row_groups_read,
+                report.row_groups_total
+            );
+            let stats = report.remote_fetch.expect("remote stats");
+            assert!(
+                stats.bytes_fetched * 4 < stats.object_size,
+                "city extract should move <25% of the remote object even \
+                 across streaming passes: {stats:?}"
+            );
+            eprintln!(
+                "remote_s3_city_extract_integration: {} requests, {} of {} bytes ({:.2}%)",
+                stats.requests,
+                stats.bytes_fetched,
+                stats.object_size,
+                100.0 * stats.bytes_fetched as f64 / stats.object_size as f64
+            );
+        }
     }
 }

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -55,11 +55,11 @@ use arrow_schema::{DataType, Schema, SchemaRef};
 use arrow_select::take::take;
 use geo::Geometry;
 use geoarrow::array::from_arrow_array;
-use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::arrow::ProjectionMask;
 use rayon::prelude::*;
 
 use crate::batch_processor::{extract_geometries_from_array, extract_geometries_opt_from_array};
+use crate::input::InputSource;
 
 use super::assign::{apply_density_budget, assign_levels, AssignFeature, FeatureKind};
 use super::cluster::{build_cluster_tables, verify_sum_invariant, ClusterEntry, ClusterTables};
@@ -68,11 +68,11 @@ use super::convert::{
     append_coalesced_count_field, append_point_count_field, apply_cluster_columns,
     apply_coalesced_count, build_generalization, build_level_batch, build_level_coalesce_table,
     build_source_schema, class_ranking_provenance, coalesce_effective, coalesce_level_chains,
-    count_vertices, detect_crs, extract_class_ranks, extract_sort_keys, feature_kind,
-    fill_level_bytes, find_geometry_column, geometry_bbox, mixed_geometry_field,
-    overture_road_ranking, usable_geometry, validate_cluster_schema, validate_coalesce_schema,
-    ClassRanking, CoalesceTable, ConvertError, ConvertOptions, ConvertReport, GroupInterner,
-    LevelReport, KNOWN_ROAD_CLASSES, ROAD_VOCAB_MIN_DISTINCT,
+    count_vertices, extract_class_ranks, extract_sort_keys, feature_kind, fill_level_bytes,
+    find_geometry_column, geometry_bbox, mixed_geometry_field, overture_road_ranking,
+    usable_geometry, validate_cluster_schema, validate_coalesce_schema, ClassRanking,
+    CoalesceTable, ConvertError, ConvertOptions, ConvertReport, GroupInterner, LevelReport,
+    KNOWN_ROAD_CLASSES, ROAD_VOCAB_MIN_DISTINCT,
 };
 use super::level::{Crs, Mode, RankingProvenance};
 use super::simplify::{
@@ -99,7 +99,7 @@ struct EmitLevel {
 
 /// Streaming counterpart of [`super::convert::convert_to_overviews`].
 pub(super) fn convert_streaming(
-    input_path: &Path,
+    source: &InputSource,
     output_path: &Path,
     options: &ConvertOptions,
 ) -> Result<ConvertReport, ConvertError> {
@@ -109,13 +109,16 @@ pub(super) fn convert_streaming(
         return Err(ConvertError::RankingConflict);
     }
 
-    // CRS detection + rejection (spec Q3) — footer-only read.
-    let crs = detect_crs(input_path)?;
-
     // Schema checks (level column, geometry column) — footer-only read.
-    let file = File::open(input_path)?;
-    let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
+    // (For a remote source, #210, the footer is range-fetched once here and
+    // cached across the passes below.)
+    let builder = source.open()?;
     let input_schema: SchemaRef = builder.schema().clone();
+
+    // CRS detection + rejection (spec Q3) — footer metadata only.
+    let crs = super::convert::detect_crs_from_kv(
+        builder.metadata().file_metadata().key_value_metadata(),
+    )?;
 
     // Regional extract (#102): prune input row groups by bbox covering
     // statistics — footer metadata only, no data pages of skipped groups are
@@ -163,7 +166,7 @@ pub(super) fn convert_streaming(
         num_rows,
         skipped_rows,
     } = run_pass1(
-        input_path,
+        source,
         &input_schema,
         geom_idx,
         options,
@@ -427,7 +430,7 @@ pub(super) fn convert_streaming(
             &mut writer,
             level_idx,
             e.hint,
-            input_path,
+            source,
             options.read_batch_size,
             selected_row_groups.as_deref(),
             &ctx,
@@ -471,6 +474,7 @@ pub(super) fn convert_streaming(
         row_groups_read,
         antimeridian_suspect_features,
         duration_secs: start.elapsed().as_secs_f64(),
+        remote_fetch: super::convert::log_remote_fetch(source),
     })
 }
 
@@ -672,7 +676,7 @@ struct Pass1Output {
 /// the per-spec source values (parallel to `acc_cols`). Memory: `O(read
 /// batch)` transient + `O(N)` small per-feature records.
 fn run_pass1(
-    input_path: &Path,
+    source: &InputSource,
     input_schema: &Schema,
     geom_idx: usize,
     options: &ConvertOptions,
@@ -701,8 +705,7 @@ fn run_pass1(
     // Original schema index → projected batch column index.
     let proj = |orig: usize| cols.binary_search(&orig).expect("projected column");
 
-    let file = File::open(input_path)?;
-    let mut builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
+    let mut builder = source.open()?;
     let mask = ProjectionMask::roots(builder.parquet_schema(), cols.iter().copied());
     // Regional extract (#102): read only the bbox-selected row groups
     // (identical selection in pass 2, keeping row indices aligned).
@@ -1000,14 +1003,12 @@ fn write_level_streaming(
     writer: &mut OverviewWriter<File>,
     level_idx: usize,
     hint: usize,
-    input_path: &Path,
+    source: &InputSource,
     read_batch_size: usize,
     row_groups: Option<&[usize]>,
     ctx: &LevelStreamCtx<'_>,
 ) -> Result<(usize, usize), ConvertError> {
-    let file = File::open(input_path)?;
-    let mut builder =
-        ParquetRecordBatchReaderBuilder::try_new(file)?.with_batch_size(read_batch_size.max(1));
+    let mut builder = source.open()?.with_batch_size(read_batch_size.max(1));
     // Regional extract (#102): read the same bbox-selected row groups as
     // pass 1, so the winner tables' global row indices line up.
     if let Some(rgs) = row_groups {

--- a/crates/core/src/quality.rs
+++ b/crates/core/src/quality.rs
@@ -120,9 +120,20 @@ pub fn extract_crs(path: &Path) -> Result<CrsInfo> {
 
     let metadata = reader.metadata();
     let file_metadata = metadata.file_metadata();
+    crs_info_from_kv_metadata(file_metadata.key_value_metadata())
+}
 
+/// Extract CRS information from already-parsed parquet key-value metadata.
+///
+/// The metadata-only core of [`extract_crs`], shared with input paths that
+/// have a parsed footer in hand already (e.g. remote inputs, #210, where the
+/// footer was range-fetched once and re-opening the file would cost another
+/// round trip).
+pub fn crs_info_from_kv_metadata(
+    kv_metadata: Option<&Vec<parquet::file::metadata::KeyValue>>,
+) -> Result<CrsInfo> {
     // Look for the "geo" key in key-value metadata
-    let Some(kv_metadata) = file_metadata.key_value_metadata() else {
+    let Some(kv_metadata) = kv_metadata else {
         // No metadata at all - assume WGS84 with warning
         tracing::warn!("GeoParquet file has no key-value metadata; assuming WGS84");
         return Ok(CrsInfo::wgs84());

--- a/crates/python/Cargo.toml
+++ b/crates/python/Cargo.toml
@@ -14,7 +14,7 @@ name = "gpq_tiles"
 crate-type = ["cdylib"]
 
 [dependencies]
-gpq-tiles-core = { workspace = true }
+gpq-tiles-core = { workspace = true, features = ["remote"] }
 pyo3 = { workspace = true }
 tempfile = "3"
 

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -36,7 +36,9 @@ use std::path::Path;
 /// them raises ``TypeError``.
 ///
 /// Args:
-///     input (str): Path to input GeoParquet file (EPSG:4326 or EPSG:3857).
+///     input (str): Path to input GeoParquet file (EPSG:4326 or EPSG:3857),
+///         or a remote URL (``s3://``, ``https://``, ``gs://``) read via
+///         byte-range requests.
 ///     output (str): Path to output PMTiles file.
 ///     min_zoom (int, optional): Minimum (coarsest) zoom level. Defaults to 0.
 ///     max_zoom (int, optional): Maximum (finest) zoom level. Defaults to 14.
@@ -170,6 +172,17 @@ fn convert_report_to_dict(py: Python<'_>, report: &ConvertReport) -> PyResult<Py
     dict.set_item("row_groups_total", report.row_groups_total)?;
     dict.set_item("row_groups_read", report.row_groups_read)?;
     dict.set_item("duration_secs", report.duration_secs)?;
+    // Remote-input fetch counters (#210); None for local inputs.
+    match &report.remote_fetch {
+        Some(stats) => {
+            let rf = PyDict::new(py);
+            rf.set_item("requests", stats.requests)?;
+            rf.set_item("bytes_fetched", stats.bytes_fetched)?;
+            rf.set_item("object_size", stats.object_size)?;
+            dict.set_item("remote_fetch", rf)?;
+        }
+        None => dict.set_item("remote_fetch", py.None())?,
+    }
     Ok(dict.into())
 }
 
@@ -183,7 +196,10 @@ fn convert_report_to_dict(py: Python<'_>, report: &ConvertReport) -> PyResult<Py
 /// exportable to PMTiles by ``export_pmtiles()``.
 ///
 /// Args:
-///     input (str): Input GeoParquet file (EPSG:4326 or EPSG:3857).
+///     input (str): Input GeoParquet file (EPSG:4326 or EPSG:3857): a local
+///         path or a remote URL (``s3://``, ``https://``, ``gs://``) read via
+///         byte-range requests. With ``bbox``, only the matching row groups
+///         of a remote input are ever downloaded.
 ///     output (str): Output overview GeoParquet file.
 ///     mode (str, optional): Level materialization mode, "duplicating" (each
 ///         level is a self-contained rendering) or "partitioning" (each
@@ -283,7 +299,9 @@ fn convert_report_to_dict(py: Python<'_>, report: &ConvertReport) -> PyResult<Py
 ///     "level", "gsd", "zoom", "feature_count", "vertex_count",
 ///     "uncompressed_bytes", "compressed_bytes"), "input_features",
 ///     "total_rows", "total_vertices", "total_compressed_bytes",
-///     "row_groups_total", "row_groups_read", "duration_secs".
+///     "row_groups_total", "row_groups_read", "duration_secs", and
+///     "remote_fetch" (None for local inputs; for remote URLs a dict with
+///     "requests", "bytes_fetched", "object_size").
 ///
 /// Raises:
 ///     ValueError: Invalid options (bad mode/direction/op, conflicting or

--- a/crates/python/tests/test_overview.py
+++ b/crates/python/tests/test_overview.py
@@ -36,7 +36,9 @@ class TestRemoteInput:
                 gpq_tiles.overview("ftp://example.com/x.parquet", str(out))
 
     def test_docstring_mentions_remote_urls(self):
-        assert "s3://" in gpq_tiles.overview.__doc__
+        doc = gpq_tiles.overview.__doc__
+        assert doc is not None
+        assert "s3://" in doc
 
 
 class TestOverviewApi:

--- a/crates/python/tests/test_overview.py
+++ b/crates/python/tests/test_overview.py
@@ -26,6 +26,19 @@ needs_roads = pytest.mark.skipif(
 )
 
 
+class TestRemoteInput:
+    """Remote-URL input handling (#210) — no network needed."""
+
+    def test_unsupported_scheme_is_helpful_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir) / "o.parquet"
+            with pytest.raises(RuntimeError, match="s3://"):
+                gpq_tiles.overview("ftp://example.com/x.parquet", str(out))
+
+    def test_docstring_mentions_remote_urls(self):
+        assert "s3://" in gpq_tiles.overview.__doc__
+
+
 class TestOverviewApi:
     """API-surface tests for overview() (no fixture needed)."""
 
@@ -182,6 +195,8 @@ class TestOverviewIntegration:
             assert report["input_features"] > 0
             assert report["total_rows"] >= report["input_features"]
             assert report["duration_secs"] > 0
+            # Local inputs carry no remote fetch counters (#210).
+            assert report["remote_fetch"] is None
             # z0..z6 requested; coarse levels where every (tiny) building falls
             # below the visibility gate are omitted, so <= 7 levels survive and
             # the canonical (finest) one is always z6 with every input feature.

--- a/deny.toml
+++ b/deny.toml
@@ -16,6 +16,23 @@ ignore = [
     # paste is unmaintained; pulled in transitively by parquet (arrow-rs).
     # Blocked on arrow-rs migrating off it. Re-evaluate on arrow/parquet bump.
     { id = "RUSTSEC-2024-0436", reason = "transitive via parquet/arrow-rs; no fix released" },
+    # quick-xml < 0.41 XML-parsing DoS pathologies (quadratic duplicate-
+    # attribute check; unbounded NsReader namespace allocation). Transitive
+    # via object_store's S3/GCS support (remote input, #210), which uses
+    # quick-xml only to parse XML responses from the *configured* storage
+    # endpoint (list/multipart/error bodies) — not attacker-supplied
+    # documents; worst case is self-DoS by a hostile bucket provider. No
+    # object_store release reaches the fix yet: even 0.14.0 pins
+    # quick-xml ^0.40.1 (< 0.41), and 0.13+ needs rustc 1.85 > our 1.75
+    # MSRV anyway. Mirror of the same ignores in .cargo/audit.toml
+    # (cargo-audit does not read this file). Re-evaluate on object_store
+    # bump.
+    { id = "RUSTSEC-2026-0194", reason = "transitive via object_store (s3/gcs XML responses); no release with quick-xml >=0.41 exists" },
+    { id = "RUSTSEC-2026-0195", reason = "transitive via object_store (s3/gcs XML responses); no release with quick-xml >=0.41 exists" },
+    # rustls-pemfile is unmaintained (functionality folded into rustls-pki-
+    # types); pulled in transitively by object_store (remote input, #210).
+    # Blocked on object_store dropping it upstream. Re-evaluate on bump.
+    { id = "RUSTSEC-2025-0134", reason = "transitive via object_store; unmaintained-only advisory, no vulnerability" },
 ]
 
 [licenses]

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ export_pmtiles("overviews.parquet", "output.pmtiles")
 - [Overview Tuning](OVERVIEW_TUNING.md) — Every generalization knob explained
 - [API Reference](api-reference.md) — CLI flags, Python API, Rust API
 - [Advanced Usage](advanced-usage.md) — Input optimization, memory, export
-- [Remote Reads](remote-reads.md) — Querying overview files on object storage with DuckDB
+- [Remote Reads](remote-reads.md) — Converting directly from s3://, https://, gs:// inputs, and querying overview files in place with DuckDB
 - [Architecture](architecture.md) — Design decisions and internals
 
 ## License

--- a/docs/remote-reads.md
+++ b/docs/remote-reads.md
@@ -1,4 +1,80 @@
-# Reading Overviews from Object Storage with DuckDB
+# Remote Reads
+
+Two independent capabilities live on this page:
+
+1. [**Converting directly from remote GeoParquet**](#converting-directly-from-remote-geoparquet)
+   — `gpq-tiles overview s3://bucket/file.parquet out.parquet` (native,
+   issue #210).
+2. [**Querying overview files in place with DuckDB**](#reading-overviews-from-object-storage-with-duckdb)
+   — the client-side recipe for files you have already published.
+
+## Converting directly from remote GeoParquet
+
+The `overview` and `tiles` subcommands (and the Python `overview()` /
+`convert()` functions) accept `s3://`, `https://`, `http://`, and
+`gs://` URLs as the *input* path. The converter reads the object with
+HTTP byte-range requests through the same synchronous parquet pipeline
+used for local files: footer first, then each column chunk of each row
+group it actually needs. Nothing is staged to disk.
+
+```bash
+# Full remote conversion
+gpq-tiles overview s3://bucket/country.parquet overviews.parquet
+
+# The headline: a regional extract composing with --bbox row-group
+# pruning (#102) — pruned row groups are NEVER downloaded.
+gpq-tiles overview s3://bucket/country.parquet city.parquet \
+    --bbox 28.75,46.95,28.95,47.10
+```
+
+Measured on the bench bucket (`us-east-2`, residential link): a
+Chisinau extract from the 92 MB Moldova polygons file (20k-row row
+groups) reads **5/31 row groups, 16.6 MiB = 17.9 % of the object** in
+~9 s; a neighborhood extract from the 28 MB NYC points file reads
+**3/23 row groups, 3.7 MiB = 12.9 %** in ~4 s — without ever
+downloading either file.
+Every conversion from a remote input logs (and reports, in the JSON
+report's `remote_fetch` field) the request count and bytes moved.
+
+What to know:
+
+- **Auth (S3)** — the standard AWS credential chain, same as DuckDB's
+  `credential_chain` provider and gpio: env keys, `AWS_PROFILE` /
+  shared config, SSO, IMDS. If the chain resolves nothing, requests
+  fall back to *unsigned*, so public buckets work with no setup. Set
+  the region explicitly (`AWS_REGION=us-east-2`): with no region in
+  env or profile the conversion fails fast with a hint, and a wrong
+  region costs a redirect round trip per request.
+- **Plain HTTPS** — anonymous; any server that honors `Range` works
+  (public S3/GCS URLs, GitHub release assets, ...).
+- **`--bbox` + row groups** — savings are bounded by the input's
+  row-group granularity and spatial ordering. A gpio-optimized input
+  (`gpio sort hilbert --add-bbox`, modest `--row-group-size`) is what
+  makes the few-percent extract real; a file with 4 giant row groups
+  cannot be pruned finer than quarters.
+- **Fetch behavior** — one range request per selected column chunk
+  (the page reader's many small reads are served from a whole-chunk
+  buffer), plus the footer. The parsed footer and up to 256 MiB of
+  fetched chunks are cached per conversion, so the streaming
+  pipeline's per-pass/per-level re-reads are refetch-free while the
+  selected data fits that cache (measured: the default streaming
+  pipeline and `--no-streaming` move identical bytes on a city
+  extract). Only when a conversion's *selected* data exceeds 256 MiB
+  does streaming mode re-fetch evicted chunks on later passes —
+  for a huge full-file remote conversion, consider downloading first.
+- **Latency vs bytes** — requests are issued sequentially, so on a
+  fast link a plain `aws s3 cp` + local convert can still win on wall
+  time (92 MB corpus file, residential fiber: ~3 s download+convert
+  vs ~9 s remote-direct). Remote-direct wins on bytes moved (5.6×
+  less on that extract), on slow/metered links, and whenever you
+  don't want the full file on disk.
+- **Remote output is out of scope** — write locally, then
+  `aws s3 cp`.
+- Rust builds: remote input lives behind the `remote` cargo feature of
+  `gpq-tiles-core` (off by default for the bare library; the CLI and
+  Python builds enable it).
+
+## Reading Overviews from Object Storage with DuckDB
 
 Overview GeoParquet is designed to be queried in place over HTTP range
 requests: a viewport query touches **0.14–6.5 % of the file**, whatever
@@ -15,7 +91,7 @@ viewports, and harness as the §2b baseline; raw data in
 [`benchmarks/overview/duckdb_knobs_results.json`](https://github.com/geoparquet-io/gpq-tiles/blob/main/benchmarks/overview/duckdb_knobs_results.json),
 harness `bench_duckdb_knobs.py`).
 
-## One-time setup
+### One-time setup
 
 ```sql
 INSTALL httpfs;
@@ -35,7 +111,7 @@ Public buckets / plain HTTPS need no secret at all —
 matters: with the wrong (or defaulted) region every request can pay an
 extra 301-redirect round trip.
 
-## Recommended session settings
+### Recommended session settings
 
 ```sql
 SET enable_http_metadata_cache = true;  -- cache HEAD results across queries
@@ -47,7 +123,7 @@ SET parquet_metadata_cache = true;      -- cache parsed parquet footers
 
 That is the whole recipe. The rest of this section is the evidence.
 
-### What each knob measurably did
+#### What each knob measurably did
 
 Sweep: two datasets (79 MB points, 343 MB polygons), three viewports
 each (world/regional/street), cold = fresh process, 3-run medians.
@@ -70,7 +146,7 @@ you is the *session*: metadata caches plus the (default-on) external
 file cache turn repeat and overlapping viewports from seconds into
 milliseconds.
 
-### Cold vs warm-session behavior
+#### Cold vs warm-session behavior
 
 What to expect, using the 343 MB polygons file as the example
 (medians; the small file behaves the same, scaled down):
@@ -100,7 +176,7 @@ format supports it: a purpose-built reader gets footer-cached pans of
 130–300 ms (see the latency-floor section of `RESULTS.md` §2b and
 `benchmarks/overview/parallel_reader.py`).
 
-## The viewport query (read protocol)
+### The viewport query (read protocol)
 
 An overview file is plain GeoParquet plus a `level` column and a
 `geo:overviews` footer key. The whole read protocol is: pick a level,


### PR DESCRIPTION
Closes #210

## What

`gpq-tiles overview` / `tiles` (and Python `overview()` / `convert()`) now accept `s3://`, `https://`, `http://`, and `gs://` URLs as the input path. The converter reads the object with HTTP byte-range requests through the existing **synchronous** parquet pipeline — nothing is staged to disk, and the pipeline itself was not rewritten as async.

```bash
gpq-tiles overview s3://bucket/country.parquet city.parquet --bbox 28.75,46.95,28.95,47.10
```

## Design

- **`InputSource` abstraction** (`crates/core/src/input.rs`): `Local(PathBuf)` (unchanged behavior) or `Remote` backed by `object_store`, implementing parquet's `ChunkReader`. All five former `std::fs::File::open` input sites in `convert.rs` / `stream.rs` / `quality.rs` route through it. New public entry `convert_to_overviews_source(&InputSource, ...)` for callers with custom stores.
- **Buffered range-fetch adapter**: the parquet page reader touches a column chunk via many small reads (thrift page header through `get_read`, then per-page `get_bytes`). Each **selected** column chunk is fetched as **one** range request on first touch and buffered; a 256 MiB insertion-order cache keeps fetched chunks so the streaming pipeline's per-pass/per-level re-reads are refetch-free for regional extracts. The parsed footer is fetched once per conversion and reused across all opens.
- **Composition with #102/#207 (the headline)**: `select_input_row_groups` decides row groups from footer statistics alone, so with `--bbox` the pruned row groups are **never downloaded**. Sequential reads are clamped to column-chunk boundaries so not one byte of a pruned group moves — `bbox_extract_{streaming,in_memory}_fetches_only_selected_row_groups` assert this against the recorded fetch ranges (every fetched range must avoid pruned groups' byte spans).
- **Auth**: standard AWS credential chain via `aws-config` (env keys, `AWS_PROFILE`/shared config, SSO, IMDS — what DuckDB `credential_chain`/gpio users expect), bridged into `object_store`'s credential provider with refresh. No resolvable credentials ⇒ unsigned requests, so public buckets work with zero setup. Region: `AWS_REGION`/`AWS_DEFAULT_REGION` env wins, then the profile-resolved region; neither ⇒ fail fast with a hint. Plain HTTPS is anonymous (any `Range`-honoring server).
- **Feature gating**: core gains a non-default `remote` feature (object_store + tokio + aws-config + url + async-trait); **the CLI and Python crates enable it by default**, so every shipped binary has it. A URL input on a non-`remote` core build gets a clear error. CI compiles it everywhere (`--all-features`).
- **Reporting**: `ConvertReport.remote_fetch { requests, bytes_fetched, object_size }` (also in the Python report dict + `--report` JSON), plus an info log line per conversion.
- Unsupported schemes get a helpful error; `export-pmtiles`/`decode` reject URLs with a pointer to `overview`/`tiles` (remote *output* is a non-goal).

## Bytes moved (the point of the feature)

Bench bucket, `us-east-2`, gpio-optimized inputs (Hilbert + bbox covering, 20k-row row groups — uploaded as `corpus/*.rg20k.parquet`):

| extract | row groups read | bytes moved | wall |
|---|---|---|---|
| Chisinau from 92 MB Moldova polygons | 5/31 | **16.6 MiB = 17.9 %** | ~9 s |
| NYC neighborhood from 28 MB points | 3/23 | **3.7 MiB = 12.9 %** | ~4 s |
| download-then-convert (Moldova) | — | 92 MB (100 %) | ~3 s on fast fiber |

Streaming vs in-memory now move **identical bytes** (the chunk cache absorbs the multi-pass re-reads; before the cache, streaming refetched 52 % vs 18 %). Honest caveat, documented in `docs/remote-reads.md`: requests are sequential, so on a fast link `aws s3 cp` + local convert still wins wall time; remote-direct wins bytes (5.6× less here), slow/metered links, and no-disk-staging. Savings are bounded by input row-group granularity — the original 6-row-group Moldova file could only be pruned to 54 %, which is exactly the gpio row-group-sizing recommendation.

## Tests

Unit (in-memory object store, run in CI):
- `input::tests::*` — scheme parsing (local/relative/`file://`/Windows-drive), helpful unsupported-scheme error, `RemoteDisabled` without the feature, parquet roundtrip over range requests, footer cached across opens, sequential-read correctness, out-of-bounds range error
- `overview::convert::tests::remote_input::bbox_extract_streaming_fetches_only_selected_row_groups` / `..._in_memory_...` — **the #210 property**: fetched ranges ∩ pruned row-group spans = ∅, selected group fetched, `bytes_fetched < object_size`
- `remote_convert_matches_local_convert`, `unsupported_scheme_errors_through_convert`
- Python: `TestRemoteInput` (scheme error via bindings, docstring), `remote_fetch is None` for local inputs

Network integration (skip gracefully — loudly — without credentials/network; verified both paths):
- `remote_s3_city_extract_integration` — full remote `--bbox` convert against `s3://gpq-tiles-bench/corpus/points-nyc-medium.rg20k.parquet`, asserts pruning fired and `bytes_fetched < 25 %` of the object (measured 12.87 %, default streaming pipeline)
- `input::tests::remote_tests::https_public_object_integration` — anonymous HTTPS footer read of a GitHub release asset, asserts partial fetch

Gates run: targeted `overview::convert::` (50), `input::` (15), CLI (4), Python remote tests; `cargo clippy --all-targets --all-features -D`-clean; `cargo fmt`; `cargo machete` clean; core compiles with and without `remote`.

## Docs

- `docs/remote-reads.md` — new "Converting directly from remote GeoParquet" section (auth, fetch behavior, latency-vs-bytes tradeoff, granularity guidance) ahead of the existing DuckDB recipe (headings demoted under the new page structure)
- `context/ARCHITECTURE.md` module map, README feature bullet, CLI `--help`, Python docstrings

## Notes

- `object_store` pinned to 0.12 (0.14 needs rustc 1.85 > our 1.75 MSRV). The `remote` dependency tree (aws-config et al.) may not build on 1.75 itself, but it is feature-gated off in the bare core library and nothing in CI pins the MSRV toolchain.
- Uploaded `corpus/points-nyc-medium.{,rg20k.}parquet` and `corpus/polygons-ftw-moldova-large.{,rg20k.}parquet` to the bench bucket (the existing `overviews/*.dup.parquet` objects carry a `level` column, which `convert` rightly rejects as input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)