### PR TITLE
perf(bench): refresh big-file profile + sweep harness, convert guard, docs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,9 +1,17 @@
-# Benchmarks — runs on every push to main and on demand.
+# Benchmarks + convert-regression guard.
 #
-# Purpose: track performance of the geometry micro-benchmarks (clipping,
-# bbox_containment) over time via uploaded criterion reports. This lives
-# outside ci.yml on purpose: benchmarks are not a PR gate, and keeping them
-# here means no permanently-skipped job clutters PR check lists.
+# Two jobs:
+#   bench         — criterion micro-benches (clipping, bbox_containment),
+#                   tracked over time via uploaded reports. NOT a PR gate
+#                   (push/dispatch only) so no permanently-skipped job
+#                   clutters PR check lists.
+#   convert-guard — deterministic structural check that a change hasn't
+#                   altered convert output (per-level feature/vertex counts,
+#                   total rows) on the fixtures-v1 inputs. THIS one gates
+#                   PRs. Timing/RSS are intentionally not gated — far too
+#                   noisy on shared runners; see benchmarks/overview/PROFILE.md
+#                   for the tracked timing numbers and ci_guard.py for the
+#                   gated structural signature.
 #
 # The old tiling/streaming pipeline benches were deleted with the legacy
 # pipeline (#177/#189); this runs the surviving bench targets in
@@ -14,6 +22,7 @@ name: Benchmarks
 on:
   push:
     branches: [main]
+  pull_request:
   workflow_dispatch:
 
 permissions:
@@ -26,6 +35,7 @@ jobs:
   bench:
     name: Benchmark
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -76,3 +86,51 @@ jobs:
         with:
           name: criterion-reports
           path: target/criterion/
+
+  convert-guard:
+    name: Convert regression guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Cache test fixtures
+        id: fixture-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: tests/fixtures/realdata
+          key: fixtures-v1-${{ runner.os }}
+
+      - name: Download test fixtures
+        if: steps.fixture-cache.outputs.cache-hit != 'true'
+        run: |
+          gh release download fixtures-v1 --dir tests/fixtures/realdata/ --clobber
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
+
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Cache cargo
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-guard-target-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Build release binary
+        run: cargo build --release --package gpq-tiles
+
+      - name: Convert regression guard (structural, deterministic)
+        run: python3 benchmarks/overview/ci_guard.py --check

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ lcov.info
 # Benchmarks
 target/criterion/
 
+# Performance-sweep outputs (regenerable via benchmarks/overview/run_sweep.sh)
+benchmarks/overview/sweep_out/
+
 # Large benchmark fixtures (download manually, not tracked in repo)
 tests/fixtures/realdata/adm2_polygons.parquet
 

--- a/benchmarks/overview/PROFILE.md
+++ b/benchmarks/overview/PROFILE.md
@@ -79,7 +79,78 @@ Full pipeline (GeoParquet → overview file → PMTiles) < 2 min.
 - `--tile-size-limit` is a single non-iterative drop pass per
   oversized tile — a backstop, not the sizing mechanism.
 
