### PR TITLE
perf(export): parallelize scan_level and gzip compression (#227)

### DIFF
--- a/crates/core/src/overview/export.rs
+++ b/crates/core/src/overview/export.rs
@@ -81,7 +81,8 @@ use serde::Serialize;
 
 use crate::batch_processor::extract_geometries_from_array;
 use crate::clip::clip_geometry;
-use crate::compression::Compression;
+use crate::compression::{self, Compression};
+use crate::dedup::TileHasher;
 use crate::mvt::{LayerBuilder, PropertyValue, TileBuilder};
 use crate::pmtiles_writer::StreamingPmtilesWriter;
 use crate::tile::{tile_ranges_for_bbox, tiles_for_bbox, BboxTileRanges, TileBounds, TileCoord};
@@ -208,11 +209,17 @@ struct Feature {
     props: Vec<(String, PropertyValue)>,
 }
 
-/// An encoded tile ready to hand to the PMTiles writer.
+/// An encoded tile ready to hand to the PMTiles writer. `data` is already
+/// **gzip-compressed** (compression runs in the parallel encode section, not on
+/// the serial writer thread — issue #227). `hash` is [`TileHasher::hash`] of the
+/// *uncompressed* MVT bytes, the dedup key; `raw_len` is the uncompressed length,
+/// kept for the writer's dedup byte-savings stat.
 struct EncodedTile {
     x: u32,
     y: u32,
     data: Vec<u8>,
+    hash: u64,
+    raw_len: usize,
     feature_count: usize,
     oversized: bool,
 }
@@ -351,7 +358,15 @@ fn export_pmtiles_with_partition_target(
                     if t.oversized {
                         oversized += 1;
                     }
-                    writer.add_tile_with_count(zoom, t.x, t.y, &t.data, t.feature_count)?;
+                    writer.add_tile_precompressed(
+                        zoom,
+                        t.x,
+                        t.y,
+                        t.hash,
+                        &t.data,
+                        t.raw_len,
+                        t.feature_count,
+                    )?;
                 }
                 tile_count += tiles.len();
             }
@@ -359,7 +374,7 @@ fn export_pmtiles_with_partition_target(
         }
         log::debug!(
             "[profile] z{zoom} (level {level_idx}, {} feats, {tile_count} tiles, {} partitions): \
-             scan={scan_secs:.2}s clip+encode={:.2}s write(gzip)={write_secs:.2}s",
+             scan={scan_secs:.2}s clip+encode+gzip={:.2}s write={write_secs:.2}s",
             scan.feature_count,
             partitions.len(),
             t_tiles.elapsed().as_secs_f64() - write_secs,
@@ -458,10 +473,6 @@ struct LevelCtx<'a> {
     opts: &'a ExportOptions,
 }
 
