### PR TITLE
perf(core): single-read pipelined pass-2 engine + --profile presets (#213, #212)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ parquet = "58"
 arrow-schema = "58"
 arrow-array = "58"
 arrow-select = "58"
+arrow-ipc = "58"
 geo = "0.32"
 geozero = { version = "0.14", features = ["with-wkb", "with-geo"] }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -514,6 +514,30 @@ struct OverviewArgs {
     #[arg(long, value_name = "ROWS", default_value = "8192")]
     read_batch_size: usize,
 
+    /// Memory/throughput profile for the single-read pass-2 engine (#213/#212).
+    ///
+    /// `speed` buffers each output level's rows in RAM (fastest; peak RAM grows
+    /// with buffered output). `bounded` spills them to temporary Arrow IPC
+    /// files (memory-capped; slight temp-I/O cost). `auto` (default) picks per
+    /// mode + estimated size — duplicating → speed, partitioning → bounded, and
+    /// any run whose estimated buffered output exceeds a budget → bounded.
+    /// Output is byte-identical across profiles. No effect with --no-streaming.
+    #[arg(
+        long,
+        default_value = "auto",
+        value_parser = ["auto", "speed", "bounded"]
+    )]
+    profile: String,
+
+    /// Read batches allowed in flight through the pass-2 pipeline at once
+    /// (read/compute-overlap knob; bounded-channel depth).
+    ///
+    /// Higher improves core utilization on long-pole geometries at
+    /// proportionally more peak memory (in-flight-batches × read-batch-size rows
+    /// resident). No effect with --no-streaming.
+    #[arg(long, value_name = "N", default_value = "4")]
+    in_flight_batches: usize,
+
     /// Write the JSON conversion report to this path.
     #[arg(long, value_name = "PATH")]
     report: Option<PathBuf>,