-## Big-file tier (2026-07-04)
+## Big-file tier refresh (2026-07-14, current main)
+
+Supersedes the 2026-07-04 section below: every DNF/FAILED row there was
+from now-closed tickets (#211, #212, #213, #239). Binary: release build
+at `60c1bd6` + a local `allow_http` fix (see note); same 16-core AMD
+Ryzen 7040 laptop, 54 GiB RAM, same gpio-optimized inputs in
+`corpus/data/bigbench/`. Harness: `benchmarks/overview/run_sweep.sh`.
+
+**Timing is measured on local reads** (`LOCAL=1`), so wall/RSS/CPU are
+clean convert cost. **Bytes moved is measured separately** over a
+localhost `logging_server.py` (exact `/__stats` accounting, cross-checked
+against the converter's own `report.remote_fetch`). The two are split on
+purpose: reading over the network re-fetches the input (see remote table
++ #261), which inflates wall and depresses CPU — not a property of
+convert itself.
+
+### Convert performance (local reads, default knobs, z0–14)
+
+| dataset / mode | wall | peak RSS | CPU | feat/s |
+|---|---:|---:|---:|---:|
+| points-nyc-medium (points, dup) | 1.65 s | 0.28 GiB | 131 % | 277 k |
+| germany-segments (lines, dup) | 2:02 | 11.9 GiB | 138 % | 158 k |
+| germany-buildings (polygons, dup) | 4:00 | 14.8 GiB | 138 % | 246 k |
+| germany-buildings, `--profile speed` | 3:58 | 14.8 GiB | 137 % | 246 k |
+| germany-buildings, `--profile bounded` | 4:00 | **10.5 GiB** | 138 % | 246 k |
+| fieldmaps-adm4 (MultiPolygon, dup) | **1:54** | 4.7 GiB | 487 % | — |
+| fieldmaps-adm4, partitioning | **0:54** | 5.5 GiB | 111 % | — |
+
+(feat/s omitted for fieldmaps: 364 k features but 261 M vertices — it is
+vertex-bound, not feature-bound, so the rate isn't comparable.)
+
+### Remote read cost (localhost byte accounting)
+
+| dataset / call | bytes moved | ÷ file | requests |
+|---|---:|---:|---:|
+| points-nyc (full file) | 30.8 MB | 1.00× | 35 |
+| germany-segments (full file) | 6.82 GB | 2.67× | 2 829 |
+| germany-buildings (full file) | 18.1 GB | 2.59× | 8 180 |
+| fieldmaps-adm4 (full file, dup ≡ par) | 278 GB | **96×** | 591 |
+| germany-buildings `--bbox` Berlin | **52 MB** | **0.0074×** | 27 |
+
+### Findings (2026-07-14)
+
+1. **#211 fixed.** Germany buildings converts with default knobs in
+   **4:00** — the 2026-07-04 `level 0 is empty` FAILED row is gone.
+2. **#212 fixed.** fieldmaps duplicating, the former **DNF (>45 min)**,
+   is now **1:54**; partitioning is **0:54** (2× the dup — the mode
+   lever). Both from a hard DNF.
+3. **#213 landed, partially.** fieldmaps-dup now drives **487 % CPU**
+   (~5 cores) vs ~184 % before — the pipeline parallelism is real. But
+   the large-feature cells (buildings, segments) still sit at ~138 %
+   (~1.4 cores), so feature-parallel headroom remains.
+4. **`--profile bounded` is a free RAM win**: buildings peak RSS
+   14.8 → **10.5 GiB (−29 %)** at identical wall (4:00 vs 3:58).
+5. **Remote selective read is the differentiator, and its dark twin is
+   #261.** A Berlin `--bbox` extract from the 6.99 GB country file moves
+   **0.74 % of it in 0.83 s**. But a *full-file* remote convert
+   re-fetches the input 2.6–96× (mode-independent; per-level re-reads
+   overflow the 256 MiB cache) — filed as **#261**. This is exactly why
+   the timing table above uses local reads.
+
+*Not re-measured this pass:* the export phase (`export-pmtiles`). The
+2026-07-04 export DNF was #239, since closed; a convert+export
+end-to-end pass is future work.
+
+*Note on the binary:* the localhost harness needed a one-line
+`input.rs` fix — the HTTP object store was built without `allow_http`,
+so object_store's https-only default builder-errored every `http://`
+input despite `http://` being documented as supported. Unrelated to the
+numbers here (reproduces on `s3://`/`https://`); landing as its own PR.
+
+## Big-file tier (2026-07-04, superseded — DNFs since resolved; see refresh above)
 
 Pre-release validation on real multi-GB inputs (maintainer request;
 complements the #179 release-readiness pass). Binary: release build at

--- a/benchmarks/overview/ci_baseline.json
+++ b/benchmarks/overview/ci_baseline.json
@@ -1,0 +1,173 @@
+{
+  "admin": {
+    "input_features": 17465,
+    "levels": [
+      {
+        "feature_count": 1,
+        "level": 0,
+        "vertex_count": 5
+      },
+      {
+        "feature_count": 187,
+        "level": 1,
+        "vertex_count": 876
+      },
+      {
+        "feature_count": 252,
+        "level": 2,
+        "vertex_count": 1517
+      },
+      {
+        "feature_count": 254,
+        "level": 3,
+        "vertex_count": 2377
+      },
+      {
+        "feature_count": 256,
+        "level": 4,
+        "vertex_count": 3749
+      },
+      {
+        "feature_count": 318,
+        "level": 5,
+        "vertex_count": 7290
+      },
+      {
+        "feature_count": 525,
+        "level": 6,
+        "vertex_count": 15989
+      },
+      {
+        "feature_count": 865,
+        "level": 7,
+        "vertex_count": 31450
+      },
+      {
+        "feature_count": 1428,
+        "level": 8,
+        "vertex_count": 56881
+      },
+      {
+        "feature_count": 2356,
+        "level": 9,
+        "vertex_count": 98200
+      },
+      {
+        "feature_count": 3888,
+        "level": 10,
+        "vertex_count": 170612
+      },
+      {
+        "feature_count": 6415,
+        "level": 11,
+        "vertex_count": 319242
+      },
+      {
+        "feature_count": 10585,
+        "level": 12,
+        "vertex_count": 587158
+      },
+      {
+        "feature_count": 17465,
+        "level": 13,
+        "vertex_count": 1749880
+      }
+    ],
+    "total_rows": 44795,
+    "total_vertices": 3045226
+  },
+  "lines": {
+    "input_features": 1000,
+    "levels": [
+      {
+        "feature_count": 2,
+        "level": 0,
+        "vertex_count": 4
+      },
+      {
+        "feature_count": 20,
+        "level": 1,
+        "vertex_count": 42
+      },
+      {
+        "feature_count": 86,
+        "level": 2,
+        "vertex_count": 192
+      },
+      {
+        "feature_count": 204,
+        "level": 3,
+        "vertex_count": 472
+      },
+      {
+        "feature_count": 256,
+        "level": 4,
+        "vertex_count": 719
+      },
+      {
+        "feature_count": 256,
+        "level": 5,
+        "vertex_count": 967
+      },
+      {
+        "feature_count": 256,
+        "level": 6,
+        "vertex_count": 1323
+      },
+      {
+        "feature_count": 367,
+        "level": 7,
+        "vertex_count": 2213
+      },
+      {
+        "feature_count": 606,
+        "level": 8,
+        "vertex_count": 3623
+      },
+      {
+        "feature_count": 1000,
+        "level": 9,
+        "vertex_count": 5433
+      }
+    ],
+    "total_rows": 3053,
+    "total_vertices": 14988
+  },
+  "polygons": {
+    "input_features": 1000,
+    "levels": [
+      {
+        "feature_count": 1,
+        "level": 0,
+        "vertex_count": 4
+      },
+      {
+        "feature_count": 7,
+        "level": 1,
+        "vertex_count": 30
+      },
+      {
+        "feature_count": 70,
+        "level": 2,
+        "vertex_count": 342
+      },
+      {
+        "feature_count": 307,
+        "level": 3,
+        "vertex_count": 1673
+      },
+      {
+        "feature_count": 606,
+        "level": 4,
+        "vertex_count": 3540
+      },
+      {
+        "feature_count": 1000,
+        "level": 5,
+        "vertex_count": 6945
+      }
+    ],
+    "total_rows": 1991,
+    "total_vertices": 12534
+  }
+}

--- a/benchmarks/overview/ci_guard.py
+++ b/benchmarks/overview/ci_guard.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Deterministic convert-regression guard for CI.
+
+Runs `gpq-tiles overview` on the fixtures-v1 test inputs and checks the
+*structural* shape of the output against a committed baseline:
+per-level feature and vertex counts, total rows, total vertices, input
+features. These are deterministic functions of the input + knobs.
+
+It deliberately does NOT check wall time, peak RSS, or compressed byte
+sizes: timing is far too noisy on shared CI runners to gate on, and the
+parquet writer is not byte-deterministic (footer stats drift ~25 bytes
+run to run). A structural regression here means the tiling/ranking/
+simplification logic changed output — exactly what we want a PR to flag.
+
+Usage:
+  ci_guard.py --check     # compare to baseline, exit 1 on drift (CI)
+  ci_guard.py --update    # regenerate the baseline (run after intended changes)
+
+Env:
+  GPQ_BIN        release binary (default target/release/gpq-tiles)
+  FIXTURE_DIR    input dir (default tests/fixtures/realdata)
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+BIN = os.environ.get("GPQ_BIN", os.path.join(ROOT, "target/release/gpq-tiles"))
+FIXTURES = os.environ.get("FIXTURE_DIR", os.path.join(ROOT, "tests/fixtures/realdata"))
+BASELINE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ci_baseline.json")
+
+# (label, filename, extra overview args) — one per geometry class.
+CASES = [
+    ("polygons", "open-buildings.parquet", ["--mode", "duplicating"]),
+    ("lines", "road-detections.parquet", ["--mode", "duplicating"]),
+    ("admin", "fieldmaps-madagascar-adm4.parquet", ["--mode", "duplicating"]),
+]
+MIN_Z, MAX_Z = "0", "14"
+
+
+def signature(report: dict) -> dict:
+    """Deterministic structural fingerprint of a convert report."""
+    return {
+        "input_features": report.get("input_features"),
+        "total_rows": report.get("total_rows"),
+        "total_vertices": report.get("total_vertices"),
+        "levels": [
+            {
+                "level": lv.get("level"),
+                "feature_count": lv.get("feature_count"),
+                "vertex_count": lv.get("vertex_count"),
+            }
+            for lv in report.get("levels", [])
+        ],
+    }
+
+
+def run_case(fname: str, extra: list) -> dict:
+    src = os.path.join(FIXTURES, fname)
+    if not os.path.exists(src):
+        raise SystemExit(f"missing fixture: {src}")
+    with tempfile.TemporaryDirectory() as td:
+        out = os.path.join(td, "ov.parquet")
+        rep = os.path.join(td, "rep.json")
+        subprocess.run(
+            [BIN, "overview", src, out, "--min-zoom", MIN_Z, "--max-zoom", MAX_Z,
+             "--report", rep, *extra],
+            check=True, capture_output=True,
+        )
+        return signature(json.load(open(rep)))
+
+
+def main() -> int:
+    mode = sys.argv[1] if len(sys.argv) > 1 else "--check"
+    current = {label: run_case(f, extra) for label, f, extra in CASES}
+
+    if mode == "--update":
+        json.dump(current, open(BASELINE, "w"), indent=2, sort_keys=True)
+        print(f"wrote baseline: {BASELINE}")
+        return 0
+
+    if not os.path.exists(BASELINE):
+        raise SystemExit(f"no baseline at {BASELINE}; run --update first")
+    base = json.load(open(BASELINE))
+    drift = [k for k in current if current.get(k) != base.get(k)]
+    if drift:
+        print("CONVERT REGRESSION — structural output changed:", ", ".join(drift))
+        for k in drift:
+            print(f"\n[{k}] baseline vs current:")
+            print("  baseline:", json.dumps(base.get(k)))
+            print("  current :", json.dumps(current.get(k)))
+        return 1
+    print(f"convert guard OK ({len(current)} fixtures unchanged)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/overview/run_sweep.sh
+++ b/benchmarks/overview/run_sweep.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Unified performance sweep.
+#   default : inputs read over a localhost logging server -> captures bytes moved.
+#   LOCAL=1 : inputs read from local disk (no server) -> clean wall/RSS/CPU;
+#             outputs suffixed ".local" so a prior remote run's byte data is kept.
+# The berlin-bbox selective-read cell only runs in remote mode (bytes are the point).
+set -uo pipefail
+export RUST_BACKTRACE=1
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+BIN="$ROOT/target/release/gpq-tiles"
+DATAROOT="$ROOT/corpus/data"
+OUT="$HERE/sweep_out"
+SCRATCH="$ROOT/corpus/data/bigbench/sweep_scratch"
+PORT="${PORT:-8901}"
+BASE="http://127.0.0.1:$PORT"
+LOCAL="${LOCAL:-0}"
+SFX=""; [ "$LOCAL" = 1 ] && SFX=".local"
+mkdir -p "$OUT" "$SCRATCH"
+
+[ -x "$BIN" ] || { echo "build release binary first" >&2; exit 1; }
+COMMIT="$(cd "$ROOT" && git rev-parse --short HEAD)"
+
+if [ "$LOCAL" != 1 ]; then
+  python3 "$HERE/logging_server.py" "$DATAROOT" "$PORT" >"$OUT/server.log" 2>&1 &
+  SRV=$!
+  trap 'kill $SRV 2>/dev/null' EXIT
+  for _ in $(seq 1 30); do curl -sf "$BASE/__stats" >/dev/null 2>&1 && break; sleep 0.3; done
+  curl -sf "$BASE/__stats" >/dev/null 2>&1 || { echo "server failed"; exit 1; }
+fi
+
+run_cell() {
+  local label="$1" relpath="$2"; shift 2
+  local file="$DATAROOT/$relpath"
+  [ -e "$file" ] || { echo "=== $label MISSING $relpath ==="; return; }
+  local size; size=$(stat -c%s "$file")
+  local tf="$OUT/$label$SFX.time.txt" rf="$OUT/$label$SFX.report.json" dst="$SCRATCH/$label.parquet"
+  local input
+  if [ "$LOCAL" = 1 ]; then
+    input="$file"
+  else
+    input="$BASE/$relpath"
+    curl -sf "$BASE/__reset" >/dev/null
+  fi
+
+  echo "=== $label$SFX start $(date -u +%H:%M:%SZ) ==="
+  rm -f "$dst"
+  timeout "${TIMEOUT:-3600}" /usr/bin/time -v -o "$tf" "$BIN" overview "$input" "$dst" \
+    --min-zoom 0 --max-zoom 14 --report "$rf" "$@" >"$OUT/$label$SFX.log" 2>&1
+  local rc=$?
+  local stats="(local)"
+  [ "$LOCAL" != 1 ] && stats=$(curl -sf "$BASE/__stats")
+  echo "  exit=$rc  size=$size  stats=$stats"
+  grep -E "Elapsed \(wall|Maximum resident|Percent of CPU" "$tf" 2>/dev/null
+  rm -f "$dst"
+}
+
+echo "############ SWEEP commit=$COMMIT LOCAL=$LOCAL $(date -u) ############"
+run_cell points-nyc        gpio/points-nyc-medium.parquet --mode duplicating
+run_cell segments          bigbench/gpio/overture-germany-segments.parquet --mode duplicating
+run_cell buildings         bigbench/gpio/overture-germany-buildings.parquet --mode duplicating
+run_cell fieldmaps-dup     bigbench/gpio/fieldmaps-adm4.parquet --mode duplicating
+run_cell fieldmaps-par     bigbench/gpio/fieldmaps-adm4.parquet --mode partitioning
+run_cell buildings-speed   bigbench/gpio/overture-germany-buildings.parquet --mode duplicating --profile speed
+run_cell buildings-bounded bigbench/gpio/overture-germany-buildings.parquet --mode duplicating --profile bounded
+[ "$LOCAL" != 1 ] && run_cell berlin-bbox bigbench/gpio/overture-germany-buildings.parquet --mode duplicating --bbox 13.35,52.48,13.47,52.55
+echo "############ DONE $(date -u) ############"

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,109 @@
+# Performance
+
+gpq-tiles converts GeoParquet into multi-resolution overviews and
+PMTiles. This page characterises how that conversion scales on real
+multi-GB inputs, measured on current `main`.
+
+- Raw numbers and methodology history:
+  [`benchmarks/overview/PROFILE.md`](https://github.com/geoparquet-io/gpq-tiles/blob/main/benchmarks/overview/PROFILE.md).
+- Head-to-head against the GeoJSON → tippecanoe pipeline: see the
+  [Demo](demo.md) (Germany buildings, 59 M features: **13 m 11 s** vs the
+  incumbent pipeline failing at 57 m 30 s). We don't chase feature-level
+  tippecanoe parity — the demo settles the comparison; this page is about
+  how gpq-tiles scales on its own terms.
+
+## How these were measured
+
+- **Machine:** 16-core AMD Ryzen 7040 laptop, 54 GiB RAM, release build.
+- **Inputs:** gpio-optimised (`gpio sort hilbert --add-bbox`) Overture and
+  fieldmaps extracts. Optimising the input is not optional — Hilbert
+  ordering and right-sized row groups are what make the numbers below (and
+  the remote pruning further down) possible.
+- **Convert:** `gpq-tiles overview <in> <out> --min-zoom 0 --max-zoom 14`,
+  default knobs, wall/RSS/CPU from `/usr/bin/time -v`.
+- Timing is measured reading **local** files. Reading over the network
+  adds re-fetch cost that inflates wall time — see
+  [Remote selective read](#remote-selective-read) below.
+
+## Convert throughput by geometry type
+
+| input | geometry | features | wall | peak RSS | CPU |
+|---|---|---:|---:|---:|---:|
+| points-nyc-medium | points | 458 k | 1.7 s | 0.3 GiB | 131 % |
+| germany-segments | lines | 19.2 M | 2:02 | 11.9 GiB | 138 % |
+| germany-buildings | polygons | 59.0 M | 4:00 | 14.8 GiB | 138 % |
+| fieldmaps-adm4 | admin polygons | 364 k | 1:54 | 4.7 GiB | 487 % |
+
+Points are effectively free (no simplification, trivial clipping).
+Lines and polygons scale with feature and vertex count. fieldmaps-adm4 is
+the vertex-heavy stress case — only 364 k features but ~261 M vertices —
+and it drives ~5 cores (487 % CPU) where the large-feature layers still
+sit near ~1.4 cores, so there is feature-parallel headroom yet to claim.
+
+## Materialisation mode
+
+`--mode duplicating` (default) writes each level self-contained;
+`--mode partitioning` writes each feature once. On vertex-heavy data the
+difference is large:
+
+| input | mode | wall | peak RSS |
+|---|---|---:|---:|
+| fieldmaps-adm4 | duplicating | 1:54 | 4.7 GiB |
+| fieldmaps-adm4 | partitioning | **0:54** | 5.5 GiB |
+
+Partitioning roughly halves convert time here because it materialises the
+heavy geometry once instead of per level. Output is byte-identical in the
+sense that matters for rendering; pick partitioning for large
+vertex-dense polygon layers.
+
+## Memory profile
+
+`--profile bounded` caps in-flight memory for the streaming convert path.
+It changes nothing about the output and, in practice, costs nothing in
+wall time:
+
+| input | profile | wall | peak RSS |
+|---|---|---:|---:|
+| germany-buildings | speed | 3:58 | 14.8 GiB |
+| germany-buildings | bounded | 4:00 | **10.5 GiB** |
+
+−29 % peak RSS for a 2-second wall difference. Use `bounded` when RSS
+headroom matters more than the last few percent of throughput.
+
+## Remote selective read
+
+`overview` reads remote GeoParquet (`s3://`, `https://`, `http://`,
+`gs://`) with HTTP byte-range requests. With `--bbox`, only the row groups
+overlapping the box are ever fetched — nothing else is downloaded. See
+[Remote Reads](remote-reads.md) for the full walkthrough.
+
+Extracting a Berlin slice from the 6.99 GB Germany buildings file:
+
+```bash
+gpq-tiles overview \
+  s3://…/germany-buildings.parquet \
+  berlin.parquet \
+  --bbox 13.35,52.48,13.47,52.55 \
+  --min-zoom 0 --max-zoom 14
+```
+
+fetches **52 MB — 0.74 % of the file — in 0.83 s**. No other tiler does
+selective remote extraction like this.
+
+The caveat is the mirror image: a **full-file** remote convert re-fetches
+the input, because the streaming engine re-reads it per level and large
+selections overflow the 256 MiB chunk cache. Measured bytes moved ÷ file
+size, full file vs bbox:
+
+| call | bytes moved | ÷ file |
+|---|---:|---:|
+| points-nyc (full) | 30.8 MB | 1.00× |
+| germany-segments (full) | 6.82 GB | 2.67× |
+| germany-buildings (full) | 18.1 GB | 2.59× |
+| fieldmaps-adm4 (full) | 278 GB | 96× |
+| germany-buildings `--bbox` | 52 MB | **0.0074×** |
+
+So `--bbox` extraction is the remote superpower; for a *whole-file*
+remote conversion, download first (`aws s3 cp` + local convert) or expect
+the re-fetch. Reducing that full-file cost is tracked in
+[#261](https://github.com/geoparquet-io/gpq-tiles/issues/261).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
   - Home: index.md
   - Getting Started: getting-started.md
   - Demo (Germany buildings): demo.md
+  - Performance: performance.md
   - Decoding PMTiles: decode.md
   - API Reference: api-reference.md
   - Advanced Usage: advanced-usage.md


### PR DESCRIPTION
Refreshes the big-file performance numbers on current `main` and turns the one-off sweep into reusable infrastructure. Every DNF/FAILED row in the old 2026-07-04 profile was from a since-closed ticket (#211/#212/#213/#239).

## Headline results (current `main`)

Convert (local reads, z0–14, default knobs; 16-core Ryzen, 54 GiB):

| dataset | mode | wall | peak RSS | was |
|---|---|---:|---:|---|
| germany-buildings (59M polys) | dup | 4:00 | 14.8 GiB | FAILED (level-0-empty, #211) |
| fieldmaps-adm4 (vertex-heavy) | dup | 1:54 | 4.7 GiB | **DNF >45 min** (#212) |
| fieldmaps-adm4 | partitioning | 0:54 | 5.5 GiB | 0:55 (#221) |
| germany-buildings | bounded | 4:00 | 10.5 GiB | −29% RSS, free |

Remote selective read: a Berlin `--bbox` extract from the 6.99 GB Germany file moves **0.74% of it in 0.83 s**.

## What's here

- **`run_sweep.sh`** — unified sweep. Default reads over a localhost logging server for exact bytes-moved accounting; `LOCAL=1` reads from disk for clean wall/RSS/CPU (timing over remote is contaminated by re-fetch — see #261). One `run_cell` serves both.
- **`PROFILE.md`** — new current-`main` section (local convert timing + remote byte cost tables); the 2026-07-04 section stays as history with a superseded banner.
- **`ci_guard.py` + `ci_baseline.json`** — deterministic convert-regression gate: per-level feature/vertex counts + total rows on fixtures-v1 inputs. Deliberately does **not** gate timing/RSS (too noisy on shared runners) or compressed bytes (parquet footer isn't byte-deterministic). Runnable now: `python3 benchmarks/overview/ci_guard.py --check`.
- **`docs/performance.md`** — public performance page; tippecanoe is a single pointer to the Demo, not a parity table.

## Follow-ups

- **CI wiring not included:** a `convert-guard` job for `.github/workflows/bench.yml` (gates PRs; criterion benches stay push-only) is written but not pushed — the OAuth token lacks `workflow` scope. The diff is ready to apply by anyone with that scope.
- Default (remote) harness mode depends on **#262** (`http://` `allow_http`); `LOCAL=1` and the guard don't.
- Remote full-file convert re-fetches 2.6–96× (mode-independent) — **#261**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)