-/// Pass 1: stream the level band once and record, per tile, how many
-/// (feature × tile) members it will receive, plus the band's row count and
-/// the union of feature bboxes. Geometries are decoded for their bbox and
-/// dropped immediately; properties are not extracted.
 fn scan_level(
     reader: &OverviewReader,
     level_idx: usize,
@@ -485,26 +496,74 @@ fn scan_level(
         let mut geoms: Vec<Geometry<f64>> = Vec::with_capacity(batch.num_rows());
         extract_geometries_from_array(garr.as_ref(), &mut geoms)?;
         scan.feature_count += geoms.len();
-        for geom in &geoms {
-            let Some(rect) = geom.bounding_rect() else {
-                continue;
-            };
-            let mut bbox = TileBounds::new(rect.min().x, rect.min().y, rect.max().x, rect.max().y);
-            if matches!(crs, Crs::Epsg3857) {
-                // Web Mercator -> lon/lat is monotone per axis, so reprojecting
-                // the two corners reprojects the bbox — bit-identical to taking
-                // the bbox of the reprojected geometry.
-                let (lng_min, lat_min) = webmerc_to_lnglat(bbox.lng_min, bbox.lat_min);
-                let (lng_max, lat_max) = webmerc_to_lnglat(bbox.lng_max, bbox.lat_max);
-                bbox = TileBounds::new(lng_min, lat_min, lng_max, lat_max);
-            }
+
+        // Sizing every feature's tile footprint is embarrassingly parallel per
+        // feature (issue #227): each feature independently contributes its bbox
+        // to the bounds union and one member to each tile it spans. Fold into
+        // per-thread (bounds, counts) accumulators, then reduce. Both reductions
+        // (bbox union, per-tile count sum) are commutative and associative, so
+        // the merged result — and thus the exported archive — is identical to
+        // the old serial scan regardless of thread scheduling.
+        let (batch_bounds, batch_counts) = geoms
+            .par_iter()
+            .fold(
+                || (None::<TileBounds>, HashMap::<u64, usize>::new()),
+                |(mut bounds, mut counts), geom| {
+                    if let Some(rect) = geom.bounding_rect() {
+                        let mut bbox =
+                            TileBounds::new(rect.min().x, rect.min().y, rect.max().x, rect.max().y);
+                        if matches!(crs, Crs::Epsg3857) {
+                            // Web Mercator -> lon/lat is monotone per axis, so
+                            // reprojecting the two corners reprojects the bbox —
+                            // bit-identical to taking the bbox of the reprojected
+                            // geometry.
+                            let (lng_min, lat_min) = webmerc_to_lnglat(bbox.lng_min, bbox.lat_min);
+                            let (lng_max, lat_max) = webmerc_to_lnglat(bbox.lng_max, bbox.lat_max);
+                            bbox = TileBounds::new(lng_min, lat_min, lng_max, lat_max);
+                        }
+                        match &mut bounds {
+                            Some(acc) => acc.expand(&bbox),
+                            None => bounds = Some(bbox),
+                        }
+                        for tc in tiles_for_bbox(&bbox, zoom) {
+                            *counts.entry(tile_key(tc.x, tc.y)).or_insert(0) += 1;
+                        }
+                    }
+                    (bounds, counts)
+                },
+            )
+            .reduce(
+                || (None::<TileBounds>, HashMap::<u64, usize>::new()),
+                |(b_a, c_a), (b_b, c_b)| {
+                    let bounds = match (b_a, b_b) {
+                        (Some(mut a), Some(b)) => {
+                            a.expand(&b);
+                            Some(a)
+                        }
+                        (Some(a), None) | (None, Some(a)) => Some(a),
+                        (None, None) => None,
+                    };
+                    // Merge the smaller map into the larger to minimize rehashing.
+                    let (mut dst, src) = if c_a.len() >= c_b.len() {
+                        (c_a, c_b)
+                    } else {
+                        (c_b, c_a)
+                    };
+                    for (k, v) in src {
+                        *dst.entry(k).or_insert(0) += v;
+                    }
+                    (bounds, dst)
+                },
+            );
+
+        if let Some(b) = batch_bounds {
             match &mut scan.bounds {
-                Some(acc) => acc.expand(&bbox),
-                None => scan.bounds = Some(bbox),
+                Some(acc) => acc.expand(&b),
+                None => scan.bounds = Some(b),
             }
-            for tc in tiles_for_bbox(&bbox, zoom) {
-                *scan.tile_counts.entry(tile_key(tc.x, tc.y)).or_insert(0) += 1;
-            }
+        }
+        for (k, v) in batch_counts {
+            *scan.tile_counts.entry(k).or_insert(0) += v;
         }
     }
     Ok(scan)
@@ -590,7 +649,7 @@ fn process_partition(
     let collect_secs = t_collect.elapsed().as_secs_f64();
     let t_encode = Instant::now();
     let n_members = members.len();
-    let tiles = encode_members(members, ctx.zoom, ctx.opts);
+    let tiles = encode_members(members, ctx.zoom, ctx.opts)?;
     log::debug!(
         "[profile]     z{} partition [{:x}..{:x}]: rows_read={seq} members={n_members} \
          tiles={} collect={collect_secs:.2}s sort+encode={:.2}s",
@@ -968,13 +1027,11 @@ fn members_recursive_vec(
     out
 }
 
-/// Group members by tile and MVT-encode. A **parallel sort** on
-/// `(tile key, band order)` replaces the old serial per-zoom `BTreeMap`
-/// merge — `(key, seq)` pairs are unique (one member per feature per tile),
-/// so the unstable sort is deterministic, and within a tile members stay in
-/// band (file) order, exactly as before. Encoded tiles come back in ascending
-/// `(x, y)` order; empty tiles are dropped.
-fn encode_members(mut members: Vec<Member>, zoom: u8, opts: &ExportOptions) -> Vec<EncodedTile> {
+fn encode_members(
+    mut members: Vec<Member>,
+    zoom: u8,
+    opts: &ExportOptions,
+) -> Result<Vec<EncodedTile>, ExportError> {
     members.par_sort_unstable_by_key(|m| (m.key, m.seq));
 
     // Group boundaries (manual scan: `slice::chunk_by` needs Rust 1.77, MSRV
@@ -988,6 +1045,10 @@ fn encode_members(mut members: Vec<Member>, zoom: u8, opts: &ExportOptions) -> V
         }
     }
 
+    // Encode AND gzip-compress every tile in the parallel section, so the serial
+    // writer loop only dedups and appends bytes (issue #227). Compression must
+    // match the writer's `tile_compression` (Gzip) so `add_tile_precompressed`
+    // stays byte-identical to the old serial `add_tile_with_count` path.
     groups
         .into_par_iter()
         .filter_map(|g| {
@@ -997,13 +1058,21 @@ fn encode_members(mut members: Vec<Member>, zoom: u8, opts: &ExportOptions) -> V
             if count == 0 {
                 return None;
             }
-            Some(EncodedTile {
+            let hash = TileHasher::hash(&data);
+            let raw_len = data.len();
+            let compressed = match compression::compress(&data, Compression::Gzip) {
+                Ok(c) => c,
+                Err(e) => return Some(Err(ExportError::from(e))),
+            };
+            Some(Ok(EncodedTile {
                 x,
                 y,
-                data,
+                data: compressed,
+                hash,
+                raw_len,
                 feature_count: count,
                 oversized,
-            })
+            }))
         })
         .collect()
 }
@@ -1089,7 +1158,16 @@ fn encode_level_tiles(features: &[Feature], zoom: u8, opts: &ExportOptions) -> V
             });
         }
     }
