### PR TITLE
fix(core): enable allow_http for http:// remote inputs

### DIFF
--- a/crates/core/src/input.rs
+++ b/crates/core/src/input.rs
@@ -278,7 +278,7 @@ pub(crate) mod remote {
     use object_store::gcp::GoogleCloudStorageBuilder;
     use object_store::http::HttpBuilder;
     use object_store::path::Path as ObjectPath;
-    use object_store::{CredentialProvider, ObjectStore, ObjectStoreScheme};
+    use object_store::{ClientOptions, CredentialProvider, ObjectStore, ObjectStoreScheme};
     use parquet::arrow::arrow_reader::{
         ArrowReaderMetadata, ArrowReaderOptions, ParquetRecordBatchReaderBuilder,
     };
@@ -381,6 +381,7 @@ pub(crate) mod remote {
                     Arc::new(
                         HttpBuilder::new()
                             .with_url(origin)
+                            .with_client_options(ClientOptions::new().with_allow_http(true))
                             .build()
                             .map_err(|e| store_error(url_str, e))?,
                     )


### PR DESCRIPTION
## Problem

`overview`/`tiles` document `http://` as a supported remote input scheme (`docs/remote-reads.md`, `input.rs` module docs), but every `http://` input failed immediately:

```
remote input error for http://...: Generic HTTP error:
Error performing HEAD http://... - HTTP error: builder error
```

The `Http` branch built a bare `HttpBuilder`, and object_store's `ClientOptions` defaults to **https-only**, so any non-TLS URL is rejected before the request is sent.

## Fix

Thread `ClientOptions::new().with_allow_http(true)` into the `Http` branch. `s3://`/`https://`/`gs://` are unaffected (they don't go through this branch, and https already allowed).

## How it surfaced

Building the performance-sweep harness, which serves gpio-optimized inputs over a localhost `logging_server.py` for exact byte accounting. Every `http://` cell builder-errored until this fix; with it, all 8 cells convert and byte accounting matches the converter's own `report.remote_fetch`.

## Testing

Manual/integration: the sweep exercised this across 8 cells over `http://127.0.0.1` (points/lines/polygons, dup/partitioning, `--profile`, `--bbox`). A hermetic unit test needs a local HTTP listener, which the existing `https_public_object_integration` test also sidesteps (it skips when offline); happy to add a gated one if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)