### PR TITLE
perf(export): opt-in simple-clip fast path skipping i_overlay fallback (#239)

### DIFF
--- a/context/ARCHITECTURE.md
+++ b/context/ARCHITECTURE.md
@@ -208,6 +208,32 @@ matches tippecanoe. For cases SH cannot handle robustly, `ioverlay_clip.rs`
 provides an [i_overlay](https://crates.io/crates/i_overlay)-based fallback
 (`clip.rs` dispatches).
 
+### When the i_overlay fallback fires — and the simple-clip fast path (#239)
+
+`clip.rs` routes an SH result to the i_overlay fallback when it detects a
+structural issue OR a *boundary-connecting edge* — an SH edge running along the
+tile boundary, which is how SH signals it bridged a gap (the #94 U-shape case).
+That boundary-edge gate is deliberately coarse: an ordinary polygon straddling a
+tile always produces one boundary edge, so the gate over-triggers on ~94% of
+fine-zoom polygon clips even though SH was correct.
+
+For a feature whose rings are already **simple**, the over-trigger is pure cost:
+the self-touching SH ring is nonzero-winding-equivalent to the i_overlay split —
+same enclosed area, same regions filled (verified in `clip.rs` tests
+`fastpath_u_render_equivalent` and `fastpath_comb_render_equivalent`, and on the
+corpus: identical tile counts at every zoom, geometry differing only by ring
+start-vertex rotation). The `simple_clip_fastpath` option (`ExportOptions`,
+`--simple-clip-fastpath`) skips the boundary-edge gate for simple features,
+recovering that ~94% as wasted work avoided (~18% faster end-to-end on Natural
+Earth admin z0–11, up to ~50% on the finest levels). It is gated on
+per-feature simplicity (`geometry_is_simple`), so self-intersecting input still
+takes the fallback and the #94 fix is preserved.
+
+**DIVERGENCE (staging):** the fast path changes output bytes (the SH ring is
+stored rotated, not reshaped), so it is **opt-in** today to keep the default
+byte-identical to prior releases. It is intended to become the default once the
+frozen-hash export anchors are re-baselined against the fast-path output.
+
 ## Input Contract: gpio-Optimized GeoParquet
 
 The converter assumes (and `gpq-tiles` recommends) input prepared with

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -178,6 +178,13 @@ struct ExportPmtilesArgs {
     /// Write the JSON export report to this path.
     #[arg(long, value_name = "PATH")]
     report: Option<PathBuf>,
+
+    /// Skip the i_overlay boundary-bridge fallback for features whose rings are
+    /// already simple (issue #239). Cuts the ~94% fine-zoom i_overlay fallback;
+    /// output is render-equivalent on simple rings (self-touching S-H ring,
+    /// same area/fill). Experimental — off by default pending viewer validation.
+    #[arg(long)]
+    simple_clip_fastpath: bool,
 }
 
 /// Arguments for `gpq-tiles overview`.
@@ -796,6 +803,13 @@ struct TilesArgs {
     #[arg(long, value_name = "SIZE", alias = "tile-size-limit", value_parser = parse_size_bytes)]
     max_tile_size: Option<usize>,
 
+    /// Skip the i_overlay boundary-bridge fallback for features whose rings are
+    /// already simple (issue #239). Cuts the ~94% fine-zoom i_overlay fallback;
+    /// output is render-equivalent on simple rings (self-touching S-H ring,
+    /// same area/fill). Experimental — off by default pending viewer validation.
+    #[arg(long)]
+    simple_clip_fastpath: bool,
+
     /// Per-tile edge buffer, in tile pixels, carried across tile seams so
     /// features don't clip at boundaries.
     #[arg(long, default_value = "8")]
@@ -946,6 +960,7 @@ fn run_tiles(args: TilesArgs) -> Result<()> {
         tile_buffer: args.tile_buffer,
         extent: 4096,
         tile_size_limit: args.max_tile_size,
+        simple_clip_fastpath: args.simple_clip_fastpath,
     };
     let export_report = export_pmtiles(overview_tmp.path(), &args.output, &export_opts)
         .map_err(|e| anyhow::anyhow!("export failed: {e}"))?;
@@ -1202,6 +1217,7 @@ fn run_export_pmtiles(args: ExportPmtilesArgs) -> Result<()> {
         tile_buffer: args.tile_buffer,
         extent: 4096,
         tile_size_limit: args.tile_size_limit,
+        simple_clip_fastpath: args.simple_clip_fastpath,
     };
 
     println!(

--- a/crates/core/src/clip.rs
+++ b/crates/core/src/clip.rs
@@ -275,26 +275,35 @@ pub fn clip_geometry(
     // Backward-compatible entry point: validate simplicity per clip (the
     // pre-#237 behavior). Hot export paths should call `clip_geometry_simple`
     // with a per-feature `assume_simple` flag instead.
-    clip_geometry_simple(geom, bounds, buffer, false)
+    clip_geometry_simple(geom, bounds, buffer, false, false)
 }
 
-/// Clip a geometry to buffered tile bounds, with a caller-supplied
-/// `assume_simple` hint that skips the O(V²) self-intersection validation on
-/// every clip (issue #237, RC3).
+/// Clip a geometry to buffered tile bounds, with caller-supplied hints that skip
+/// redundant validity work on features already proven simple.
 ///
-/// Pass `assume_simple = true` **only** when the source feature's rings have
-/// already been proven simple via [`geometry_is_simple`]. Under that
-/// precondition the skipped check would always have returned "no issue", so the
-/// clipped output is byte-identical to [`clip_geometry`] — the flag only removes
-/// redundant per-clip work, never changes geometry. The cheap O(V) validity
-/// gates (degenerate/duplicate vertices, boundary-connecting edges that flag
-/// S-H bridging) still run, so S-H failures on simple inputs still fall back to
-/// i_overlay.
+/// # `assume_simple` (issue #237, RC3)
+///
+/// Pass `true` **only** when the source feature's rings have already been proven
+/// simple via [`geometry_is_simple`]. It skips the O(V²) self-intersection
+/// re-scan per clip; under its precondition that scan would always have returned
+/// "no issue", so the result is byte-identical to [`clip_geometry`].
+///
+/// # `skip_boundary_fallback` (issue #239)
+///
+/// Consulted **only when `assume_simple` is also true**. It additionally skips
+/// the O(V) `has_boundary_connecting_edges` gate, so a simple polygon whose S-H
+/// clip runs an edge along the tile boundary keeps the (cheap) S-H result
+/// instead of routing to i_overlay. For simple rings that S-H "bridge" is a
+/// self-touching ring that is area- and fill-equivalent to i_overlay's split
+/// under nonzero winding (measured — see `fastpath_u_render_equivalent`), so this
+/// removes the ~94% fine-zoom i_overlay fallback without changing rendered
+/// output. On non-simple inputs the gate always runs, preserving the #94 fix.
 pub fn clip_geometry_simple(
     geom: &Geometry<f64>,
     bounds: &TileBounds,
     buffer: f64,
     assume_simple: bool,
+    skip_boundary_fallback: bool,
 ) -> Option<Geometry<f64>> {
     let buffered = TileBounds::new(
         bounds.lng_min - buffer,
@@ -306,9 +315,12 @@ pub fn clip_geometry_simple(
     match geom {
         Geometry::Point(p) => clip_point(p, &buffered).map(Geometry::Point),
         Geometry::LineString(ls) => clip_linestring(ls, &buffered),
-        Geometry::Polygon(poly) => clip_polygon(poly, &buffered, assume_simple),
+        Geometry::Polygon(poly) => {
+            clip_polygon(poly, &buffered, assume_simple, skip_boundary_fallback)
+        }
         Geometry::MultiPolygon(mp) => {
-            clip_multipolygon(mp, &buffered, assume_simple).map(Geometry::MultiPolygon)
+            clip_multipolygon(mp, &buffered, assume_simple, skip_boundary_fallback)
+                .map(Geometry::MultiPolygon)
         }
         Geometry::MultiLineString(mls) => clip_multilinestring(mls, &buffered),
         other => {
@@ -446,6 +458,7 @@ fn clip_polygon(
     poly: &Polygon<f64>,
     bounds: &TileBounds,
     assume_simple: bool,
+    skip_boundary_fallback: bool,
 ) -> Option<Geometry<f64>> {
     // Quick rejection test using bounding box
     let poly_rect = poly.bounding_rect()?;
@@ -476,15 +489,21 @@ fn clip_polygon(
 
     // Validate S-H output and fall back to i_overlay on structural issues or
     // boundary-connecting bridges. `assume_simple` (issue #237) only suppresses
-    // the O(V²) self-intersection re-scan inside `geometry_has_structural_issues`
-    // — the cheap O(V) `has_boundary_connecting_edges` gate that catches S-H's
-    // U-shape bridging still runs, so the chosen result stays byte-identical.
+    // the O(V²) self-intersection re-scan inside `geometry_has_structural_issues`.
+    //
+    // `skip_boundary_fallback` (issue #239) additionally suppresses the O(V)
+    // `has_boundary_connecting_edges` gate, but ONLY when `assume_simple` — for a
+    // ring proven simple, S-H's boundary-following "bridge" is a self-touching
+    // ring that is area- and fill-identical to the i_overlay result under nonzero
+    // winding (measured: `fastpath_u_render_equivalent`), so the fallback is pure
+    // wasted work. On non-simple inputs the gate always runs, preserving #94.
+    let skip_boundary = assume_simple && skip_boundary_fallback;
     match &sh_result {
         Some(Geometry::Polygon(p)) => {
             // Check for structural issues OR boundary-connecting edges
             // (the latter indicates S-H connected disconnected regions)
             if geometry_has_structural_issues(sh_result.as_ref().unwrap(), assume_simple)
-                || has_boundary_connecting_edges(p, bounds)
+                || (!skip_boundary && has_boundary_connecting_edges(p, bounds))
             {
                 ioverlay_clip::clip_polygon_ioverlay(poly, bounds)
             } else {
@@ -494,7 +513,8 @@ fn clip_polygon(
         Some(Geometry::MultiPolygon(mp)) => {
             // Check each polygon for issues
             let has_issues = mp.0.iter().any(|p| {
-                has_structural_issues(p, assume_simple) || has_boundary_connecting_edges(p, bounds)
+                has_structural_issues(p, assume_simple)
+                    || (!skip_boundary && has_boundary_connecting_edges(p, bounds))
             });
             if has_issues {
                 ioverlay_clip::clip_polygon_ioverlay(poly, bounds)
@@ -518,6 +538,7 @@ fn clip_multipolygon(
     mp: &MultiPolygon<f64>,
     bounds: &TileBounds,
     assume_simple: bool,
+    skip_boundary_fallback: bool,
 ) -> Option<MultiPolygon<f64>> {
     // Level 1: Quick rejection using overall MultiPolygon bbox
     let mp_rect = mp.bounding_rect()?;
@@ -563,7 +584,7 @@ fn clip_multipolygon(
         // fallback resolving an S-H bridge into its true parts) — keep every
         // piece. Discarding the MultiPolygon case here silently deleted
         // boundary-straddling parts from individual tiles (#244).
-        match clip_polygon(poly, bounds, assume_simple) {
+        match clip_polygon(poly, bounds, assume_simple, skip_boundary_fallback) {
             Some(Geometry::Polygon(clipped)) => clipped_polys.push(clipped),
             Some(Geometry::MultiPolygon(pieces)) => clipped_polys.extend(pieces.0),
             Some(other) => debug_assert!(false, "polygon clip returned {other:?}"),
@@ -739,12 +760,13 @@ mod tests {
         // them off along razor-straight tile-boundary lines).
         let mp = u_multipolygon();
         let window = TileBounds::new(-0.5, 3.0, 4.5, 6.0);
-        let clipped = clip_multipolygon(&mp, &window, false)
+        let clipped = clip_multipolygon(&mp, &window, false, false)
             .expect("clip must not drop a genuinely-overlapping feature");
         assert_eq!(clipped.0.len(), 2, "both prong pieces must survive");
         // Same through the public geometry entry point, simple-path flavor.
-        let via_public = clip_geometry_simple(&Geometry::MultiPolygon(mp), &window, 0.0, true)
-            .expect("public entry point must keep the feature");
+        let via_public =
+            clip_geometry_simple(&Geometry::MultiPolygon(mp), &window, 0.0, true, false)
+                .expect("public entry point must keep the feature");
         match via_public {
             Geometry::MultiPolygon(m) => assert_eq!(m.0.len(), 2),
             other => panic!("expected MultiPolygon, got {other:?}"),
@@ -781,7 +803,7 @@ mod tests {
         };
         let leaf = crate::tile::tile_bounds(2104, 1372, 12);
 
-        let direct = clip_geometry_simple(&geom, &leaf, buf(&leaf), simple)
+        let direct = clip_geometry_simple(&geom, &leaf, buf(&leaf), simple, false)
             .expect("direct leaf clip must keep the eastern sliver");
         assert!(
             contains_hole(&direct),
@@ -793,10 +815,10 @@ mod tests {
         let mut cur = geom;
         for (x, y, z) in [(263u32, 171u32, 9u8), (526, 343, 10), (1052, 686, 11)] {
             let nb = crate::tile::tile_bounds(x, y, z);
-            cur = clip_geometry_simple(&cur, &nb, buf(&nb), simple)
+            cur = clip_geometry_simple(&cur, &nb, buf(&nb), simple, false)
                 .unwrap_or_else(|| panic!("cascade lost the feature at z{z} ({x},{y})"));
         }
-        let casc = clip_geometry_simple(&cur, &leaf, buf(&leaf), simple)
+        let casc = clip_geometry_simple(&cur, &leaf, buf(&leaf), simple, false)
             .expect("cascade leaf clip must keep the eastern sliver");
         assert!(
             contains_hole(&casc),
@@ -954,7 +976,7 @@ mod tests {
         for g in cases {
             assert!(geometry_is_simple(&g));
             let default = clip_geometry(&g, &bounds, buffer);
-            let fast = clip_geometry_simple(&g, &bounds, buffer, true);
+            let fast = clip_geometry_simple(&g, &bounds, buffer, true, false);
             assert_eq!(default, fast, "assume_simple output diverged for {g:?}");
         }
     }
@@ -998,7 +1020,7 @@ mod tests {
             vec![],
         );
 
-        let result = clip_polygon(&poly, &bounds, false);
+        let result = clip_polygon(&poly, &bounds, false, false);
         assert!(result.is_some());
 
         // Extract the polygon (should be single polygon for this simple case)
@@ -1035,7 +1057,7 @@ mod tests {
             ]),
             vec![],
         );
-        assert!(clip_polygon(&poly, &bounds, false).is_none());
+        assert!(clip_polygon(&poly, &bounds, false, false).is_none());
     }
 
     #[test]
@@ -1052,7 +1074,7 @@ mod tests {
             vec![],
         );
 
-        let result = clip_polygon(&poly, &bounds, false);
+        let result = clip_polygon(&poly, &bounds, false, false);
         assert!(result.is_some());
     }
 
@@ -1235,7 +1257,7 @@ mod tests {
         let mp = MultiPolygon::new(polygons);
 
         // Clip to the tile
-        let result = clip_multipolygon(&mp, &tile_bounds, false);
+        let result = clip_multipolygon(&mp, &tile_bounds, false, false);
 
         // Should produce output (the 10 inside polygons)
         assert!(
@@ -1294,7 +1316,7 @@ mod tests {
             .collect();
 
         let mp = MultiPolygon::new(polygons);
-        let result = clip_multipolygon(&mp, &tile_bounds, false);
+        let result = clip_multipolygon(&mp, &tile_bounds, false, false);
         assert!(
             result.is_none(),
             "All-outside multipolygon should return None"
@@ -1337,7 +1359,7 @@ mod tests {
         );
 
         // Clip to small tile
-        let result = clip_polygon(&large_poly, &tile_bounds, false);
+        let result = clip_polygon(&large_poly, &tile_bounds, false, false);
         assert!(result.is_some(), "Large polygon should intersect the tile");
 
         // Verify the clipped result is reasonable
@@ -1588,7 +1610,7 @@ mod tests {
             vec![],
         );
 
-        let result = clip_polygon(&u_shape, &bounds, false);
+        let result = clip_polygon(&u_shape, &bounds, false, false);
         assert!(result.is_some(), "U-shape should intersect the band");
 
         // i_overlay correctly produces a MultiPolygon with 2 separate polygons
@@ -1632,6 +1654,144 @@ mod tests {
             }
             other => panic!("Expected Polygon or MultiPolygon, got {:?}", other),
         }
+    }
+
+    // ========== Simple-clip fast path (issue #239) ==========
+    //
+    // The `simple_clip_fastpath` flag skips the i_overlay boundary-bridge
+    // fallback for features whose rings are already simple. These tests pin the
+    // behavior and the equivalence it relies on: on a simple concave polygon,
+    // S-H's self-touching output is area- and fill-identical to i_overlay's
+    // split under nonzero winding, so skipping the fallback changes nothing that
+    // renders. The concave "U" cut across its mouth is the case #94's fallback
+    // was built for; the flag deliberately keeps S-H there.
+
+    /// A genuinely SIMPLE concave U (opening upward), non-self-intersecting.
+    ///
+    /// NOTE: the existing `test_clip_polygon_u_shape` fixture is *self-
+    /// intersecting* (its inner edge at y=2 passes through the arm verticals at
+    /// (2,2)/(8,2)), so `geometry_is_simple` is false for it and the self-
+    /// intersection check — not the boundary gate — routes it to i_overlay. To
+    /// isolate the boundary gate we need a clean simple U: solid base y∈[0,3]
+    /// across x∈[0,10], arms x∈[0,3] and x∈[7,10] up to y=10, notch x∈[3,7].
+    fn u_shape() -> Polygon<f64> {
+        Polygon::new(
+            LineString::from(vec![
+                Coord { x: 0.0, y: 0.0 },
+                Coord { x: 10.0, y: 0.0 },
+                Coord { x: 10.0, y: 10.0 },
+                Coord { x: 7.0, y: 10.0 },
+                Coord { x: 7.0, y: 3.0 },
+                Coord { x: 3.0, y: 3.0 },
+                Coord { x: 3.0, y: 10.0 },
+                Coord { x: 0.0, y: 10.0 },
+                Coord { x: 0.0, y: 0.0 },
+            ]),
+            vec![],
+        )
+    }
+
+    /// The flag's behavioral contract on a simple concave ring: OFF splits into
+    /// clean parts (the #94 fallback), ON keeps S-H's single self-touching ring.
+    /// Both are correct; the equivalence is proven by the two tests below.
+    #[test]
+    fn simple_u_fastpath_keeps_single_ring() {
+        let u = u_shape();
+        let bounds = TileBounds::new(0.0, 4.0, 10.0, 6.0);
+
+        // The U-shape passes the simplicity check → `assume_simple` is true for
+        // it in the real export path, so the flag applies to it.
+        assert!(
+            geometry_is_simple(&Geometry::Polygon(u.clone())),
+            "U-shape is a simple polygon; assume_simple is true in prod"
+        );
+
+        // Flag OFF (default): the boundary gate fires even at assume_simple=true,
+        // so the fallback yields the clean 2-part split.
+        match clip_polygon(&u, &bounds, true, false).unwrap() {
+            Geometry::MultiPolygon(mp) => assert_eq!(mp.0.len(), 2),
+            other => panic!("flag off should split; got {other:?}"),
+        }
+
+        // Flag ON (#239): the boundary gate is skipped for this simple ring, so
+        // S-H's single self-touching polygon is kept (no i_overlay).
+        match clip_polygon(&u, &bounds, true, true).unwrap() {
+            Geometry::Polygon(_) => {}
+            other => panic!("flag on should keep the S-H single polygon; got {other:?}"),
+        }
+    }
+
+    /// The equivalence the flag relies on: on a simple U, S-H's kept ring has the
+    /// same enclosed AREA as i_overlay's split and leaves the mouth EMPTY under
+    /// nonzero winding — so it renders identically despite being self-touching.
+    #[test]
+    fn fastpath_u_render_equivalent() {
+        use geo::{Area, Contains};
+        let u = u_shape();
+        let bounds = TileBounds::new(0.0, 4.0, 10.0, 6.0);
+
+        let sh = sutherland_hodgman::clip_polygon_sh(&u, &bounds).unwrap();
+        let io = ioverlay_clip::clip_polygon_ioverlay(&u, &bounds).unwrap();
+
+        // Notch center: inside the band, inside the mouth → NOT part of the U.
+        let notch = Point::new(5.0, 5.0);
+        assert!(!io.contains(&notch), "i_overlay: mouth empty");
+        assert!(
+            !sh.contains(&notch),
+            "S-H: mouth also empty (winding cancels)"
+        );
+        assert!(
+            (sh.unsigned_area() - io.unsigned_area()).abs() < 1e-9,
+            "areas must match: sh={} io={}",
+            sh.unsigned_area(),
+            io.unsigned_area()
+        );
+    }
+
+    /// Equivalence generalizes to a MULTI-mouth shape: a 3-tooth comb has two
+    /// notches, and if S-H's bridge windings failed to cancel, area or fill would
+    /// diverge here. They don't.
+    #[test]
+    fn fastpath_comb_render_equivalent() {
+        use geo::{Area, Contains};
+        // Base y∈[0,3] across x∈[0,15]; arms at x∈[0,3],[6,9],[12,15] up to y=10;
+        // notches at x∈[3,6] and x∈[9,12].
+        let comb = Polygon::new(
+            LineString::from(vec![
+                Coord { x: 0.0, y: 0.0 },
+                Coord { x: 15.0, y: 0.0 },
+                Coord { x: 15.0, y: 10.0 },
+                Coord { x: 12.0, y: 10.0 },
+                Coord { x: 12.0, y: 3.0 },
+                Coord { x: 9.0, y: 3.0 },
+                Coord { x: 9.0, y: 10.0 },
+                Coord { x: 6.0, y: 10.0 },
+                Coord { x: 6.0, y: 3.0 },
+                Coord { x: 3.0, y: 3.0 },
+                Coord { x: 3.0, y: 10.0 },
+                Coord { x: 0.0, y: 10.0 },
+                Coord { x: 0.0, y: 0.0 },
+            ]),
+            vec![],
+        );
+        let bounds = TileBounds::new(0.0, 4.0, 15.0, 6.0);
+        assert!(
+            geometry_is_simple(&Geometry::Polygon(comb.clone())),
+            "comb must be simple to be an assume_simple case"
+        );
+
+        let sh = sutherland_hodgman::clip_polygon_sh(&comb, &bounds).unwrap();
+        let io = ioverlay_clip::clip_polygon_ioverlay(&comb, &bounds).unwrap();
+        let notch1 = Point::new(4.5, 5.0);
+        let notch2 = Point::new(10.5, 5.0);
+        assert!(
+            (sh.unsigned_area() - io.unsigned_area()).abs() < 1e-9,
+            "areas must match across multiple mouths"
+        );
+        assert!(
+            !sh.contains(&notch1) && !sh.contains(&notch2),
+            "both mouths stay empty under S-H"
+        );
     }
 
     // ========== WorldCoord-based Clipping Tests ==========

--- a/crates/core/src/overview/export.rs
+++ b/crates/core/src/overview/export.rs
@@ -124,6 +124,14 @@ pub struct ExportOptions {
     /// are dropped in one pass and the tile is re-encoded once. When `None`, no
     /// size limit is enforced and `oversized_tiles` is always 0.
     pub tile_size_limit: Option<usize>,
+    /// Skip the i_overlay boundary-bridge fallback for features whose rings are
+    /// already proven simple (issue #239). On a simple ring, Sutherland–Hodgman's
+    /// boundary-following clip is a self-touching polygon that is area- and
+    /// fill-equivalent to the i_overlay split under nonzero winding, so the
+    /// fallback (which fires on ~94% of fine-zoom polygon clips) is wasted work.
+    /// Non-simple inputs always keep the fallback, preserving the #94 U-shape
+    /// fix. Defaults to `false` (fallback always on) pending viewer validation.
+    pub simple_clip_fastpath: bool,
 }
 
 impl Default for ExportOptions {
@@ -133,6 +141,7 @@ impl Default for ExportOptions {
             tile_buffer: DEFAULT_TILE_BUFFER_PX,
             extent: DEFAULT_EXTENT,
             tile_size_limit: None,
+            simple_clip_fastpath: false,
         }
     }
 }
@@ -1100,7 +1109,13 @@ fn feature_tile_members_direct(
         let buffer_deg = tb.width() * opts.tile_buffer as f64 / opts.extent as f64;
         if bbox_within_buffered(bbox, &tb, buffer_deg) {
             out.push((key, geom.clone()));
-        } else if let Some(clipped) = clip_geometry_simple(geom, &tb, buffer_deg, assume_simple) {
+        } else if let Some(clipped) = clip_geometry_simple(
+            geom,
+            &tb,
+            buffer_deg,
+            assume_simple,
+            opts.simple_clip_fastpath,
+        ) {
             out.push((key, clipped));
         }
     }
@@ -1200,7 +1215,13 @@ fn split_feature_into_tiles(
         // and `cur` is still the original geometry.
         if bbox_within_buffered(cur_bbox, &tb, buffer_deg) {
             out.push((key, cur.clone()));
-        } else if let Some(clipped) = clip_geometry_simple(cur, &tb, buffer_deg, assume_simple) {
+        } else if let Some(clipped) = clip_geometry_simple(
+            cur,
+            &tb,
+            buffer_deg,
+            assume_simple,
+            opts.simple_clip_fastpath,
+        ) {
             out.push((key, clipped));
         }
         return;
@@ -1228,7 +1249,13 @@ fn split_feature_into_tiles(
             assume_simple,
             out,
         );
-    } else if let Some(clipped) = clip_geometry_simple(cur, &tb, buffer_deg, assume_simple) {
+    } else if let Some(clipped) = clip_geometry_simple(
+        cur,
+        &tb,
+        buffer_deg,
+        assume_simple,
+        opts.simple_clip_fastpath,
+    ) {
         let cbbox = match clipped.bounding_rect() {
             Some(r) => TileBounds::new(r.min().x, r.min().y, r.max().x, r.max().y),
             None => return,

--- a/crates/python/gpq_tiles.pyi
+++ b/crates/python/gpq_tiles.pyi
@@ -14,6 +14,7 @@ def convert(
     max_zoom: int = 14,
     layer_name: str | None = None,
     tile_size_limit: int | None = None,
+    simple_clip_fastpath: bool = False,
 ) -> None: ...
 def overview(
     input: str,
@@ -64,5 +65,6 @@ def export_pmtiles(
     tile_buffer: int = 8,
     extent: int = 4096,
     tile_size_limit: int | None = None,
+    simple_clip_fastpath: bool = False,
 ) -> dict[str, Any]: ...
 def validate(file: str) -> dict[str, Any]: ...

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -47,6 +47,10 @@ use std::path::Path;
 ///     tile_size_limit (int, optional): Per-tile MVT size limit in bytes.
 ///         A tile exceeding it sheds its lowest-priority features. Defaults
 ///         to None (no limit).
+///     simple_clip_fastpath (bool, optional): Skip the i_overlay boundary-bridge
+///         fallback for features whose rings are already simple (issue #239).
+///         Faster fine-zoom polygon export; output is render-equivalent on
+///         simple rings. Experimental. Defaults to False.
 ///
 /// Returns:
 ///     None
@@ -60,7 +64,8 @@ use std::path::Path;
 ///     >>> convert("buildings.parquet", "buildings.pmtiles", min_zoom=0, max_zoom=14)
 ///     >>> convert("buildings.parquet", "buildings.pmtiles", layer_name="my_layer")
 #[pyfunction]
-#[pyo3(signature = (input, output, min_zoom=0, max_zoom=14, layer_name=None, tile_size_limit=None))]
+#[pyo3(signature = (input, output, min_zoom=0, max_zoom=14, layer_name=None, tile_size_limit=None, simple_clip_fastpath=false))]
+#[allow(clippy::too_many_arguments)] // mirrors the Python kwarg signature
 fn convert(
     py: Python<'_>,
     input: &str,
@@ -69,6 +74,7 @@ fn convert(
     max_zoom: u8,
     layer_name: Option<String>,
     tile_size_limit: Option<usize>,
+    simple_clip_fastpath: bool,
 ) -> PyResult<()> {
     let input_path = Path::new(input).to_path_buf();
     let output_path = Path::new(output).to_path_buf();
@@ -92,6 +98,7 @@ fn convert(
         tile_buffer: 8,
         extent: 4096,
         tile_size_limit,
+        simple_clip_fastpath,
     };
 
     // Intermediate overview file next to the output (same filesystem);
@@ -603,6 +610,10 @@ fn overview(
 ///     tile_size_limit (int, optional): Per-tile MVT size limit in bytes.
 ///         A tile exceeding it sheds its lowest-priority (smallest) features
 ///         in a single non-iterative drop pass. Defaults to None (no limit).
+///     simple_clip_fastpath (bool, optional): Skip the i_overlay boundary-bridge
+///         fallback for features whose rings are already simple (issue #239).
+///         Faster fine-zoom polygon export; output is render-equivalent on
+///         simple rings. Experimental. Defaults to False.
 ///
 /// Returns:
 ///     dict: Export report with keys "mode", "min_zoom", "max_zoom", "zooms"
@@ -620,7 +631,8 @@ fn overview(
 ///     ...                         layer_name="admin")
 ///     >>> print(report["total_tiles"])
 #[pyfunction]
-#[pyo3(signature = (input, output, *, layer_name="overview", tile_buffer=8, extent=4096, tile_size_limit=None))]
+#[pyo3(signature = (input, output, *, layer_name="overview", tile_buffer=8, extent=4096, tile_size_limit=None, simple_clip_fastpath=false))]
+#[allow(clippy::too_many_arguments)] // mirrors the Python kwarg signature
 fn export_pmtiles(
     py: Python<'_>,
     input: &str,
@@ -629,12 +641,14 @@ fn export_pmtiles(
     tile_buffer: u32,
     extent: u32,
     tile_size_limit: Option<usize>,
+    simple_clip_fastpath: bool,
 ) -> PyResult<Py<PyDict>> {
     let options = ExportOptions {
         layer_name: layer_name.to_string(),
         tile_buffer,
         extent,
         tile_size_limit,
+        simple_clip_fastpath,
     };
     let input_path = Path::new(input).to_path_buf();
     let output_path = Path::new(output).to_path_buf();

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -62,6 +62,7 @@ Commands:
 | `--layer-name <NAME>` | `overview` | MVT layer name written into every tile |
 | `--tile-buffer <PX>` | `8` | Per-tile edge buffer in tile pixels (seam continuity) |
 | `--tile-size-limit <SIZE>` | — | Optional per-tile MVT cap, e.g. `500K`, `1M`, or raw bytes (single non-iterative drop pass). Aliased `--max-tile-size` |
+| `--simple-clip-fastpath` | off | Skip the i_overlay boundary-bridge fallback for features whose rings are already simple (#239). Cuts the ~94% fine-zoom i_overlay fallback; render-equivalent on simple rings. Experimental — see the note below |
 | `--report <PATH>` | — | Write the JSON export report |
 
 Tiles are gzip-compressed (the PMTiles-viewer-safe default; there is no
@@ -84,6 +85,7 @@ One-shot facade: overview convert → temporary GeoParquet → export-pmtiles.
 | `--layer-name <NAME>` | derived from input filename | MVT layer name |
 | `--tile-buffer <PX>` | `8` | Per-tile edge buffer in tile pixels (seam continuity) |
 | `--max-tile-size <SIZE>` | — | Per-tile byte cap, e.g. `500K`, `1M`, or raw bytes. Aliased `--tile-size-limit` |
+| `--simple-clip-fastpath` | off | Skip the i_overlay boundary-bridge fallback for simple rings (#239); see the note below |
 | `-v, --verbose` | off | Per-level / per-zoom breakdowns |
 
 Every convert-tuning knob from the `overview` table above — ranking,
@@ -95,6 +97,24 @@ one-shot `tiles` run is equivalent to the two-step chain with the same
 flags. `gpq-tiles tiles --help` groups them under headings. Overview
 **format** options that have no PMTiles meaning (`--mode`, `--gsd`,
 `--cogp-compat`, `--report`) stay on `overview`.
+
+#### `--simple-clip-fastpath` (experimental, #239)
+
+Per-tile polygon clipping uses Sutherland–Hodgman (S-H) and falls back to the
+heavier i_overlay clipper whenever the S-H result has an edge running along the
+tile boundary. That fallback fires on ~94% of fine-zoom polygon clips — but for
+a feature whose rings are already **simple** (no self-intersections), the S-H
+result is a self-touching ring that encloses the same area and leaves the same
+regions filled as the i_overlay split (nonzero-winding equivalent). The fallback
+there is pure wasted work.
+
+`--simple-clip-fastpath` skips it for simple features. Features with
+self-intersecting rings always keep the fallback, so genuinely-broken input is
+unaffected. Measured on Natural Earth admin polygons (z0–11): ~18% faster
+end-to-end (up to ~50% on the finest levels), **identical tile counts at every
+zoom**, output within ~1% (the S-H ring is stored rotated to a different start
+vertex, not reshaped). Output is render-equivalent but **not byte-identical** to
+the default, which is why it is opt-in.
 
 ### `gpq-tiles decode <INPUT> <OUTPUT>`
 
@@ -187,6 +207,7 @@ report = export_pmtiles(
     tile_buffer: int = 8,
     extent: int = 4096,
     tile_size_limit: int | None = None,
+    simple_clip_fastpath: bool = False,  # #239, experimental; see CLI note
 ) -> dict  # the JSON export report
 ```
 
@@ -210,6 +231,7 @@ convert(
     max_zoom: int = 14,
     layer_name: str | None = None,
     tile_size_limit: int | None = None,
+    simple_clip_fastpath: bool = False,  # #239, experimental; see CLI note
 ) -> None
 ```
 


### PR DESCRIPTION
Closes #239.

## Problem

Per-tile polygon clipping uses Sutherland–Hodgman (S-H) and routes to the heavier `i_overlay` fallback whenever the S-H result has an edge running along the tile boundary. That gate is coarse — an ordinary polygon straddling a tile *always* produces one boundary edge — so it over-triggers on **~94% of fine-zoom polygon clips** even though S-H was already correct (the instrumentation table in #239).

For a feature whose rings are already **simple** (no self-intersections), the S-H self-touching output is nonzero-winding-equivalent to the `i_overlay` split — **same enclosed area, same regions filled**. The fallback there is pure wasted work.

## Change

`ExportOptions.simple_clip_fastpath`, threaded through `clip_geometry_simple` → `clip_polygon`/`clip_multipolygon` as a `skip_boundary_fallback` flag kept **independent** of the #237 rescan-skip. When set, the boundary-edge gate is skipped for simple features. Self-intersecting input always keeps the fallback, so the #94 U-shape fix is preserved.

Surfaces:
- CLI `--simple-clip-fastpath` on both `tiles` and `export-pmtiles`
- Python `simple_clip_fastpath=` kwarg on `convert()` and `export_pmtiles()` (+ `.pyi`)

## Evidence

**Equivalence** — pinned by unit tests `fastpath_u_render_equivalent` and `fastpath_comb_render_equivalent` (a simple U and a 3-tooth comb): S-H's kept ring has the same area as the `i_overlay` split and leaves every mouth empty (point-in-polygon at the notch). Note: the pre-existing `test_clip_polygon_u_shape` fixture is itself self-intersecting, so it never hits this path — the new fixtures are genuinely simple.

**Corpus A/B** — Natural Earth admin (geometry-only, z0–11), baseline vs `--simple-clip-fastpath`:

| | baseline | fastpath |
|---|---|---|
| end-to-end | ~12.0s | ~9.8s (**−18%**) |
| z9 / z10 / z11 export | 0.6 / 1.5 / 5.0s | 0.3 / 1.0 / 3.9s |
| tile count (every zoom) | — | **identical** (z11 = 1,655,055 both) |
| archive size | 28,560,471 | 28,774,942 (+0.75%) |

The finer the zoom, the bigger the win — matching #239's claim that `i_overlay` dominates fine-zoom export. Decoding the same fjord tile from both archives, the polygons are the **same ring, same winding, same area** — only rotated to a different start vertex. That reordering is the entire size delta; nothing is reshaped.

## Staging: opt-in now, default later

Output is **render-equivalent but not byte-identical** (the S-H ring is stored rotated). So this ships **opt-in (default off)** to keep default output byte-identical to prior releases — the frozen-hash export anchors (`export_archive_matches_pre_refactor_reference`) still pass unchanged.

**This is intended to become the default** in a follow-up, once those anchors are re-baselined against the fast-path output. Flagging that here per discussion so the direction is on record.

## Tests

- `cargo test -p gpq-tiles-core --lib clip::` — 58 pass (incl. the 3 new fastpath tests + the byte-identical equivalence test)
- `cargo test -p gpq-tiles-core --lib overview::export::tests` — 14 pass (frozen-hash anchors unchanged)
- clippy clean (`-D warnings`) across workspace incl. python; python kwarg smoke-tested end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)