-    encode_members(members, zoom, opts)
+    // `encode_members` returns gzip-COMPRESSED tile bytes (issue #227 moved
+    // compression into the parallel encode section). This helper exists to
+    // exercise MVT *encoding*, so decompress each tile back to raw MVT bytes;
+    // the assertions in the tests below operate on the uncompressed payload.
+    let mut tiles = encode_members(members, zoom, opts).expect("in-memory gzip is infallible");
+    for t in &mut tiles {
+        t.data = crate::compression::decompress(&t.data, Compression::Gzip)
+            .expect("gzip roundtrip of just-compressed tile");
+    }
+    tiles
 }
 
 /// Test-support: read every feature (geometry + carried properties) of a level

--- a/crates/core/src/pmtiles_writer.rs
+++ b/crates/core/src/pmtiles_writer.rs
@@ -1363,6 +1363,73 @@ impl StreamingPmtilesWriter {
         Ok(())
     }
 
+    /// Add a tile whose bytes are **already compressed** with this writer's
+    /// `tile_compression`.
+    ///
+    /// This is the parallel-friendly counterpart of [`Self::add_tile_with_count`]:
+    /// the caller compresses tile bytes off-thread (e.g. inside a Rayon
+    /// `par_iter`) and hands the finished bytes here so the serial ordering loop
+    /// never runs gzip. To keep deduplication byte-for-byte identical to the
+    /// serial path, `hash` MUST be the [`TileHasher::hash`] of the tile's
+    /// **uncompressed** MVT bytes (never the compressed bytes), and `raw_len` the
+    /// uncompressed length (used only for the dedup byte-savings stat). Because
+    /// compression is deterministic, an identical uncompressed hash implies
+    /// identical compressed bytes, so the archive is bit-identical to compressing
+    /// serially.
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_tile_precompressed(
+        &mut self,
+        z: u8,
+        x: u32,
+        y: u32,
+        hash: u64,
+        compressed: &[u8],
+        raw_len: usize,
+        feature_count: usize,
+    ) -> std::io::Result<()> {
+        let temp_file = self
+            .temp_file
+            .as_mut()
+            .ok_or_else(|| std::io::Error::other("Writer already finalized"))?;
+
+        let id = tile_id(z, x, y);
+        self.stats.total_tiles += 1;
+        self.total_features += feature_count as u64;
+
+        // Track zoom range
+        self.min_zoom = self.min_zoom.min(z);
+        self.max_zoom = self.max_zoom.max(z);
+
+        // Dedup on the uncompressed hash (same key as add_tile_with_count).
+        if let Some((offset, length)) = self.dedup_cache.get(&hash) {
+            self.entries.push(StreamingDirEntry {
+                tile_id: id,
+                offset: *offset,
+                length: *length,
+            });
+            self.stats.bytes_saved_dedup += raw_len as u64;
+            return Ok(());
+        }
+
+        // New unique tile - write the pre-compressed bytes verbatim.
+        let compressed_len = compressed.len() as u32;
+        temp_file.write_all(compressed)?;
+
+        let offset = self.current_offset;
+        self.dedup_cache.insert(hash, (offset, compressed_len));
+        self.entries.push(StreamingDirEntry {
+            tile_id: id,
+            offset,
+            length: compressed_len,
+        });
+
+        self.current_offset += compressed_len as u64;
+        self.stats.unique_tiles += 1;
+        self.stats.bytes_written += compressed_len as u64;
+
+        Ok(())
+    }
+
     /// Finalize the PMTiles file.
     ///
     /// Reads tile data from temp file and assembles the final PMTiles archive