@@ -744,7 +768,7 @@ fn run_tiles(args: TilesArgs) -> Result<()> {
 fn run_overview(args: OverviewArgs) -> Result<()> {
     use gpq_tiles_core::overview::assign::{AssignConfig, DensityBudgetConfig, SortDirection};
     use gpq_tiles_core::overview::convert::{convert_to_overviews, ConvertOptions, LevelPlan};
-    use gpq_tiles_core::overview::level::Mode;
+    use gpq_tiles_core::overview::level::{MemoryProfile, Mode};
     use gpq_tiles_core::overview::simplify::SimplifyOptions;
     use gpq_tiles_core::overview::writer::RowGroupSizePolicy;
 
@@ -754,6 +778,13 @@ fn run_overview(args: OverviewArgs) -> Result<()> {
         "duplicating" => Mode::Duplicating,
         "partitioning" => Mode::Partitioning,
         other => anyhow::bail!("invalid --mode '{other}' (duplicating|partitioning)"),
+    };
+
+    let profile = match args.profile.as_str() {
+        "auto" => MemoryProfile::Auto,
+        "speed" => MemoryProfile::Speed,
+        "bounded" => MemoryProfile::Bounded,
+        other => anyhow::bail!("invalid --profile '{other}' (auto|speed|bounded)"),
     };
 
     // Explicit --gsd list overrides the zoom range.
@@ -856,6 +887,8 @@ fn run_overview(args: OverviewArgs) -> Result<()> {
         full_column_stats: args.full_column_stats,
         streaming: !args.no_streaming,
         read_batch_size: args.read_batch_size,
+        profile,
+        in_flight_batches: args.in_flight_batches,
         cluster: args.cluster,
         accumulate,
         coalesce_lines,

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -37,10 +37,12 @@ parquet = { workspace = true }
 arrow-schema = { workspace = true }
 arrow-array = { workspace = true }
 arrow-select = { workspace = true }
+arrow-ipc = { workspace = true }
 geo = { workspace = true }
 geozero = { workspace = true }
 prost = { workspace = true }
 rayon = { workspace = true }
+crossbeam-channel = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }
 tracing = { workspace = true }

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -63,8 +63,8 @@ use super::coalesce::{
 };
 use super::level::{
     gsd_with_base, AccumulatedColumn, ClusteringProvenance, CoalescingProvenance, Crs,
-    DensityProvenance, Generalization, GeneralizationLevel, Mode, RankingProvenance, GSD_TILE_BASE,
-    METERS_PER_DEGREE,
+    DensityProvenance, Generalization, GeneralizationLevel, MemoryProfile, Mode, RankingProvenance,
+    GSD_TILE_BASE, METERS_PER_DEGREE,
 };
 use super::simplify::{simplify_for_level, Simplified, SimplifyOptions};
 use super::writer::{
@@ -314,6 +314,18 @@ pub struct ConvertOptions {
     /// overhead at the cost of proportionally more peak memory; smaller
     /// batches bound memory tighter. No effect when `streaming` is `false`.
     pub read_batch_size: usize,
+    /// Memory/throughput profile for the streaming pass-2 engine (#213/#212).
+    /// Default [`MemoryProfile::Auto`], resolved per mode + estimated output
+    /// size at convert entry. Changes speed and peak memory only — output is
+    /// byte-identical across profiles. No effect when `streaming` is `false`.
+    pub profile: MemoryProfile,
+    /// Number of Arrow read batches allowed in flight through the streaming
+    /// pass-2 pipeline at once (bounded-channel depth / read-compute overlap
+    /// knob). Default [`DEFAULT_IN_FLIGHT_BATCHES`]. Higher improves core
+    /// utilization on long-pole geometries at proportionally more peak memory
+    /// (`in_flight_batches × read_batch_size` rows resident). No effect when
+    /// `streaming` is `false`.
+    pub in_flight_batches: usize,
     /// Enable point clustering (plan Q4; opt-in per spec §11 Q4). Duplicating
     /// mode only. When enabled, each level's point cell-winners absorb the
     /// other point features in their cell: the output gains a `point_count`
@@ -379,6 +391,11 @@ pub struct ConvertOptions {
 /// Default rows per read batch for the streaming pipeline (H3).
 pub const DEFAULT_READ_BATCH_SIZE: usize = 8192;
 
+/// Default number of read batches in flight through the pass-2 pipeline
+/// (#213). Four keeps a few cores fed on long-pole geometries while bounding
+/// resident batches to `4 × read_batch_size` rows.
+pub const DEFAULT_IN_FLIGHT_BATCHES: usize = 4;
+
 impl Default for ConvertOptions {
     fn default() -> Self {
         Self {
@@ -400,6 +417,8 @@ impl Default for ConvertOptions {
             full_column_stats: false,
             streaming: true,
             read_batch_size: DEFAULT_READ_BATCH_SIZE,
+            profile: MemoryProfile::Auto,
+            in_flight_batches: DEFAULT_IN_FLIGHT_BATCHES,
             cluster: false,
             accumulate: Vec::new(),
             coalesce_lines: true,
@@ -644,6 +663,11 @@ fn validate_options(options: &ConvertOptions) -> Result<(), ConvertError> {
             )));
         }
     }
+    if options.in_flight_batches == 0 {
+        return Err(ConvertError::InvalidConfig(
+            "in-flight-batches must be >= 1".to_string(),
+        ));
+    }
     Ok(())
 }
 
@@ -667,6 +691,39 @@ pub fn convert_to_overviews_source(
     source: &InputSource,
     output_path: &Path,
     options: &ConvertOptions,
+) -> Result<ConvertReport, ConvertError> {
+    convert_to_overviews_source_strategy(
+        source,
+        output_path,
+        options,
+        super::stream::Pass2Strategy::Pipelined,
+    )
+}
+
+/// [`convert_to_overviews`] over a path with an explicit pass-2
+/// [`Pass2Strategy`] — tests pin the serial reference strategy through the
+/// exact production setup.
+///
+/// [`Pass2Strategy`]: super::stream::Pass2Strategy
+#[cfg(test)]
+pub(crate) fn convert_to_overviews_strategy(
+    input_path: impl AsRef<Path>,
+    output_path: impl AsRef<Path>,
+    options: &ConvertOptions,
+    strategy: super::stream::Pass2Strategy,
+) -> Result<ConvertReport, ConvertError> {
+    let source = InputSource::from_path(input_path.as_ref())?;
+    convert_to_overviews_source_strategy(&source, output_path.as_ref(), options, strategy)
+}
+
+/// [`convert_to_overviews_source`] with an explicit pass-2 [`Pass2Strategy`].
+/// Runs the full option normalization (validation, cluster/accumulate checks,
+/// the partitioning-coalesce-inert rewrite) before dispatching.
+pub(crate) fn convert_to_overviews_source_strategy(
+    source: &InputSource,
+    output_path: &Path,
+    options: &ConvertOptions,
+    strategy: super::stream::Pass2Strategy,
 ) -> Result<ConvertReport, ConvertError> {
     // Knob sanity (H4), shared by both pipelines.
     validate_options(options)?;
@@ -705,7 +762,7 @@ pub fn convert_to_overviews_source(
     // Two-pass bounded-memory pipeline (H3, default). The in-memory path below
     // is kept as the reference implementation (`streaming: false`).
     if options.streaming {
-        return super::stream::convert_streaming(source, output_path, options);
+        return super::stream::convert_streaming_strategy(source, output_path, options, strategy);
     }
 
     let start = Instant::now();
@@ -3148,6 +3205,179 @@ mod tests {
                 read_level_rows(&mr, level),
                 read_level_rows(&sr, level),
                 "level {level} rows differ"
+            );
+        }
+    }
+
+    /// Assert two overview output files are structurally + logically identical:
+    /// same row-group layout (the deterministic on-disk structure), same footer
+    /// `geo:overviews` metadata, and same per-level row content (ids, attrs,
+    /// geometry, order). This is the meaningful "byte-identical" invariant — the
+    /// Parquet writer's footer metadata region is not byte-deterministic
+    /// run-to-run (serial-vs-serial also differs by a few bytes there), so a raw
+    /// `Vec<u8>` compare is not a valid equivalence check.
+    fn assert_outputs_equivalent(a: &Path, b: &Path, ctx: &str) {
+        use parquet::file::reader::{FileReader, SerializedFileReader};
+
+        // Row-group layout (num groups, rows per group, column count).
+        let layout = |p: &Path| -> Vec<(i64, usize)> {
+            let r = SerializedFileReader::new(std::fs::File::open(p).unwrap()).unwrap();
+            let md = r.metadata();
+            (0..md.num_row_groups())
+                .map(|i| (md.row_group(i).num_rows(), md.row_group(i).columns().len()))
+                .collect()
+        };
+        assert_eq!(layout(a), layout(b), "{ctx}: row-group layout differs");
+
+        // Footer geo:overviews metadata (semantic).
+        assert_eq!(
+            overviews_footer_json(a),
+            overviews_footer_json(b),
+            "{ctx}: geo:overviews footer differs"
+        );
+
+        // Per-level row content + order.
+        let ra = OverviewReader::open(a).unwrap();
+        let rb = OverviewReader::open(b).unwrap();
+        assert_eq!(
+            ra.num_levels(),
+            rb.num_levels(),
+            "{ctx}: level count differs"
+        );
+        for level in 0..ra.num_levels() {
+            assert_eq!(
+                read_level_rows(&ra, level),
+                read_level_rows(&rb, level),
+                "{ctx}: level {level} rows differ"
+            );
+        }
+    }
+
+    /// The single-read pipelined engine (#213/#212) must produce output
+    /// identical to the serial per-level-re-read reference — across both modes,
+    /// both sink backings (speed = RAM, bounded = Arrow IPC spill), and the
+    /// clustering feature. The bounded case also proves the spill round-trip is
+    /// lossless.
+    #[test]
+    fn pipelined_matches_serial() {
+        use super::super::level::MemoryProfile;
+        use super::super::stream::Pass2Strategy;
+
+        // A polygon set (duplicating/clustering simplify paths) and a dense
+        // point grid (partitioning fans many features across several levels, so
+        // the engine buffers/spills multiple non-finest levels).
+        let poly_in = tempfile::NamedTempFile::new().unwrap();
+        write_input(poly_in.path(), &synthetic_geometries(), false, None);
+        let grid_in = tempfile::NamedTempFile::new().unwrap();
+        write_input(grid_in.path(), &grid_points(600), false, None);
+
+        let cases: Vec<(&str, &Path, ConvertOptions)> = vec![
+            (
+                "duplicating",
+                poly_in.path(),
+                ConvertOptions {
+                    mode: Mode::Duplicating,
+                    levels: LevelPlan::ZoomRange {
+                        min_zoom: 1,
+                        max_zoom: 10,
+                    },
+                    ..Default::default()
+                },
+            ),
+            (
+                "partitioning",
+                grid_in.path(),
+                ConvertOptions {
+                    mode: Mode::Partitioning,
+                    levels: LevelPlan::ZoomRange {
+                        min_zoom: 1,
+                        max_zoom: 9,
+                    },
+                    ..Default::default()
+                },
+            ),
+            (
+                "clustering",
+                grid_in.path(),
+                ConvertOptions {
+                    mode: Mode::Duplicating,
+                    cluster: true,
+                    levels: LevelPlan::ZoomRange {
+                        min_zoom: 1,
+                        max_zoom: 9,
+                    },
+                    ..Default::default()
+                },
+            ),
+        ];
+
+        for (name, input, base) in &cases {
+            let serial_out = tempfile::NamedTempFile::new().unwrap();
+            convert_to_overviews_strategy(input, serial_out.path(), base, Pass2Strategy::Serial)
+                .unwrap();
+
+            for profile in [MemoryProfile::Speed, MemoryProfile::Bounded] {
+                let opts = ConvertOptions {
+                    profile,
+                    ..base.clone()
+                };
+                let piped_out = tempfile::NamedTempFile::new().unwrap();
+                convert_to_overviews_strategy(
+                    input,
+                    piped_out.path(),
+                    &opts,
+                    Pass2Strategy::Pipelined,
+                )
+                .unwrap();
+                assert_outputs_equivalent(
+                    serial_out.path(),
+                    piped_out.path(),
+                    &format!("{name}/{profile:?}"),
+                );
+            }
+        }
+    }
+
+    /// Pipelined output must be invariant to batching/overlap knobs
+    /// (`read_batch_size`, `in_flight_batches`) — proving the ordered-sink /
+    /// no-reorder-buffer invariant holds regardless of how the single read is
+    /// chunked or how many batches overlap in flight.
+    #[test]
+    fn pipelined_invariant_to_batching_knobs() {
+        use super::super::stream::Pass2Strategy;
+
+        let geoms = grid_points(600);
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        write_input(tin.path(), &geoms, false, None);
+
+        let base = ConvertOptions {
+            mode: Mode::Duplicating,
+            levels: LevelPlan::ZoomRange {
+                min_zoom: 1,
+                max_zoom: 9,
+            },
+            ..Default::default()
+        };
+
+        let convert = |read_batch_size: usize, in_flight_batches: usize| {
+            let opts = ConvertOptions {
+                read_batch_size,
+                in_flight_batches,
+                ..base.clone()
+            };
+            let out = tempfile::NamedTempFile::new().unwrap();
+            convert_to_overviews_strategy(tin.path(), out.path(), &opts, Pass2Strategy::Pipelined)
+                .unwrap();
+            out
+        };
+
+        let reference = convert(7, 1);
+        for (rbs, ifb) in [(64usize, 4usize), (4096, 8)] {
+            let candidate = convert(rbs, ifb);
+            assert_outputs_equivalent(
+                reference.path(),
+                candidate.path(),
+                &format!("read_batch_size={rbs} in_flight_batches={ifb}"),
             );
         }
     }

--- a/crates/core/src/overview/level.rs
+++ b/crates/core/src/overview/level.rs
@@ -115,6 +115,30 @@ pub enum Mode {
     Partitioning,
 }
 
+/// Memory/throughput profile for the streaming pass-2 engine.
+///
+/// The engine reads the input **once** and pipelines Parquet read/decode with
+/// parallel per-feature simplification, buffering each output level until it is
+/// written (levels are written coarse→fine). This profile selects how that
+/// per-level output is buffered — it changes **speed and peak memory only**;
+/// output bytes are identical across all profiles and thread counts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MemoryProfile {
+    /// Resolve per mode + estimated output size at convert entry (duplicating →
+    /// [`Speed`](Self::Speed), partitioning → [`Bounded`](Self::Bounded); any
+    /// run whose estimated buffered output exceeds a memory budget flips to
+    /// `Bounded`). The resolved choice is logged. This is the default.
+    #[default]
+    Auto,
+    /// Buffer each output level's rows in RAM before writing. Fastest; peak RAM
+    /// grows with total buffered output.
+    Speed,
+    /// Spill each output level's rows to a temporary Arrow IPC file and stream
+    /// them back at write time, capping peak RAM.
+    Bounded,
+}
+
 /// OPTIONAL, informative per-level generalization provenance (§3.5).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Generalization {

--- a/crates/core/src/overview/mod.rs
+++ b/crates/core/src/overview/mod.rs
@@ -20,6 +20,7 @@ pub mod export;
 #[cfg(test)]
 mod hostile;
 pub mod level;
+mod pipeline;
 pub mod reader;
 pub mod simplify;
 mod stream;

--- a/crates/core/src/overview/pipeline.rs
+++ b/crates/core/src/overview/pipeline.rs
@@ -1,0 +1,313 @@
+//! Single-read, pipelined pass-2 engine for the streaming converter
+//! (#213 / #212).
+//!
+//! The original pass 2 ([`super::stream`]) re-opened and re-read the entire
+//! input **once per emitted level** (15 full-file reads on a 15-level plan) and
+//! parallelized only a per-batch `par_iter` within one level at a time —
+//! starving to ~2 of 16 threads because reads between batches were serial and a
+//! single giant geometry was a per-batch long pole.
+//!
+//! This engine reads the input **once** and fans each batch to **all** buffered
+//! levels at once:
+//!
+//! - a dedicated reader thread streams the input in order over a bounded
+//!   channel (depth = `in_flight`, the read/compute-overlap and backpressure
+//!   knob), tagging each batch with its cumulative `row_offset`;
+//! - the consumer processes one batch at a time (batches stay in read order, so
+//!   no reorder buffer is needed), but parallelizes across levels — every
+//!   `(level × feature)` simplification in the batch is a rayon task, so the
+//!   giant-geometry long pole at one level overlaps the other levels' work;
+//! - each level's finished output batches accumulate in an ordered **sink**
+//!   (RAM under the `speed` profile, spilled to a temporary Arrow IPC file under
+//!   `bounded`), and after the read completes the sinks drain into the writer in
+//!   level order (writers demand levels 0,1,2… contiguously).
+//!
+//! Output is **byte-identical** to the serial path: within a batch the ascending
+//! `selected` order and `process_level_batch`'s order-preserving `par_iter` are
+//! unchanged, and batches reach every sink in ascending read order, so each
+//! level's row sequence — and therefore its row-group boundaries — match exactly.
+//!
+//! The finest/canonical level is **not** handled here: it is verbatim, the
+//! largest level, and written last, so [`super::stream`] streams it directly
+//! into the writer on a second read rather than buffering it
+//! ("canonical-streamed-last").
+
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
+use std::time::{Duration, Instant};
+
+use arrow_array::RecordBatch;
+use arrow_ipc::reader::StreamReader;
+use arrow_ipc::writer::StreamWriter;
+use arrow_schema::Schema;
+use crossbeam_channel::bounded;
+use rayon::prelude::*;
+use tempfile::NamedTempFile;
+
+use crate::input::InputSource;
+
+use super::convert::ConvertError;
+use super::level::{MemoryProfile, Mode};
+use super::stream::{process_level_batch, LevelStreamCtx, Pass2Timers};
+use super::writer::OverviewWriter;
+
+/// How a level's buffered output is held until it is written.
+#[derive(Clone, Copy, Debug)]
+pub(super) enum SinkBacking {
+    /// Buffer output batches in RAM (`speed` profile).
+    Ram,
+    /// Spill output batches to a temporary Arrow IPC file (`bounded` profile).
+    Spill,
+}
+
+/// Resolve the [`MemoryProfile`] (including [`MemoryProfile::Auto`]) to a
+/// concrete [`SinkBacking`], logging the decision.
+///
+/// `buffered_rows` is the total winner count of the levels the engine buffers
+/// (all but the streamed finest level). `Auto` keeps duplicating mode in RAM
+/// (it buffers only the small, geometrically-decayed coarse levels) and keeps
+/// partitioning mode in RAM only while the buffered set is small — partitioning
+/// buffers full-resolution geometry, so a large buffered set spills. An
+/// explicit profile always wins.
+pub(super) fn resolve_backing(
+    profile: MemoryProfile,
+    mode: Mode,
+    buffered_rows: usize,
+) -> SinkBacking {
+    /// Buffered-row count above which `Auto` spills partitioning's
+    /// full-resolution geometry instead of holding it in RAM.
+    const PARTITIONING_SPILL_ROWS: usize = 2_000_000;
+
+    let backing = match profile {
+        MemoryProfile::Speed => SinkBacking::Ram,
+        MemoryProfile::Bounded => SinkBacking::Spill,
+        MemoryProfile::Auto => match mode {
+            Mode::Duplicating => SinkBacking::Ram,
+            Mode::Partitioning => {
+                if buffered_rows > PARTITIONING_SPILL_ROWS {
+                    SinkBacking::Spill
+                } else {
+                    SinkBacking::Ram
+                }
+            }
+        },
+    };
+    log::debug!(
+        "pass2 memory profile {profile:?} + {mode:?} (buffered ~{buffered_rows} rows) → {backing:?}"
+    );
+    backing
+}
+
+/// A message from the reader thread: one raw input batch, its cumulative row
+/// offset, and how long the read+decode took (for [profile] accounting).
+struct ReadMsg {
+    row_offset: usize,
+    batch: RecordBatch,
+    read_dur: Duration,
+}
+
+/// One level's ordered output buffer.
+enum LevelSink {
+    Ram(Vec<RecordBatch>),
+    Spill(SpillState),
+}
+
+impl LevelSink {
+    fn new(backing: SinkBacking, out_schema: &Schema) -> Result<Self, ConvertError> {
+        Ok(match backing {
+            SinkBacking::Ram => LevelSink::Ram(Vec::new()),
+            SinkBacking::Spill => LevelSink::Spill(SpillState::new(out_schema)?),
+        })
+    }
+
+    fn push(&mut self, batch: RecordBatch) -> Result<(), ConvertError> {
+        match self {
+            LevelSink::Ram(v) => {
+                v.push(batch);
+                Ok(())
+            }
+            LevelSink::Spill(s) => s.push(&batch),
+        }
+    }
+}
+
+/// A level spilled to a temporary Arrow IPC stream file. The write handle and
+/// the read handle are independent `reopen()`s of the same temp file; Arrow IPC
+/// is a lossless value round-trip, so the reloaded batches are identical to the
+/// buffered ones and the final Parquet encode stays byte-identical.
+struct SpillState {
+    writer: StreamWriter<BufWriter<File>>,
+    temp: NamedTempFile,
+}
+
+impl SpillState {
+    fn new(out_schema: &Schema) -> Result<Self, ConvertError> {
+        let temp = NamedTempFile::new()?;
+        let write_handle = temp.reopen()?;
+        let writer = StreamWriter::try_new(BufWriter::new(write_handle), out_schema)?;
+        Ok(SpillState { writer, temp })
+    }
+
+    fn push(&mut self, batch: &RecordBatch) -> Result<(), ConvertError> {
+        self.writer.write(batch)?;
+        Ok(())
+    }
+
+    /// Finish writing and reopen the temp file for reading. The returned
+    /// [`NamedTempFile`] must be held until the reader is exhausted so the file
+    /// is not unlinked mid-read (and is cleaned up on drop afterwards).
+    fn into_reader(self) -> Result<(StreamReader<BufReader<File>>, NamedTempFile), ConvertError> {
+        let SpillState { mut writer, temp } = self;
+        writer.finish()?; // writes EOS + flushes the BufWriter to the file
+        drop(writer); // close the write handle
+        let read_handle = temp.reopen()?;
+        let reader = StreamReader::try_new(BufReader::new(read_handle), None)?;
+        Ok((reader, temp))
+    }
+}
+
+/// Buffer + write levels `0..ctxs.len()` (all but the streamed finest level)
+/// from a single read of the input. Returns `(rows_written, vertex_count)` per
+/// level, in level order.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn run_pass2_buffered(
+    writer: &mut OverviewWriter<File>,
+    ctxs: &[LevelStreamCtx<'_>],
+    hints: &[usize],
+    source: &InputSource,
+    read_batch_size: usize,
+    selected_row_groups: Option<&[usize]>,
+    in_flight: usize,
+    backing: SinkBacking,
+    out_schema: &Schema,
+) -> Result<Vec<(usize, usize)>, ConvertError> {
+    let num_levels = ctxs.len();
+    debug_assert_eq!(num_levels, hints.len());
+
+    let t_engine = Instant::now();
+    let timers = Pass2Timers::default();
+
+    let mut sinks: Vec<LevelSink> = Vec::with_capacity(num_levels);
+    for _ in 0..num_levels {
+        sinks.push(LevelSink::new(backing, out_schema)?);
+    }
+    let mut rows = vec![0usize; num_levels];
+    let mut verts = vec![0usize; num_levels];
+
+    // Build the single-pass reader here (bbox-selected row groups, #102 — the
+    // same selection both passes use, so global row indices stay aligned), then
+    // hand the owned reader to a dedicated reader thread. A synchronous Parquet
+    // reader driven from a dedicated thread (not the rayon pool) keeps reads
+    // from being head-of-line blocked behind compute work.
+    let mut builder = source.open()?.with_batch_size(read_batch_size.max(1));
+    if let Some(rgs) = selected_row_groups {
+        builder = builder.with_row_groups(rgs.to_vec());
+    }
+    let mut reader = builder.build()?;
+
+    let (tx, rx) = bounded::<ReadMsg>(in_flight.max(1));
+    let reader_handle = std::thread::spawn(move || -> Result<(), ConvertError> {
+        let mut row_offset = 0usize;
+        loop {
+            let t_read = Instant::now();
+            match reader.next() {
+                None => break,
+                Some(Ok(batch)) => {
+                    let read_dur = t_read.elapsed();
+                    let offset = row_offset;
+                    row_offset += batch.num_rows();
+                    if tx
+                        .send(ReadMsg {
+                            row_offset: offset,
+                            batch,
+                            read_dur,
+                        })
+                        .is_err()
+                    {
+                        break; // consumer dropped the receiver (error path)
+                    }
+                }
+                Some(Err(e)) => return Err(e.into()),
+            }
+        }
+        Ok(())
+    });
+
+    // Consumer: process batches in read order; parallelize across levels within
+    // each batch. Because batches arrive in order and are appended before the
+    // next is pulled, each sink stays in input order without a reorder buffer.
+    let consume: Result<(), ConvertError> = (|| {
+        for msg in rx.iter() {
+            Pass2Timers::add_dur(timers.read_cell(), msg.read_dur);
+            let batch = &msg.batch;
+            let row_offset = msg.row_offset;
+            let results: Vec<Result<Option<(RecordBatch, usize)>, ConvertError>> = (0..num_levels)
+                .into_par_iter()
+                .map(|li| process_level_batch(batch, row_offset, &ctxs[li], &timers))
+                .collect();
+            for (li, res) in results.into_iter().enumerate() {
+                if let Some((out, v)) = res? {
+                    rows[li] += out.num_rows();
+                    verts[li] += v;
+                    sinks[li].push(out)?;
+                }
+            }
+        }
+        Ok(())
+    })();
+    drop(rx); // ensure the reader thread can stop if the consumer errored
+
+    // Join the reader before propagating: a reader error is the more likely
+    // root cause and takes precedence over a downstream consume error.
+    match reader_handle.join() {
+        Ok(read_result) => read_result?,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
+    consume?;
+
+    // Drain each level's sink into the writer, in level order.
+    for li in 0..num_levels {
+        let sink = std::mem::replace(&mut sinks[li], LevelSink::Ram(Vec::new()));
+        drain_sink(writer, li, hints[li], sink)?;
+    }
+
+    timers.log_engine_summary(t_engine.elapsed().as_secs_f64(), rows.iter().sum());
+    Ok(rows.into_iter().zip(verts).collect())
+}
+
+/// Drain one level's sink into `writer.write_level`. The RAM path is
+/// infallible; the spill path reuses the error-parking discipline of
+/// `write_level_streaming` because `write_level` consumes an infallible
+/// iterator but Arrow IPC read-back can fail.
+fn drain_sink(
+    writer: &mut OverviewWriter<File>,
+    level_idx: usize,
+    hint: usize,
+    sink: LevelSink,
+) -> Result<(), ConvertError> {
+    match sink {
+        LevelSink::Ram(batches) => {
+            writer.write_level(level_idx, Some(hint), batches.into_iter())?;
+            Ok(())
+        }
+        LevelSink::Spill(state) => {
+            // `_temp` keeps the spill file on disk until the reader is drained.
+            let (mut reader, _temp) = state.into_reader()?;
+            let err: std::cell::RefCell<Option<ConvertError>> = std::cell::RefCell::new(None);
+            let iter = std::iter::from_fn(|| match reader.next() {
+                None => None,
+                Some(Ok(b)) => Some(b),
+                Some(Err(e)) => {
+                    *err.borrow_mut() = Some(ConvertError::Arrow(e));
+                    None
+                }
+            });
+            let res = writer.write_level(level_idx, Some(hint), iter);
+            if let Some(e) = err.borrow_mut().take() {
+                return Err(e); // spill read error takes precedence over the writer's
+            }
+            res?;
+            Ok(())
+        }
+    }
+}

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -48,6 +48,7 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
 use std::fs::File;
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use arrow_array::{Array, RecordBatch, UInt32Array};
@@ -75,6 +76,7 @@ use super::convert::{
     KNOWN_ROAD_CLASSES, ROAD_VOCAB_MIN_DISTINCT,
 };
 use super::level::{Crs, Mode, RankingProvenance};
+use super::pipeline;
 use super::simplify::{
     full_resolution_fallback_count, simplify_for_level, Simplified, SimplifyOptions,
 };
@@ -97,11 +99,25 @@ struct EmitLevel {
     hint: usize,
 }
 
-/// Streaming counterpart of [`super::convert::convert_to_overviews`].
-pub(super) fn convert_streaming(
+/// Pass-2 execution strategy. Both produce byte-identical output; `Serial` is
+/// the pre-#213 per-level-re-read reference, retained for differential testing.
+#[derive(Clone, Copy)]
+pub(crate) enum Pass2Strategy {
+    /// One in-order re-read per level (the reference path).
+    #[cfg_attr(not(test), allow(dead_code))]
+    Serial,
+    /// Single-read pipelined engine ([`super::pipeline`]); the production path.
+    Pipelined,
+}
+
+/// Streaming counterpart of [`super::convert::convert_to_overviews`], with an
+/// explicit pass-2 [`Pass2Strategy`] (production uses `Pipelined`; tests pin
+/// `Serial` to assert the pipelined engine is equivalent).
+pub(crate) fn convert_streaming_strategy(
     source: &InputSource,
     output_path: &Path,
     options: &ConvertOptions,
+    strategy: Pass2Strategy,
 ) -> Result<ConvertReport, ConvertError> {
     let start = Instant::now();
 
@@ -379,64 +395,131 @@ pub(super) fn convert_streaming(
         .filter(|&c| c != geom_idx)
         .collect();
 
-    // --- Pass 2: per level, stream → filter → simplify → write. --------------
+    // --- Pass 2: single-read pipelined engine + canonical streamed last. -----
     let t_pass2 = Instant::now();
-    let mut level_reports = Vec::with_capacity(emitted.len());
-    for (level_idx, e) in emitted.iter().enumerate() {
-        // Verbatim path: partitioning at every level (§2.3), and duplicating at
-        // the canonical (finest) level (§2.4).
-        let verbatim = matches!(options.mode, Mode::Partitioning) || e.orig as usize == finest;
-        // Coalescing (Q3): rebuild this level's chain table (chains + gate +
-        // thin + simplify) from the pass-1 line scratch. Canonical level is
-        // never coalesced (§2.4). Memory: one level's surviving chains.
-        let coalesce_table: Option<CoalesceTable> = coalesce_scratch
-            .as_ref()
-            .filter(|_| !verbatim)
-            .map(|scratch| {
-                build_level_coalesce_table(
-                    &scratch.inputs(),
-                    e.orig as usize,
-                    finest,
-                    e.gsd,
-                    crs,
-                    options,
+
+    // Prebuild every non-verbatim level's coalesce chain table up front, in
+    // parallel: the single read fans each batch to all levels at once, so all
+    // levels' tables must exist during the read. Deterministic and keyed by rep
+    // row, so this is byte-identical to the former per-level build.
+    let coalesce_tables: Vec<Option<CoalesceTable>> = match &coalesce_scratch {
+        Some(scratch) => {
+            let inputs = scratch.inputs();
+            emitted
+                .par_iter()
+                .map(|e| {
+                    let verbatim =
+                        matches!(options.mode, Mode::Partitioning) || e.orig as usize == finest;
+                    (!verbatim).then(|| {
+                        build_level_coalesce_table(
+                            &inputs,
+                            e.orig as usize,
+                            finest,
+                            e.gsd,
+                            crs,
+                            options,
+                        )
+                    })
+                })
+                .collect()
+        }
+        None => std::iter::repeat_with(|| None)
+            .take(emitted.len())
+            .collect(),
+    };
+
+    let duplicating = matches!(options.mode, Mode::Duplicating);
+    let ctxs: Vec<LevelStreamCtx> = emitted
+        .iter()
+        .enumerate()
+        .map(|(i, e)| {
+            let verbatim = matches!(options.mode, Mode::Partitioning) || e.orig as usize == finest;
+            LevelStreamCtx {
+                source_schema: &source_schema,
+                cluster_schema: &cluster_schema,
+                out_schema: &out_schema,
+                non_geom_cols: &non_geom_cols,
+                geom_idx,
+                min_levels: &min_levels,
+                orig_level: e.orig,
+                duplicating,
+                verbatim,
+                gsd_m: e.gsd,
+                crs,
+                simplify: &options.simplify,
+                cluster_enabled: options.cluster,
+                // Canonical level: singleton clusters, columns verbatim (§2.4).
+                cluster_table: cluster_tables
+                    .as_ref()
+                    .filter(|_| e.orig as usize != finest)
+                    .map(|t| &t[e.orig as usize]),
+                acc_cols: &acc_cols,
+                coalesce_enabled: options.coalesce_lines,
+                kinds: kinds.as_deref(),
+                coalesce_table: coalesce_tables[i].as_ref(),
+            }
+        })
+        .collect();
+
+    let n = emitted.len();
+    let hints: Vec<usize> = emitted.iter().map(|e| e.hint).collect();
+
+    // `(rows, vertices)` per level, in level order.
+    let level_stats: Vec<(usize, usize)> = match strategy {
+        // Reference: one in-order re-read per level (pre-#213 behavior).
+        Pass2Strategy::Serial => ctxs
+            .iter()
+            .enumerate()
+            .map(|(i, ctx)| {
+                write_level_streaming(
+                    &mut writer,
+                    i,
+                    hints[i],
+                    source,
+                    options.read_batch_size,
+                    selected_row_groups.as_deref(),
+                    ctx,
                 )
-            });
-        let ctx = LevelStreamCtx {
-            source_schema: &source_schema,
-            cluster_schema: &cluster_schema,
-            out_schema: &out_schema,
-            non_geom_cols: &non_geom_cols,
-            geom_idx,
-            min_levels: &min_levels,
-            orig_level: e.orig,
-            duplicating: matches!(options.mode, Mode::Duplicating),
-            verbatim,
-            gsd_m: e.gsd,
-            crs,
-            simplify: &options.simplify,
-            cluster_enabled: options.cluster,
-            // Canonical level: singleton clusters, columns verbatim (§2.4).
-            cluster_table: cluster_tables
-                .as_ref()
-                .filter(|_| e.orig as usize != finest)
-                .map(|t| &t[e.orig as usize]),
-            acc_cols: &acc_cols,
-            coalesce_enabled: options.coalesce_lines,
-            kinds: kinds.as_deref(),
-            coalesce_table: coalesce_table.as_ref(),
-        };
-        let (rows, vertices) = write_level_streaming(
-            &mut writer,
-            level_idx,
-            e.hint,
-            source,
-            options.read_batch_size,
-            selected_row_groups.as_deref(),
-            &ctx,
-        )?;
+            })
+            .collect::<Result<_, _>>()?,
+        // Production: buffer levels 0..n-1 from a single read, then stream the
+        // finest (verbatim, largest) level last straight into the writer.
+        Pass2Strategy::Pipelined => {
+            let buffered_rows: usize = hints[..n - 1].iter().sum();
+            let backing = pipeline::resolve_backing(options.profile, options.mode, buffered_rows);
+            let mut stats = if n > 1 {
+                pipeline::run_pass2_buffered(
+                    &mut writer,
+                    &ctxs[..n - 1],
+                    &hints[..n - 1],
+                    source,
+                    options.read_batch_size,
+                    selected_row_groups.as_deref(),
+                    options.in_flight_batches,
+                    backing,
+                    &out_schema,
+                )?
+            } else {
+                Vec::new()
+            };
+            stats.push(write_level_streaming(
+                &mut writer,
+                n - 1,
+                hints[n - 1],
+                source,
+                options.read_batch_size,
+                selected_row_groups.as_deref(),
+                &ctxs[n - 1],
+            )?);
+            stats
+        }
+    };
+
+    let mut level_reports = Vec::with_capacity(emitted.len());
+    for (i, e) in emitted.iter().enumerate() {
+        let (rows, vertices) = level_stats[i];
         level_reports.push(LevelReport {
-            level: level_idx,
+            level: i,
             gsd: e.gsd,
             zoom: e.zoom,
             feature_count: rows,
@@ -939,27 +1022,54 @@ fn run_pass1(
 // Pass 2: per-level streaming filter → simplify → write
 // ============================================================================
 
-/// Wall-time accumulators for one level's pass-2 stream ([profile] logging).
+/// Wall-time accumulators for pass-2 stages ([profile] logging), stored as
+/// nanoseconds. Atomic so the pipelined engine ([`super::pipeline`]) can share
+/// one set across the parallel per-level processing of a batch; the serial
+/// [`write_level_streaming`] path uses it single-threaded.
 #[derive(Default)]
-struct Pass2Timers {
+pub(super) struct Pass2Timers {
     /// Parquet read + Arrow decode of the raw batch (`reader.next()`).
-    read: Cell<Duration>,
+    read: AtomicU64,
     /// Winner selection + geometry take/decode to `geo::Geometry`.
-    decode: Cell<Duration>,
+    decode: AtomicU64,
     /// Simplification (or verbatim vertex counting at the canonical level).
-    simplify: Cell<Duration>,
+    simplify: AtomicU64,
     /// Output batch assembly (`build_level_batch`).
-    build: Cell<Duration>,
+    build: AtomicU64,
 }
 
 impl Pass2Timers {
-    fn add(cell: &Cell<Duration>, start: Instant) {
-        cell.set(cell.get() + start.elapsed());
+    fn add(cell: &AtomicU64, start: Instant) {
+        cell.fetch_add(start.elapsed().as_nanos() as u64, Ordering::Relaxed);
+    }
+    /// Add a pre-measured duration (used by the reader thread for read time).
+    pub(super) fn add_dur(cell: &AtomicU64, dur: Duration) {
+        cell.fetch_add(dur.as_nanos() as u64, Ordering::Relaxed);
+    }
+    fn secs(cell: &AtomicU64) -> f64 {
+        Duration::from_nanos(cell.load(Ordering::Relaxed)).as_secs_f64()
+    }
+    pub(super) fn read_cell(&self) -> &AtomicU64 {
+        &self.read
+    }
+    /// Emit the aggregated per-stage breakdown ([profile] logging) for the
+    /// pipelined engine, where stages interleave across levels so a per-level
+    /// split is not meaningful.
+    pub(super) fn log_engine_summary(&self, total_secs: f64, rows: usize) {
+        let read_s = Self::secs(&self.read);
+        let decode_s = Self::secs(&self.decode);
+        let simplify_s = Self::secs(&self.simplify);
+        let build_s = Self::secs(&self.build);
+        log::debug!(
+            "[profile] pass2 engine ({rows} rows): wall={total_secs:.2}s \
+             read={read_s:.2}s decode={decode_s:.2}s simplify={simplify_s:.2}s \
+             build={build_s:.2}s (stage sums are core-seconds, overlap wall)"
+        );
     }
 }
 
 /// Immutable context for one level's pass-2 stream.
-struct LevelStreamCtx<'a> {
+pub(super) struct LevelStreamCtx<'a> {
     source_schema: &'a Schema,
     /// `source_schema` + trailing `point_count` when clustering, otherwise
     /// identical (the schema [`apply_cluster_columns`] produces).
@@ -1058,21 +1168,23 @@ fn write_level_streaming(
         return Err(e); // stream error takes precedence over the writer's
     }
     res?;
-    let total = t_level.elapsed();
-    let accounted =
-        timers.read.get() + timers.decode.get() + timers.simplify.get() + timers.build.get();
+    let total = t_level.elapsed().as_secs_f64();
+    let read_s = Pass2Timers::secs(&timers.read);
+    let decode_s = Pass2Timers::secs(&timers.decode);
+    let simplify_s = Pass2Timers::secs(&timers.simplify);
+    let build_s = Pass2Timers::secs(&timers.build);
     log::debug!(
         "[profile] level {} ({}, {} rows): total={:.2}s read={:.2}s decode={:.2}s \
          simplify={:.2}s build={:.2}s write={:.2}s",
         level_idx,
         if ctx.verbatim { "verbatim" } else { "simplify" },
         rows.get(),
-        total.as_secs_f64(),
-        timers.read.get().as_secs_f64(),
-        timers.decode.get().as_secs_f64(),
-        timers.simplify.get().as_secs_f64(),
-        timers.build.get().as_secs_f64(),
-        total.saturating_sub(accounted).as_secs_f64(),
+        total,
+        read_s,
+        decode_s,
+        simplify_s,
+        build_s,
+        (total - (read_s + decode_s + simplify_s + build_s)).max(0.0),
     );
     let fallbacks = full_resolution_fallback_count() - fallbacks_before;
     if fallbacks > 0 {
@@ -1087,7 +1199,7 @@ fn write_level_streaming(
 /// Process one input batch for one level: select the level's members from the
 /// winner table, decode only their geometries, simplify (unless verbatim), and
 /// assemble the output batch. Returns `None` when no member row survives.
-fn process_level_batch(
+pub(super) fn process_level_batch(
     batch: &RecordBatch,
     row_offset: usize,
     ctx: &LevelStreamCtx<'_>,

--- a/crates/python/gpq_tiles.pyi
+++ b/crates/python/gpq_tiles.pyi
@@ -52,6 +52,8 @@ def overview(
     streaming: bool = True,
     read_batch_size: int = 8192,
     bbox: tuple[float, float, float, float] | None = None,
+    profile: str = "auto",
+    in_flight_batches: int = 4,
 ) -> dict[str, Any]: ...
 def export_pmtiles(
     input: str,

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -11,7 +11,7 @@ use gpq_tiles_core::overview::convert::{
     convert_to_overviews, ClassRanking, ConvertError, ConvertOptions, ConvertReport, LevelPlan,
 };
 use gpq_tiles_core::overview::export::{export_pmtiles as export_pmtiles_core, ExportOptions};
-use gpq_tiles_core::overview::level::Mode;
+use gpq_tiles_core::overview::level::{MemoryProfile, Mode};
 use gpq_tiles_core::overview::simplify::SimplifyOptions;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
@@ -293,6 +293,14 @@ fn convert_report_to_dict(py: Python<'_>, report: &ConvertReport) -> PyResult<Py
 ///         their data pages (inputs without covering stats read everything
 ///         and rely on the exact per-feature filter). Defaults to None
 ///         (full extent).
+///     profile (str, optional): Memory/throughput profile for the single-read
+///         pass-2 engine: "speed" (buffer output in RAM), "bounded" (spill to
+///         temporary Arrow IPC files), or "auto" (pick per mode + estimated
+///         size). Output is byte-identical across profiles. Defaults to "auto".
+///     in_flight_batches (int, optional): Read batches allowed in flight through
+///         the pass-2 pipeline at once (read/compute-overlap knob). Higher
+///         improves core utilization at proportionally more peak memory.
+///         Defaults to 4.
 ///
 /// Returns:
 ///     dict: Conversion report with keys "mode", "levels" (list of dicts with
@@ -355,6 +363,8 @@ fn convert_report_to_dict(py: Python<'_>, report: &ConvertReport) -> PyResult<Py
     streaming=true,
     read_batch_size=8192,
     bbox=None,
+    profile="auto",
+    in_flight_batches=4,
 ))]
 #[allow(clippy::too_many_arguments)] // Python API mirrors CLI flags; grouping into struct would hurt usability
 fn overview(
@@ -394,6 +404,8 @@ fn overview(
     streaming: bool,
     read_batch_size: usize,
     bbox: Option<(f64, f64, f64, f64)>,
+    profile: &str,
+    in_flight_batches: usize,
 ) -> PyResult<Py<PyDict>> {
     let mode = match mode {
         "duplicating" => Mode::Duplicating,
@@ -401,6 +413,18 @@ fn overview(
         other => {
             return Err(PyErr::new::<PyValueError, _>(format!(
                 "Invalid mode: '{}'. Valid options: duplicating, partitioning",
+                other
+            )))
+        }
+    };
+
+    let profile = match profile {
+        "auto" => MemoryProfile::Auto,
+        "speed" => MemoryProfile::Speed,
+        "bounded" => MemoryProfile::Bounded,
+        other => {
+            return Err(PyErr::new::<PyValueError, _>(format!(
+                "Invalid profile: '{}'. Valid options: auto, speed, bounded",
                 other
             )))
         }
@@ -518,6 +542,8 @@ fn overview(
         full_column_stats,
         streaming,
         read_batch_size,
+        profile,
+        in_flight_batches,
         cluster,
         accumulate,
         coalesce_lines,

--- a/docs/OVERVIEW_TUNING.md
+++ b/docs/OVERVIEW_TUNING.md
@@ -32,6 +32,11 @@ interact.
 >   disable it entirely use `--no-density-drop`.
 > - **A rank-ordered cut is emptying sparse rural areas** → RAISE `--drop-gamma`
 >   (protects sparse neighborhoods).
+> - **Conversion is slow / pins one core** → it now reads the input once and
+>   uses all cores; RAISE `--in-flight-batches` for more read/compute overlap.
+> - **Conversion runs out of memory in `speed` mode** → `--profile bounded`
+>   (spills each level to temp files; `--profile auto`, the default, picks this
+>   for you on large partitioning runs). Output is byte-identical either way.
 
 ---
 
@@ -518,6 +523,8 @@ Moldova corpus file (632k polygons, 38M vertices) peak RSS drops from ~5.4 GB
 |------|---------|-------|-----------|
 | `--read-batch-size N` | `8192` | rows per read batch | **bigger = faster-ish, more memory** |
 | `--no-streaming` | off | flag | revert to the one-pass in-memory pipeline |
+| `--profile speed\|bounded\|auto` | `auto` | preset | speed vs bounded RAM — see [Performance profiles](#performance-profiles---profile---in-flight-batches) |
+| `--in-flight-batches N` | `4` | read batches in flight | read/compute overlap — see [Performance profiles](#performance-profiles---profile---in-flight-batches) |
 
 **`--read-batch-size`** bounds the transient working set of both passes: each
 batch is decoded, filtered, simplified, and written before the next is read.
@@ -584,6 +591,62 @@ reprojects the bbox internally.
 
 ---
 
+## Performance profiles: `--profile`, `--in-flight-batches`
+
+Like the [memory / streaming knobs](#memory--streaming-knobs---no-streaming---read-batch-size),
+these never change the output's content: **the produced file is byte-identical
+across every profile, `--in-flight-batches` value, and thread count.** They
+control only how fast the conversion runs and how much memory it uses while
+running.
+
+The rewritten pass-2 engine reads the input Parquet **once** and pipelines
+Parquet read/decode with per-feature simplification fanned out across **all
+cores**. This replaces the old pass 2, which re-read the whole input once per
+level (15 reads on a 15-level plan) and simplified effectively on a single
+core. The win is largest on vertex-heavy duplicating-mode conversions and on
+partitioning mode, which previously spent ~73% of wall time re-reading the
+input (#212 / #213).
+
+The one remaining choice is **where each output level's rows live between the
+compute stage and the write stage**:
+
+- **`speed`** buffers each level's rows in RAM, then writes them. Fastest — no
+  temp I/O — but peak RAM grows with total *output* size. Best when the output
+  comfortably fits: duplicating mode, or partitioning on inputs well under
+  available RAM.
+- **`bounded`** spills each level's rows to temporary **Arrow IPC** files and
+  streams them back at write time, capping peak RAM regardless of output size.
+  Slightly slower (temp read/write) but memory-safe for very large / wide
+  inputs. Best for partitioning mode on multi-GB inputs, or memory-constrained
+  machines.
+- **`auto`** (default) picks per mode and buffered size: duplicating always uses
+  `speed` (it buffers only the small, geometrically-decayed coarse levels);
+  partitioning uses `speed` while the buffered set is small and `bounded` once it
+  grows large (partitioning buffers full-resolution geometry). The chosen profile
+  is logged.
+
+| Knob | Default | Units | Direction |
+|------|---------|-------|-----------|
+| `--profile speed\|bounded\|auto` | `auto` | preset | `speed` = fastest, most RAM; `bounded` = capped RAM, temp I/O |
+| `--in-flight-batches N` | `4` | read batches in flight | **bigger = more overlap + core use, more memory** |
+
+**`--in-flight-batches`** is the primary read/compute-overlap knob: it sets how
+many Arrow read batches may be moving through the pipeline at once (the
+bounded-channel depth). RAISE it for more read/compute overlap and better core
+utilization when a few long-pole geometries otherwise stall the pipeline; each
+extra in-flight batch costs proportionally more peak RAM (`N × read_batch_size`
+rows resident). `--read-batch-size` (above) remains the rows-per-batch knob;
+`--in-flight-batches` is how many such batches coexist.
+
+⚠️ **Interaction — `speed` + partitioning on a multi-GB input is the
+memory-risky quadrant.** `speed` buffers whole output levels in RAM, and
+partitioning's output can approach input size; on a multi-GB input that can
+exhaust memory. `auto` (the default) already routes partitioning and any
+over-budget run to `bounded` — only an explicit `--profile speed` overrides
+that. If you force `speed` on a large partitioning run, watch peak RSS.
+
+---
+
 ## Worked scenarios
 
 | Symptom | Fix |
@@ -602,6 +665,8 @@ reprojects the bbox internally.
 | Need server-side row-group skipping on a property predicate | pass `--full-column-stats` (bigger footer, gains column pruning) |
 | Tiny viewports over high-latency storage fetch too much | LOWER `--row-group-size` for tighter bbox pruning |
 | Conversion runs out of memory / swaps on a big file | streaming is already the default; LOWER `--read-batch-size`; make sure `--no-streaming` is NOT set |
+| Conversion is slow / uses only one core | the engine now reads the input once and parallelizes simplification across all cores; RAISE `--in-flight-batches` for more read/compute overlap |
+| Conversion runs out of memory in `speed` profile | `--profile bounded` (spills each level to temp files, caps RAM); `--profile auto` picks this automatically for large partitioning runs |
 
 See `corpus/SWEEPS.md` for an empirical `--line-thinning` ×
 `--simplify-factor` sweep on Portland roads, and the Q2 section there for the


### PR DESCRIPTION
Closes #213. Substantially addresses #212 (the byte-identical half; the
output-changing cascading-simplification lever is split to #218 per
maintainer direction).

## Problem

Pass 2 of the streaming converter re-opened and **re-read the entire input
once per emitted level** (15 full-file reads on a 15-level plan) and
parallelized only a per-batch `par_iter` within one level at a time —
measured at ~2 of 16 threads on the #212 big-file runs, because reads
between batches were serial and one giant geometry was a per-batch long
pole. Partitioning spent ~73% of wall re-reading; duplicating ran
effectively on one core.

## Change

A single-read pipelined engine (`crates/core/src/overview/pipeline.rs`):

- a dedicated reader thread streams the input **once** over a bounded
  channel (depth = `--in-flight-batches`, the read/compute-overlap +
  backpressure knob);
- the consumer fans each batch to **all** buffered levels at once,
  parallelizing `(level × feature)` simplification so the long pole
  overlaps other work;
- each level's output accumulates in an ordered sink and drains into the
  writer in level order;
- the finest/canonical level (verbatim, largest, written last) is streamed
  on a second read instead of buffered ("canonical-streamed-last"), keeping
  duplicating-mode peak buffer small.

Because batches reach every sink in read order, no reorder buffer is needed
and **output is unchanged** — same rows, order, geometry, row-group layout,
and footer.

## `--profile speed|bounded|auto` + `--in-flight-batches`

Reading once forces per-level output buffering; the profile selects how:
`speed` buffers in RAM, `bounded` spills to temporary Arrow IPC files
(capped RAM), `auto` (default) picks per mode + estimated size
(duplicating→speed, partitioning→bounded, over-budget→bounded, logged).
Plumbed through core `ConvertOptions`, the CLI, and the Python bindings.

## Verification

- **Differential test**: the pipelined engine matches a retained serial
  per-level-re-read reference (same row-group layout + footer + per-row
  content/order) across both modes, both sink backings (RAM & IPC spill),
  and clustering. Plus a batching-invariance test (`read_batch_size` ×
  `in_flight_batches`).
- Existing streaming↔in-memory parity suite (7 tests) now runs through the
  engine — all pass; the partitioning case runs the spill path under
  default `auto`.
- Full overview→export→PMTiles→decode integration test passes.
- **CLI end-to-end** on `monster-coastline` (raw): `speed` and `bounded`
  outputs are **byte-for-byte identical** (`cmp` = 0) and both validate
  against the spec. Logs confirm `Auto→Ram` and `Bounded→Spill` paths.
- **Python**: `overview(..., profile=...)` works for all three profiles
  (identical results) and rejects invalid values.
- `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt` clean.

Note: the Parquet writer's footer metadata region is not byte-deterministic
run-to-run (serial-vs-serial also differs by a few bytes there), so
equivalence is asserted structurally (row-group layout + footer semantics +
per-row content), which is the meaningful invariant.

**Big-file numbers**: the projected 3.5–8× wants the 2.9 GB fieldmaps adm4
input (not in-repo) — recommend recording `benchmarks/overview/PROFILE.md`
before/after there.

## Follow-ups (opened)

- #218 cascading simplification (output-changing; the biggest #212 lever) +
  validation-fallback reduction
- #219 avoid re-fetching the finest level over the network for remote inputs
- #220 per-level row-group winner indexes for partitioning (if fan-out
  misses the ~50s target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
