### PR TITLE
robustness(export): incremental checkpoints + per-level progress logging (#229)

### DIFF
--- a/context/ARCHITECTURE.md
+++ b/context/ARCHITECTURE.md
@@ -119,6 +119,21 @@ export per-zoom feature totals (a feature spanning a tile seam appears in
 every tile it touches): 0% while a level fits one tile, ~7% at z14 on
 Portland roads.
 
+**Progress logging & salvageable output (#229).** Long exports get stuck in the
+finest level's scan/clip (adm4 DNF'd at 3h13m with nothing written), so export
+emits `[export]`-prefixed `log::info!` lines — visible under the CLI's default
+`info` filter — at three granularities: a `scan complete` marker, a per-level
+`done` summary (level *i/N*, zoom, feats, tiles, partitions, elapsed), and a
+throttled within-level **wave counter** (`WAVE_LOG_INTERVAL`, 30 s) so a stuck
+level is diagnosable in minutes (counter frozen) vs merely slow (counter
+advancing). After each finished level — throttled to `CHECKPOINT_INTERVAL`
+(60 s), so fast exports that finish in one `finalize` pay nothing —
+`writer.checkpoint()` snapshots a valid archive capped at that zoom, so an
+interrupted run keeps its finished coarse zooms instead of losing hours of
+compute. `checkpoint` and `finalize` route through the same assembler, so the
+final archive is **byte-identical** whether or not any checkpoints were taken
+(verified on madagascar-adm4).
+
 ### Validate (`overview/check.rs`)
 
 `gpq-tiles validate` checks a file against spec §6.2: footer schema, level
@@ -202,6 +217,15 @@ in `benchmarks/overview/RESULTS.md` (a 631k-feature file's footer dropped
 8.84 MB → 0.24 MB).
 
 ## StreamingPmtilesWriter
+
+The writer's archive assembly (sort entries → header + directory + metadata →
+copy tile data) lives in a non-consuming `write_archive`, written to a sibling
+`<output>.partial` and atomically renamed over the target. `finalize` runs it
+once then drops the temp file; `checkpoint` (#229) runs it repeatedly without
+consuming the writer, so a kill mid-write never corrupts a previously
+checkpointed archive. Tile ids are unique, so re-sorting entries between
+checkpoints is deterministic — the final bytes are identical regardless of how
+many checkpoints ran.
 
 Export's PMTiles v3 writer streams tile data to a temp file, builds the
 directory incrementally, and deduplicates tiles by XXH3 hash → file offset,

--- a/crates/core/src/overview/export.rs
+++ b/crates/core/src/overview/export.rs
@@ -66,7 +66,7 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use arrow_array::cast::AsArray;
 use arrow_array::types::{
@@ -268,6 +268,19 @@ const PARTITION_WAVE: usize = 6;
 /// keeping per-batch memory modest).
 const EXPORT_BATCH_SIZE: usize = 8_192;
 
+/// Minimum wall-clock gap between incremental checkpoints (Issue #229). After a
+/// level finishes we snapshot a valid archive capped at that zoom, but only if
+/// this much time has elapsed since the last snapshot — so fast exports (which
+/// finish in one `finalize` well under this interval) pay nothing, while a
+/// multi-hour run keeps its finished zooms salvageable within a minute of each
+/// level completing.
+const CHECKPOINT_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Minimum wall-clock gap between within-level wave-progress log lines (Issue
+/// #229). A level stuck in its scan/clip loop stays diagnosable in minutes (the
+/// wave counter advances, or visibly does not) instead of hours of silence.
+const WAVE_LOG_INTERVAL: Duration = Duration::from_secs(30);
+
 /// Export an overview GeoParquet file to a PMTiles archive.
 ///
 /// See the module documentation for the full pipeline and the design
@@ -318,8 +331,8 @@ fn export_pmtiles_with_partition_target(
     // byte-identical to independent per-level scans.
     let t_scan = Instant::now();
     let scans = scan_all_levels(&reader, crs, &meta)?;
-    log::debug!(
-        "[profile] scan (all {num_levels} levels, single read): {:.2}s",
+    log::info!(
+        "[export] scan complete: {num_levels} levels, single read, {:.2}s",
         t_scan.elapsed().as_secs_f64()
     );
 
@@ -332,6 +345,18 @@ fn export_pmtiles_with_partition_target(
             }
         }
     }
+
+    // Set bounds up front so per-level checkpoints (#229) carry the correct
+    // archive bounds, not the writer's empty default. The value is identical to
+    // setting it just before `finalize`, so the final bytes are unchanged.
+    if let Some(b) = &overall_bounds {
+        writer.set_bounds(b);
+    }
+
+    // Throttle for incremental checkpoints (#229): a fast export finishes before
+    // the first interval elapses and never checkpoints, letting `finalize` do
+    // all the work.
+    let mut last_checkpoint = Instant::now();
 
     let mut zooms: Vec<ZoomReport> = Vec::with_capacity(num_levels);
 
@@ -360,7 +385,12 @@ fn export_pmtiles_with_partition_target(
         let mut tile_feature_count = 0usize;
         let mut oversized = 0usize;
         let mut write_secs = 0f64;
-        for wave in partitions.chunks(PARTITION_WAVE) {
+        let total_waves = partitions.len().div_ceil(PARTITION_WAVE);
+        // Within-level progress (#229): a long finest level is where runs get
+        // stuck, so emit a throttled wave counter. If it advances the level is
+        // slow; if it freezes the level is stuck — diagnosable in minutes.
+        let mut last_wave_log = Instant::now();
+        for (wave_idx, wave) in partitions.chunks(PARTITION_WAVE).enumerate() {
             let results: Vec<Vec<EncodedTile>> = process_wave(&ctx, wave)?;
             let t_write = Instant::now();
             for tiles in &results {
@@ -382,7 +412,29 @@ fn export_pmtiles_with_partition_target(
                 tile_count += tiles.len();
             }
             write_secs += t_write.elapsed().as_secs_f64();
+
+            if last_wave_log.elapsed() >= WAVE_LOG_INTERVAL {
+                log::info!(
+                    "[export] level {}/{num_levels} z{zoom}: wave {}/{total_waves}, \
+                     {tile_count} tiles, {:.0}s",
+                    level_idx + 1,
+                    wave_idx + 1,
+                    start.elapsed().as_secs_f64(),
+                );
+                last_wave_log = Instant::now();
+            }
         }
+        // Per-level summary at info so operators see progress without RUST_LOG
+        // (env_logger defaults to info). Detailed clip/write split stays debug.
+        log::info!(
+            "[export] level {}/{num_levels} z{zoom} done: {} feats, {tile_count} tiles, \
+             {} partitions, {:.1}s (total {:.0}s)",
+            level_idx + 1,
+            scan.feature_count,
+            partitions.len(),
+            t_tiles.elapsed().as_secs_f64(),
+            start.elapsed().as_secs_f64(),
+        );
         log::debug!(
             "[profile] z{zoom} (level {level_idx}, {} feats, {tile_count} tiles, {} partitions): \
              clip+encode+gzip={:.2}s write={write_secs:.2}s",
@@ -399,16 +451,29 @@ fn export_pmtiles_with_partition_target(
             tile_feature_count,
             oversized_tiles: oversized,
         });
+
+        // Salvageable output (#229): snapshot a valid archive capped at this
+        // zoom so an interrupted run keeps its finished zooms. Throttled, and
+        // skipped on the last level since `finalize` immediately follows and
+        // produces the complete archive.
+        if level_idx + 1 < num_levels && last_checkpoint.elapsed() >= CHECKPOINT_INTERVAL {
+            let t_ckpt = Instant::now();
+            writer.checkpoint(output_path.as_ref())?;
+            last_checkpoint = Instant::now();
+            log::info!(
+                "[export] checkpoint written: zooms {}..={zoom} salvageable ({:.2}s)",
+                zoom_for_level(&meta, 0),
+                t_ckpt.elapsed().as_secs_f64(),
+            );
+        }
     }
 
-    if let Some(b) = &overall_bounds {
-        writer.set_bounds(b);
-    }
     let t_finalize = Instant::now();
     writer.finalize(output_path.as_ref())?;
-    log::debug!(
-        "[profile] pmtiles finalize: {:.2}s",
-        t_finalize.elapsed().as_secs_f64()
+    log::info!(
+        "[export] finalize complete: {:.2}s (total {:.0}s)",
+        t_finalize.elapsed().as_secs_f64(),
+        start.elapsed().as_secs_f64(),
     );
 
     let total_tiles = zooms.iter().map(|z| z.tile_count).sum();

--- a/crates/core/src/pmtiles_writer.rs
+++ b/crates/core/src/pmtiles_writer.rs
@@ -1437,19 +1437,55 @@ impl StreamingPmtilesWriter {
     ///
     /// The temp file is deleted after successful finalization.
     pub fn finalize(mut self, output_path: &Path) -> Result<StreamingWriteStats> {
-        // Take the temp file handle to close it properly
-        let temp_file = self
-            .temp_file
-            .take()
-            .ok_or_else(|| Error::PMTilesWrite("Writer already finalized".to_string()))?;
+        // Assemble the complete archive (byte-identical to the last checkpoint,
+        // if any). This flushes the temp buffer in place but leaves the handle
+        // open so we can close it deterministically below.
+        self.write_archive(output_path)?;
 
-        // Flush and close temp file
-        let inner = temp_file
-            .into_inner()
-            .map_err(|e| Error::PMTilesWrite(format!("Failed to flush temp file: {}", e)))?;
-        drop(inner); // Explicitly close
+        // Close and remove the temp file now that the run is complete.
+        drop(self.temp_file.take());
+        let _ = std::fs::remove_file(&self.temp_path);
 
-        // Sort entries by tile_id for clustered mode
+        // Mark as finalized so Drop doesn't try to clean up again
+        self.finalized = true;
+
+        Ok(self.stats.clone())
+    }
+
+    /// Write a valid, self-contained PMTiles archive containing every tile
+    /// added so far, *without* consuming the writer or closing the temp file
+    /// (Issue #229 — salvageable output).
+    ///
+    /// The export loop calls this after each finished level so an interrupted
+    /// run still yields a valid archive capped at the last completed zoom
+    /// instead of losing hours of compute. `finalize` routes through the same
+    /// assembler, so the final archive is byte-identical whether or not any
+    /// intermediate checkpoints were taken.
+    ///
+    /// The archive is written to a sibling `<output>.partial` file and then
+    /// atomically renamed over `output_path`, so a kill mid-write never
+    /// corrupts a previously-checkpointed archive.
+    pub fn checkpoint(&mut self, output_path: &Path) -> Result<()> {
+        self.write_archive(output_path)
+    }
+
+    /// Shared archive assembler backing both [`checkpoint`](Self::checkpoint)
+    /// and [`finalize`](Self::finalize). Flushes the temp buffer in place (the
+    /// handle stays open so the writer remains usable) and writes the header,
+    /// directory, metadata and tile data to `output_path` atomically.
+    fn write_archive(&mut self, output_path: &Path) -> Result<()> {
+        // Flush buffered tile bytes to the temp file on disk without consuming
+        // the handle — the writer must stay usable after a checkpoint.
+        match self.temp_file.as_mut() {
+            Some(tf) => tf
+                .flush()
+                .map_err(|e| Error::PMTilesWrite(format!("Failed to flush temp file: {}", e)))?,
+            None => return Err(Error::PMTilesWrite("Writer already finalized".to_string())),
+        }
+
+        // Sort entries by tile_id for clustered mode. Tile ids are unique, so
+        // this is deterministic and idempotent — re-sorting between checkpoints
+        // and later adds yields the same final ordering as sorting once.
         self.entries.sort_by_key(|e| e.tile_id);
 
         // Build run-length encoded directory entries
@@ -1521,8 +1557,15 @@ impl StreamingPmtilesWriter {
             center_lat: (self.bounds.lat_min + self.bounds.lat_max) / 2.0,
         };
 
-        // Create output file and write all sections
-        let output_file = File::create(output_path)
+        // Assemble into a sibling `<output>.partial` file, then atomically
+        // rename over `output_path`. A kill mid-write leaves any previously
+        // checkpointed archive at `output_path` intact.
+        let partial_path = {
+            let mut os = output_path.as_os_str().to_owned();
+            os.push(".partial");
+            PathBuf::from(os)
+        };
+        let output_file = File::create(&partial_path)
             .map_err(|e| Error::PMTilesWrite(format!("Failed to create output file: {}", e)))?;
         let mut writer = BufWriter::new(output_file);
 
@@ -1557,14 +1600,14 @@ impl StreamingPmtilesWriter {
         writer
             .flush()
             .map_err(|e| Error::PMTilesWrite(format!("Failed to flush output: {}", e)))?;
+        // Close the output handle before renaming so the bytes are fully on disk.
+        drop(writer);
 
-        // Clean up temp file
-        let _ = std::fs::remove_file(&self.temp_path);
+        // Atomically publish the assembled archive.
+        std::fs::rename(&partial_path, output_path)
+            .map_err(|e| Error::PMTilesWrite(format!("Failed to publish archive: {}", e)))?;
 
-        // Mark as finalized so Drop doesn't try to clean up again
-        self.finalized = true;
-
-        Ok(self.stats.clone())
+        Ok(())
     }
 
     /// Build directory entries with run-length encoding for consecutive identical tiles.
@@ -3051,5 +3094,107 @@ mod tests {
 
         let _ = fs::remove_file(&serial_path);
         let _ = fs::remove_file(&parallel_path);
+    }
+
+    #[test]
+    fn checkpoint_produces_valid_capped_pmtiles() {
+        // Issue #229: a mid-run checkpoint must produce a fully valid PMTiles
+        // archive capped at the zooms written so far, WITHOUT consuming the
+        // writer — the export loop keeps adding finer levels afterwards.
+        let mut writer = StreamingPmtilesWriter::new(Compression::Gzip).unwrap();
+        writer.set_layer_name("test");
+        writer.set_bounds(&TileBounds::new(-180.0, -85.0, 180.0, 85.0));
+
+        // Two coarse levels finished (z0: 1 tile, z1: 2 tiles).
+        writer.add_tile(0, 0, 0, &[0x1a, 0x00]).unwrap();
+        writer.add_tile(1, 0, 0, &[0x1a, 0x01]).unwrap();
+        writer.add_tile(1, 0, 1, &[0x1a, 0x02]).unwrap();
+
+        let ckpt_path = std::env::temp_dir().join("gpq-229-checkpoint.pmtiles");
+        let _ = fs::remove_file(&ckpt_path);
+        writer
+            .checkpoint(&ckpt_path)
+            .expect("checkpoint should succeed");
+
+        // Checkpoint is a valid, capped archive.
+        let ck = fs::read(&ckpt_path).unwrap();
+        assert_eq!(&ck[0..7], b"PMTiles", "checkpoint has PMTiles magic");
+        assert_eq!(ck[7], 3, "checkpoint is version 3");
+        assert_eq!(ck[100], 0, "checkpoint min_zoom == 0");
+        assert_eq!(
+            ck[101], 1,
+            "checkpoint max_zoom capped at last finished level"
+        );
+        let ck_addressed = u64::from_le_bytes(ck[72..80].try_into().unwrap());
+        assert_eq!(ck_addressed, 3, "checkpoint holds the 3 finished tiles");
+
+        // Writer is still usable: add a finer level and finalize.
+        writer.add_tile(2, 0, 0, &[0x1a, 0x03]).unwrap();
+        let final_path = std::env::temp_dir().join("gpq-229-checkpoint-final.pmtiles");
+        let _ = fs::remove_file(&final_path);
+        writer
+            .finalize(&final_path)
+            .expect("finalize after checkpoint");
+
+        let fin = fs::read(&final_path).unwrap();
+        assert_eq!(fin[101], 2, "final max_zoom includes the finer level");
+        let fin_addressed = u64::from_le_bytes(fin[72..80].try_into().unwrap());
+        assert_eq!(fin_addressed, 4, "final holds all 4 tiles");
+
+        let _ = fs::remove_file(&ckpt_path);
+        let _ = fs::remove_file(&final_path);
+    }
+
+    #[test]
+    fn checkpoint_then_finalize_byte_identical_to_no_checkpoint() {
+        // Issue #229: intermediate checkpoints must NOT change the final bytes.
+        // Both checkpoint and finalize route through the same archive assembler,
+        // so a run that checkpoints midway must be byte-identical to one that
+        // never checkpoints. The 4th tile dups the 1st to exercise dedup.
+        let tiles: Vec<(u8, u32, u32, Vec<u8>)> = vec![
+            (0, 0, 0, vec![0x1a, 0x05, b'h', b'e', b'l', b'l', b'o']),
+            (1, 0, 0, vec![0x1a, 0x03, b'a', b'b', b'c']),
+            (1, 0, 1, vec![0x1a, 0x03, b'x', b'y', b'z']),
+            (1, 1, 1, vec![0x1a, 0x05, b'h', b'e', b'l', b'l', b'o']), // dup of (0,0,0)
+        ];
+        let dir = std::env::temp_dir();
+
+        // Baseline: no checkpoint, single finalize.
+        let mut plain = StreamingPmtilesWriter::new(Compression::Gzip).unwrap();
+        plain.set_layer_name("test");
+        plain.set_bounds(&TileBounds::new(-180.0, -85.0, 180.0, 85.0));
+        for (z, x, y, data) in &tiles {
+            plain.add_tile(*z, *x, *y, data).unwrap();
+        }
+        let plain_path = dir.join("gpq-229-plain.pmtiles");
+        let _ = fs::remove_file(&plain_path);
+        plain.finalize(&plain_path).unwrap();
+
+        // Checkpointed: assemble the archive after the first tile, keep going.
+        let mut ckpt = StreamingPmtilesWriter::new(Compression::Gzip).unwrap();
+        ckpt.set_layer_name("test");
+        ckpt.set_bounds(&TileBounds::new(-180.0, -85.0, 180.0, 85.0));
+        let ckpt_path = dir.join("gpq-229-intermediate.pmtiles");
+        let final_path = dir.join("gpq-229-checkpointed-final.pmtiles");
+        let _ = fs::remove_file(&final_path);
+        for (i, (z, x, y, data)) in tiles.iter().enumerate() {
+            ckpt.add_tile(*z, *x, *y, data).unwrap();
+            if i == 0 {
+                let _ = fs::remove_file(&ckpt_path);
+                ckpt.checkpoint(&ckpt_path).unwrap();
+            }
+        }
+        ckpt.finalize(&final_path).unwrap();
+
+        let a = fs::read(&plain_path).unwrap();
+        let b = fs::read(&final_path).unwrap();
+        assert_eq!(
+            a, b,
+            "checkpointed run must be byte-identical to the non-checkpointed finalize"
+        );
+
+        let _ = fs::remove_file(&plain_path);
+        let _ = fs::remove_file(&ckpt_path);
+        let _ = fs::remove_file(&final_path);
     }
 }


### PR DESCRIPTION
Closes #229.

## Problem

A killed export lost **all** finished zooms. Tiles stream to a temp file, but the PMTiles archive is only assembled in `finalize()` after *every* level completes — so adm4 DNF'd at 3h13m with an empty output path despite the coarse zooms finishing hours earlier. There was also no `info`-level progress, so a run stuck in the finest level's scan/clip was indistinguishable from a merely slow one.

This is a **failure-mode cost** fix, not a speed fix (see #226/#227/#228): hours of compute shouldn't evaporate on a kill, and stuck-vs-slow should be diagnosable from the log.

## What changed

### Salvageable output
- Factored `finalize`'s archive assembly into a **non-consuming `write_archive`** that writes to a sibling `<output>.partial` and **atomically renames** over the target — a kill mid-write never corrupts a previously checkpointed archive.
- Added `StreamingPmtilesWriter::checkpoint()`: re-runs `write_archive` without consuming the writer, so an interrupted run keeps a valid archive **capped at the last finished zoom**.
- The export loop checkpoints after each finished level, **throttled to `CHECKPOINT_INTERVAL` (60 s)** so fast exports (a single `finalize`) pay nothing.
- `checkpoint` and `finalize` route through the same assembler, and tile ids are unique so re-sorting between checkpoints is deterministic → **final bytes are byte-identical** whether or not any checkpoints ran.

### Progress logging (`info`-level, visible under the CLI's default filter)
- `scan complete` marker.
- Per-level `done` summary: `level i/N`, zoom, feats, tiles, partitions, elapsed.
- Throttled within-level **wave counter** (`WAVE_LOG_INTERVAL`, 30 s) — a stuck finest level is now diagnosable in minutes (counter frozen) vs slow (counter advancing).

## Scope decision on the issue's open question

The issue flagged that PMTiles v3 needs a full directory finalize, so "full incremental finalize may not be worth it." On inspection the tile *data* already streams continuously; only the cheap assembly (header + directory + metadata + data copy) was deferred. A throttled non-consuming checkpoint is therefore cheap and real salvage — better than the documented `--max-zoom` re-run fallback — so I implemented it fully.

## Verification

- **End-to-end byte-identity** on `fieldmaps-madagascar-adm4`: with `CHECKPOINT_INTERVAL` forced to 0, checkpoints fired after every level (zooms `1..=1` … `1..=5`) and the final archive sha256 **matched** the un-checkpointed run exactly. No `.partial` left behind.
- **Unit tests**: capped-checkpoint validity (magic/version/min-max-zoom/addressed-count) and `checkpoint → finalize` byte-identity (with dedup across zooms).
- `cargo clippy` clean; 57 writer + 14 export tests green.

### Sample log
```
[export] scan complete: 6 levels, single read, 0.74s
[export] level 1/6 z1 done: 1 feats, 1 tiles, 1 partitions, 0.0s (total 1s)
...
[export] level 6/6 z6 done: 17465 feats, 6 tiles, 1 partitions, 3.1s (total 5s)
[export] finalize complete: 0.00s (total 5s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)