@@ -2931,5 +2998,58 @@ mod tests {
         }
 
         let _ = fs::remove_file(output_path);
+    }
+
+    #[test]
+    fn add_tile_precompressed_matches_add_tile_with_count() {
+        // Issue #227 moves gzip off the serial writer thread: the export loop
+        // now compresses tiles inside the parallel encode section and hands the
+        // finished bytes (plus the *uncompressed* hash) to
+        // add_tile_precompressed. The resulting archive must be byte-identical
+        // to compressing serially via add_tile_with_count, including dedup: the
+        // 4th tile below repeats the 1st tile's content.
+        let tiles: Vec<(u8, u32, u32, Vec<u8>)> = vec![
+            (0, 0, 0, vec![0x1a, 0x05, b'h', b'e', b'l', b'l', b'o']),
+            (1, 0, 0, vec![0x1a, 0x03, b'a', b'b', b'c']),
+            (1, 0, 1, vec![0x1a, 0x03, b'x', b'y', b'z']),
+            (1, 1, 1, vec![0x1a, 0x05, b'h', b'e', b'l', b'l', b'o']), // dup of (0,0,0)
+        ];
+        let dir = std::env::temp_dir();
+
+        // Baseline: writer compresses each tile serially.
+        let mut serial = StreamingPmtilesWriter::new(Compression::Gzip).unwrap();
+        serial.set_layer_name("test");
+        serial.set_bounds(&TileBounds::new(-180.0, -85.0, 180.0, 85.0));
+        for (z, x, y, data) in &tiles {
+            serial.add_tile_with_count(*z, *x, *y, data, 1).unwrap();
+        }
+        let serial_path = dir.join("gpq-227-serial.pmtiles");
+        let _ = fs::remove_file(&serial_path);
+        serial.finalize(&serial_path).unwrap();
+
+        // New path: compress up front, hand bytes + uncompressed hash to writer.
+        let mut parallel = StreamingPmtilesWriter::new(Compression::Gzip).unwrap();
+        parallel.set_layer_name("test");
+        parallel.set_bounds(&TileBounds::new(-180.0, -85.0, 180.0, 85.0));
+        for (z, x, y, data) in &tiles {
+            let hash = TileHasher::hash(data);
+            let compressed = compression::compress(data, Compression::Gzip).unwrap();
+            parallel
+                .add_tile_precompressed(*z, *x, *y, hash, &compressed, data.len(), 1)
+                .unwrap();
+        }
+        let parallel_path = dir.join("gpq-227-parallel.pmtiles");
+        let _ = fs::remove_file(&parallel_path);
+        parallel.finalize(&parallel_path).unwrap();
+
+        let a = fs::read(&serial_path).unwrap();
+        let b = fs::read(&parallel_path).unwrap();
+        assert_eq!(
+            a, b,
+            "precompressed archive must be byte-identical to serial compression"
+        );
+
+        let _ = fs::remove_file(&serial_path);
+        let _ = fs::remove_file(&parallel_path);
     }
 }


