### PR TITLE
perf(convert): cap O(V²) validity check on oversized RDP candidates (#242)

### DIFF
--- a/crates/core/src/overview/pipeline.rs
+++ b/crates/core/src/overview/pipeline.rs
@@ -245,6 +245,10 @@ pub(super) fn run_pass2_buffered(
     // geometry. Otherwise (cascade off, or partitioning where every feature
     // lands on exactly one level) fan out per level as before.
     let cascade = ctxs.first().is_some_and(|c| c.is_cascading_duplicating());
+    // Heartbeat (#242): a planet-scale pass 2 runs for minutes-to-hours;
+    // without this the phase is silent at info level. Time-based so small
+    // inputs stay quiet.
+    let mut last_progress = Instant::now();
     let consume: Result<(), ConvertError> = (|| {
         for msg in rx.iter() {
             Pass2Timers::add_dur(timers.read_cell(), msg.read_dur);
@@ -270,6 +274,15 @@ pub(super) fn run_pass2_buffered(
                     verts[li] += v;
                     sinks[li].push(out)?;
                 }
+            }
+            if last_progress.elapsed().as_secs() >= 10 {
+                last_progress = Instant::now();
+                log::info!(
+                    "[convert] pass 2: {} input row(s) processed ({} output \
+                     row(s) buffered across {num_levels} level(s))",
+                    row_offset + batch.num_rows(),
+                    rows.iter().sum::<usize>(),
+                );
             }
         }
         Ok(())

--- a/crates/core/src/overview/simplify.rs
+++ b/crates/core/src/overview/simplify.rs
@@ -76,6 +76,17 @@ pub fn full_resolution_fallback_count() -> u64 {
     FULL_RES_FALLBACKS.load(Ordering::Relaxed)
 }
 
+/// Process-wide count of RDP candidates that skipped the validity check
+/// because they exceeded `MAX_VALIDATION_VERTS` (#242). Logged as a delta
+/// alongside [`full_resolution_fallback_count`] by the streaming convert
+/// loop.
+static VALIDATION_SKIPS: AtomicU64 = AtomicU64::new(0);
+
+/// Snapshot of the process-wide capped-validation skip counter.
+pub fn validation_skip_count() -> u64 {
+    VALIDATION_SKIPS.load(Ordering::Relaxed)
+}
+
 /// Default simplification factor: `tolerance = factor * gsd`.
 ///
 /// `1.0` means "simplify away detail finer than one ground sample". One GSD is
@@ -338,6 +349,53 @@ fn simplify_linestring_impl(ls: &LineString<f64>, tol: f64) -> Option<LineString
 /// geometry. Attempts run at `tol, tol/2, tol/4, tol/8`.
 const INVALID_RETRY_HALVINGS: u32 = 3;
 
+/// Vertex cap above which the RDP candidate skips `geo`'s validity check and
+/// is assumed valid.
+///
+/// # Why (issue #242)
+///
+/// `geo::algorithm::validation`'s per-ring simplicity test is **O(V²)** in
+/// ring vertex count. A fine-GSD cascade step over a continental admin
+/// polygon hands it a candidate with hundreds of thousands of vertices —
+/// gdb sampling showed a single rayon worker pinned inside
+/// `linestring_has_self_intersection` for the entire "convert wall" (~450 s
+/// per level per feature at 300 K vertices, × every fine level), which is
+/// exactly the export-side pathology capped in `clip.rs`
+/// (`MAX_SELF_INTERSECT_VERTS`, issue #237).
+///
+/// # Why assuming valid is the right default above the cap
+///
+/// A candidate only stays huge when the epsilon was small relative to the
+/// ring's detail, i.e. RDP removed few, near-collinear vertices from input
+/// we already assume valid — the *least* likely candidate to have acquired a
+/// crossing. The expensive-to-check case and the low-risk case coincide.
+/// The trade is the same as `clip.rs`: a giant candidate that *did* acquire
+/// a crossing ships unrepaired, which the overviews spec explicitly permits
+/// (geometry validity is not a conformance requirement, OVERVIEWS_SPEC §
+/// "validity") and matches tippecanoe, which never validates simplification
+/// output. Everything at or below the cap is validated exactly as before.
+const MAX_VALIDATION_VERTS: usize = 2_048;
+
+/// Total vertices across the polygon's exterior and interior rings.
+fn polygon_vertex_count(poly: &Polygon<f64>) -> usize {
+    poly.exterior().0.len() + poly.interiors().iter().map(|r| r.0.len()).sum::<usize>()
+}
+
+/// `is_valid`, capped: candidates above [`MAX_VALIDATION_VERTS`] total
+/// vertices are assumed valid without running the O(V²) scan (#242).
+fn capped_is_valid(candidate: &Polygon<f64>) -> bool {
+    let verts = polygon_vertex_count(candidate);
+    if verts > MAX_VALIDATION_VERTS {
+        VALIDATION_SKIPS.fetch_add(1, Ordering::Relaxed);
+        log::trace!(
+            "overview simplify: skipping O(V²) validity check on {verts}-vertex \
+             candidate (cap {MAX_VALIDATION_VERTS}); assuming valid"
+        );
+        return true;
+    }
+    candidate.is_valid()
+}
+
 /// `true` when RDP removed nothing: the candidate has the same ring count and
 /// per-ring vertex counts as the original. RDP output vertices are always an
 /// ordered subset of the input (endpoints included), so equal counts imply an
@@ -427,7 +485,7 @@ fn simplify_polygon_impl(
             return collapse_polygon(poly, collapse);
         }
 
-        if polygon_unchanged(&candidate, poly) || candidate.is_valid() {
+        if polygon_unchanged(&candidate, poly) || capped_is_valid(&candidate) {
             return Simplified::Keep(Geometry::Polygon(candidate));
         }
         invalid_candidate = Some(candidate);
@@ -1055,5 +1113,114 @@ mod tests {
             simplify_for_level(&mls, 1000.0, Crs::Epsg3857, &opts),
             Simplified::Dropped
         );
+    }
+
+    // ---- validation vertex cap (#242) --------------------------------------
+
+    /// A bowtie (self-crossing) quad whose left edge is padded with a fine
+    /// staircase (per period: four corners with a 0.05 x-excursion, which RDP
+    /// at epsilon 0.01 always keeps, plus one filler vertex offset 0.001 from
+    /// the middle of a straight run, which RDP always removes). The removed
+    /// fillers defeat the `polygon_unchanged` short-circuit so the candidate
+    /// reaches validation; the surviving corners keep it big. The staircase
+    /// lives at x ∈ [0, 0.051], y ∈ [1, 9] — far from the diagonals'
+    /// crossing at (5, 5) — so the candidate stays a genuine bowtie.
+    fn padded_bowtie(periods: usize) -> Polygon<f64> {
+        let mut v = vec![
+            Coord { x: 0.0, y: 0.0 },
+            Coord { x: 10.0, y: 10.0 },
+            Coord { x: 10.0, y: 0.0 },
+            Coord { x: 0.0, y: 10.0 },
+        ];
+        // Descend the left edge from y=9 toward y=1.
+        let h = 8.0 / periods as f64;
+        for i in 0..periods {
+            let y = 9.0 - i as f64 * h;
+            v.push(Coord { x: 0.0, y });
+            v.push(Coord { x: 0.05, y });
+            // Filler on the vertical run at x=0.05: deviates only 0.001 from
+            // the run's chord, so RDP (eps 0.01) removes it.
+            v.push(Coord {
+                x: 0.051,
+                y: y - h / 2.0,
+            });
+            v.push(Coord { x: 0.05, y: y - h });
+            v.push(Coord { x: 0.0, y: y - h });
+        }
+        v.push(v[0]);
+        Polygon::new(LineString::new(v), vec![])
+    }
+
+    #[test]
+    fn validation_skipped_above_vertex_cap_keeps_candidate() {
+        // geo's recursive RDP degenerates to O(n) recursion depth on the
+        // uniform-amplitude zigzag (every split is a tie), which overflows
+        // the default test stack in debug builds — run on a roomy stack.
+        std::thread::Builder::new()
+            .stack_size(64 * 1024 * 1024)
+            .spawn(validation_skipped_above_vertex_cap_impl)
+            .unwrap()
+            .join()
+            .unwrap();
+    }
+
+    /// The bowtie's two diagonals cross at exactly (5, 5). Even-odd repair
+    /// materializes that crossing as an explicit vertex; the raw RDP
+    /// candidate has no vertex anywhere near it (corners sit on x ∈ {0, 10},
+    /// padding on x ≈ 0). Presence of the vertex is therefore a race-free
+    /// witness that repair ran.
+    fn has_crossing_vertex(g: &Geometry<f64>) -> bool {
+        use geo::coords_iter::CoordsIter;
+        g.coords_iter()
+            .any(|c| (c.x - 5.0).abs() < 1e-6 && (c.y - 5.0).abs() < 1e-6)
+    }
+
+    fn validation_skipped_above_vertex_cap_impl() {
+        // Above MAX_VALIDATION_VERTS the O(V²) `is_valid` scan is skipped and
+        // the RDP candidate is assumed valid (#242): the bowtie is kept
+        // verbatim, crossing and all, instead of being even-odd repaired.
+        // 1200 periods: RDP keeps at least the two x-extreme corners per
+        // period (their 0.05 horizontal deviation is epsilon-independent),
+        // so the candidate stays comfortably above the cap.
+        let poly = padded_bowtie(1_200);
+        assert!(poly.exterior().0.len() > MAX_VALIDATION_VERTS);
+        match simplify_polygon_impl(&poly, 0.01, false, true) {
+            Simplified::Keep(g @ Geometry::Polygon(_)) => {
+                let Geometry::Polygon(ref out) = g else {
+                    unreachable!()
+                };
+                assert!(
+                    out.exterior().0.len() > MAX_VALIDATION_VERTS,
+                    "RDP should keep the zigzag padding (got {} verts)",
+                    out.exterior().0.len()
+                );
+                assert!(
+                    out.exterior().0.len() < poly.exterior().0.len(),
+                    "RDP should remove the sub-epsilon padding vertices"
+                );
+                assert!(
+                    !has_crossing_vertex(&g),
+                    "candidate must be kept verbatim, not repaired"
+                );
+            }
+            other => panic!("expected Keep(Polygon) above the cap, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validation_exact_below_vertex_cap_still_repairs() {
+        // Below the cap nothing changes: the invalid candidate is detected
+        // and even-odd repaired, materializing the (5,5) crossing vertex.
+        let poly = padded_bowtie(40);
+        assert!(poly.exterior().0.len() <= MAX_VALIDATION_VERTS);
+        match simplify_polygon_impl(&poly, 0.01, false, true) {
+            Simplified::Keep(g) => {
+                assert!(
+                    has_crossing_vertex(&g),
+                    "below the cap the bowtie must be repaired, got {g:?}"
+                );
+            }
+            other => panic!("expected Keep(repaired geometry), got {other:?}"),
+        }
     }
 }

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -81,8 +81,8 @@ use super::convert::{
 use super::level::{Crs, Mode, RankingProvenance};
 use super::pipeline;
 use super::simplify::{
-    full_resolution_fallback_count, simplify_cascade, simplify_for_level, Simplified,
-    SimplifyOptions,
+    full_resolution_fallback_count, simplify_cascade, simplify_for_level, validation_skip_count,
+    Simplified, SimplifyOptions,
 };
 use super::writer::{
     LevelSpec, LevelWriteOutcome, OverviewWriter, OverviewWriterOptions, LEVEL_COLUMN,
@@ -119,6 +119,20 @@ pub(crate) enum Pass2Strategy {
 /// Streaming counterpart of [`super::convert::convert_to_overviews`], with an
 /// explicit pass-2 [`Pass2Strategy`] (production uses `Pipelined`; tests pin
 /// `Serial` to assert the pipelined engine is equivalent).
+/// Info-level summary of RDP candidates whose validity check was skipped by
+/// the vertex cap during this conversion (#242). `skips_before` is the
+/// process-wide counter snapshot taken before pass 2.
+fn log_validation_skips(skips_before: u64) {
+    let skips = validation_skip_count() - skips_before;
+    if skips > 0 {
+        log::info!(
+            "[convert] {skips} oversized RDP candidate(s) skipped exact \
+             validity checking and were assumed valid (#242; geometry \
+             validity is not an overviews conformance requirement)"
+        );
+    }
+}
+
 pub(crate) fn convert_streaming_strategy(
     source: &InputSource,
     output_path: &Path,
@@ -211,6 +225,10 @@ pub(crate) fn convert_streaming_strategy(
         .count();
     super::convert::warn_antimeridian_suspects(antimeridian_suspect_features);
 
+    // Stage markers (#242): everything between pass 1 and the writer used to
+    // run in total info-level silence — on planet-scale inputs that was tens
+    // of minutes with no output.
+    log::info!("[convert] scan complete: {num_features} feature(s) from {num_rows} row(s)");
     log::debug!(
         "[profile] pass1 stream+scan: {:.2}s",
         t_pass1.elapsed().as_secs_f64()
@@ -236,6 +254,11 @@ pub(crate) fn convert_streaming_strategy(
     };
     log::debug!(
         "[profile] assignment+budget: {:.2}s",
+        t_assign.elapsed().as_secs_f64()
+    );
+    log::info!(
+        "[convert] level assignment complete: {} level(s) in {:.1}s",
+        level_gsds.len(),
         t_assign.elapsed().as_secs_f64()
     );
 
@@ -423,6 +446,10 @@ pub(crate) fn convert_streaming_strategy(
     // row, so this is byte-identical to the former per-level build.
     let coalesce_tables: Vec<Option<CoalesceTable>> = match &coalesce_scratch {
         Some(scratch) => {
+            log::info!(
+                "[convert] building coalesce chain tables for {} level(s)",
+                emitted.len()
+            );
             let inputs = scratch.inputs();
             emitted
                 .par_iter()
@@ -505,6 +532,10 @@ pub(crate) fn convert_streaming_strategy(
     let n = emitted.len();
     let hints: Vec<usize> = emitted.iter().map(|e| e.hint).collect();
 
+    // Snapshot for the end-of-pass-2 summary: the counter is process-wide,
+    // so report the delta from this conversion only (#242).
+    let validation_skips_before = validation_skip_count();
+
     // `(outcome, rows, vertices)` per emitted level, in level order. The
     // outcome distinguishes a written level from one the writer skipped because
     // every candidate collapsed during simplification (#211).
@@ -530,6 +561,10 @@ pub(crate) fn convert_streaming_strategy(
         Pass2Strategy::Pipelined => {
             let buffered_rows: usize = hints[..n - 1].iter().sum();
             let backing = pipeline::resolve_backing(options.profile, options.mode, buffered_rows);
+            log::info!(
+                "[convert] pass 2: building {n} overview level(s) from a \
+                 single read (finest level streamed last)"
+            );
             let mut stats = if n > 1 {
                 pipeline::run_pass2_buffered(
                     &mut writer,
@@ -557,6 +592,7 @@ pub(crate) fn convert_streaming_strategy(
             stats
         }
     };
+    log_validation_skips(validation_skips_before);
 
     // Fold each emitted level's write outcome into the shared bookkeeping
     // (#211): `record_level_outcome` appends a renumbered `LevelReport` for a
@@ -1210,7 +1246,19 @@ fn write_level_streaming(
     let fallbacks_before = full_resolution_fallback_count();
     let t_level = Instant::now();
 
+    // Heartbeat (#242): the finest level re-streams the whole input; keep
+    // the operator informed on planet-scale files (quiet on small ones).
+    let mut last_progress = Instant::now();
     let batches = std::iter::from_fn(|| loop {
+        if last_progress.elapsed().as_secs() >= 10 {
+            last_progress = Instant::now();
+            log::info!(
+                "[convert] level {level_idx}: {} input row(s) scanned, {} \
+                 row(s) written",
+                row_offset,
+                rows.get(),
+            );
+        }
         let t_read = Instant::now();
         let batch = match reader.next() {
             None => return None,

--- a/docs/OVERVIEW_TUNING.md
+++ b/docs/OVERVIEW_TUNING.md
@@ -215,6 +215,16 @@ level's tolerance instead of 1×). Files record `generalization.cascade: true`
 in the footer provenance. Pass `--no-cascade` to reproduce the pre-cascade
 output byte-for-byte.
 
+Validity-check vertex cap (#242): a simplification candidate with more than
+2,048 total vertices skips the exact validity check and is assumed valid —
+the check is O(V²) in ring size, and on continental-scale rings at fine GSDs
+it stalled conversion for tens of minutes per feature. Oversized candidates
+arise exactly when RDP removed few vertices from already-valid input, the
+least likely case to have acquired a self-intersection; geometry validity is
+not an overviews conformance requirement (OVERVIEWS_SPEC §2). Candidates at
+or below the cap are validated (and repaired) exactly as before. A skipped
+check is counted and summarized at the end of conversion at info level.
+
 ---
 
 ## Ranking: which feature wins a cell


### PR DESCRIPTION
Fixes the convert-phase wall from #242: full-planet adm4 (3.3 GB, 363,783 features) never cleared `convert_to_overviews` (killed at 35+ min). With this PR the same input completes convert in **~3.5 min** and reaches `[export] scan complete` — unblocking the #237/#238 end-to-end acceptance run.

## Root cause (gdb-sampled, not guessed)

One rayon worker pinned at 100 % CPU inside `geo::algorithm::validation::utils::linestring_has_self_intersection` — geo's **O(V²)** all-pairs ring simplicity scan — called from `candidate.is_valid()` in `simplify_polygon_impl`, once per cascade level per feature. A continental/antimeridian-crossing admin polygon carries hundreds of thousands of vertices; at fine GSDs RDP removes almost nothing, so the quadratic scan runs on ~full V, ~minutes per feature-level, serial within one feature's cascade fold. Same pathology #238 capped in the *export* clip path; this is the *convert*-side twin.

## Fix

`MAX_VALIDATION_VERTS = 2 048` (mirrors `clip.rs::MAX_SELF_INTERSECT_VERTS`, #237): candidates above the cap skip the exact validity check and are **assumed valid**; at or below the cap behavior is unchanged.

Why assuming valid is the right trade:
- Oversized candidates arise exactly when RDP removed few, near-collinear vertices from input we already assume valid — the least likely case to have acquired a crossing. The expensive-to-check case and the low-risk case coincide.
- Geometry validity is explicitly **not** a conformance requirement of the overviews spec (`context/OVERVIEWS_SPEC.md`), and tippecanoe never validates simplification output at all.
- Skips are counted and summarized at end of convert at info level.

## Also: the 35-minute silence

Everything between pass 1 and the writer logged nothing at info level. Added stage markers (`scan complete`, `level assignment`, `coalesce tables`, `pass 2`), a 10 s time-based heartbeat in both pass-2 paths (quiet on small inputs), and the skip summary.

## Numbers

| Input | main | this PR |
|---|---|---|
| adm4 5 K-row slice, convert compute | ~6.5 min | **~6 s** |
| full adm4 364 K features, convert | DNF (35+ min, killed) | **~3.5 min** (6 084 skips) |
| full adm4, reach `[export] scan complete` | never | **~7.5 min** |

Peak RSS on full adm4: ~9.6 GB (RAM-backed coarse-level buffering, by design; `--memory-profile bounded` spills).

## Correctness

- TDD: above-cap bowtie kept verbatim (red → green); below-cap bowtie still detected + even-odd repaired (guard).
- `overview::simplify` (26) and convert-related (59) + cascade (6) tests green; clippy clean.
- **Byte-identical PMTiles** vs main (`bba0329`) on `fieldmaps-madagascar-adm4` z10 (zero skips triggered there, as required — matching md5).
- `docs/OVERVIEW_TUNING.md` cascade section documents the cap.

Refs #242, #237, #238. The remaining export z13/z14 wave cost on planet inputs is #239 (unchanged here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)