### PR TITLE
docs(remote): correct full-file re-fetch multiple to measured 3.0× (#261)

### DIFF
--- a/docs/remote-reads.md
+++ b/docs/remote-reads.md
@@ -62,10 +62,13 @@ What to know:
   group's working set (floored at 256 MiB), so a single row group whose
   column chunks exceed the floor — e.g. a multi-GB geometry chunk — is
   no longer evicted mid-read and re-fetched per page (issue #261). What
-  remains is the two-pass baseline: a full-file conversion reads the
-  input roughly twice (the assign pass, then the write pass), so a huge
-  full-file remote conversion moves ~2× the object's bytes — if that
-  matters, download first.
+  remains is the multi-pass baseline: a full-file conversion reads the
+  input a few times — the assign pass, the write pass, and (at higher
+  zoom) a finest-level canonical re-read — so a full-file remote
+  conversion moves a small constant multiple of the object's bytes.
+  Measured on fieldmaps-adm4 (2.90 GB, z0–14): **96× before #261, 3.0×
+  after**. Eliminating the finest-level re-read to approach ~1× is
+  tracked in #219; if the residual matters today, download first.
 - **Latency vs bytes** — requests are issued sequentially, so on a
   fast link a plain `aws s3 cp` + local convert can still win on wall
   time (92 MB corpus file, residential fiber: ~3 s download+convert


### PR DESCRIPTION
Follow-up accuracy fix to #265.

The remote-reads note estimated the post-#261 full-file re-fetch at "~2×". The production remeasure — fieldmaps-adm4 (2.90 GB) at z0–14 over a localhost logging server, now possible since #262 enables `http://` — is **3.0×**, not 2×: assign pass + write pass + a finest-level canonical re-read at higher zoom. Two independent byte accounts agree (server `/__stats` and the converter's `remote_fetch`: 8.67 GB, 354 requests), vs **96×** pre-fix.

Updates the doc to state the measured 96× → 3.0× and points the residual (3× → ~1×, by eliminating the finest-level re-read) at #219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)