### PR DESCRIPTION
## What

Closes two of the three parallelism holes in `export_pmtiles` from #227:

1. **`scan_level` parallelized** (item 2) — the pass-1 per-feature `bbox → tiles_for_bbox → count` loop is now a rayon `fold`/`reduce` over each batch's geometries. Both reductions (bbox union, per-tile member count) are commutative and associative, so the merged result is identical regardless of thread scheduling.
2. **gzip moved into the parallel section** (item 3) — tiles are now gzip-compressed inside the existing `encode_members` `par_iter`, not serially on the writer thread. A new `StreamingPmtilesWriter::add_tile_precompressed` takes the finished bytes plus the **uncompressed** `xxh3` hash and does dedup + append only.

The third hole — the **serial giant-feature tile loop** (item 1) — is **not** re-addressed here: #226 already eliminated it structurally (recursive `O(depth × vertices)` cascade) *and* parallelized the per-feature clip via `geoms.par_iter()`. Confirmed against current `collect_batch_members`.

## Correctness — output is byte-identical

Dedup still keys on the **uncompressed** tile hash (unchanged), and gzip is deterministic, so an identical uncompressed hash ⇒ identical compressed bytes ⇒ identical archive.

Verified by:
- **frozen-hash** export test (`export_archive_matches_pre_refactor_reference`, `a108f1607d994a92`) — still green
- **partition-invariance** test — still green
- new unit test `add_tile_precompressed_matches_add_tile_with_count` — proves the parallel writer path == the serial `add_tile_with_count` path, byte-for-byte, including a deduped tile
- **`cmp` of old-vs-new PMTiles on real data**: monster-admin (73 MB) and moldova (143 MB) archives are byte-identical between `main` and this branch

Full local gate: export 13/13, writer 55/55, tile 21/21, new test 1/1, `clippy -D warnings` clean, `fmt` clean.

## Benchmarks

Baseline is `main` — which **already includes #226** — so these numbers isolate #227's contribution alone. 16-core machine, release binaries, `export-pmtiles` step only.

| corpus | old (main+#226) | new (+#227) | speedup | CPU old→new |
|---|---|---|---|---|
| monster-admin (42 MB, few giant polygons) | 4:20.16 / 1094% | 4:16.48 / 1106% | ~1.0× | 1094% → 1106% |
| moldova (425 MB, dense polygons) | 3:22.61 / 957% | 2:59.65 / 1015% | **1.13×** | 957% → 1015% |

### Why this is a multiplier, not the "5–8×" the issue imagined

The issue's estimate assumed item 1 (the serial giant-feature loop) was still the dominant cause of low core utilization. **#226 landed first and removed exactly that**, so both corpora were already running at 6–11 of 16 cores, not 2.3. What remains — serial scan, serial gzip — are real but minor once #226 is in:

- **Dense polygons (moldova)** benefit most: many features → parallel scan, many tiles → parallel gzip → **~13% faster, +58% absolute CPU**.
- **Giant polygons (monster-admin)** are already clip-bound and parallel → negligible.

The scan win is further capped by `scan_level` re-reading + Arrow-decoding the whole level band serially (I/O-bound); only the tile-counting is now parallel. That serial band re-read is what **#228** (single-read per level) targets, so scan parallelism will pay off more once #228 lands.

## Why land it anyway

Byte-identical, clean, removes two genuine serial bottlenecks, and delivers a real ~1.13× on the dense-polygon workload — with more upside once #228 removes the I/O floor.
