### PR TITLE
perf(core): parallelize convert's dominant serial stages (#264)

### DIFF
--- a/crates/core/src/overview/assign.rs
+++ b/crates/core/src/overview/assign.rs
@@ -36,17 +36,25 @@
 //! level, guaranteeing every feature is present at the canonical level (spec
 //! §2.4).
 //!
-//! # Memory (streaming-critical property)
+//! # Memory
 //!
-//! Per level, the only state is a hashmap `cell -> best-priority-so-far`. This
-//! is the property the streaming refactor (plan V4) depends on: peak memory is
-//! `O(occupied cells)` per level, not `O(features)` retained across levels.
+//! Per level, the only state is a hashmap `cell -> best-priority-so-far`,
+//! `O(occupied cells)` — never `O(features)` retained across levels. The coarse
+//! levels are built concurrently (#264, see below), so the transient peak is
+//! the sum of the *concurrently live* grids rather than a single one; this
+//! phase runs before the pass-2 geometry buffers that set overall peak RSS, so
+//! it does not move the high-water mark in practice.
 //!
-//! # Determinism
+//! # Parallelism & determinism
 //!
-//! The per-cell winner is the maximum under a *strict total order* (ties are
-//! ultimately broken by the feature `index`), so results never depend on
-//! hashmap iteration order and are identical across runs.
+//! Each level's cell-winner pass is independent, so the coarse levels run
+//! concurrently across rayon threads (#264 — this is the hot serial stage on
+//! large-feature / simple-geometry layers). Results are unaffected: the
+//! per-cell winner is the maximum under a *strict total order* (ties are
+//! ultimately broken by the feature `index`), so they never depend on hashmap
+//! iteration order or thread scheduling, and a feature takes the *coarsest*
+//! level at which it wins regardless of the order levels finish. Output is
+//! identical across runs and to a fully serial build.
 //!
 //! # DIVERGENCE FROM TIPPECANOE / cogp-rs
 //!
@@ -57,6 +65,8 @@
 //! (plan V2) shows artifacts.
 
 use std::collections::HashMap;
+
+use rayon::prelude::*;
 
 pub use super::level::{Crs, METERS_PER_DEGREE};
 
@@ -320,6 +330,56 @@ impl Priority {
     }
 }
 
+/// Build one overview level's cell-winner grid and return the winning feature
+/// positions (one per occupied cell).
+///
+/// Serial single-map build — no cross-thread merge. Parallelism in
+/// [`assign_levels`] is *across* levels (each level's grid is independent), so
+/// this per-level work stays a single tight HashMap pass with no merge tax.
+fn level_winner_positions(
+    features: &[AssignFeature],
+    config: &AssignConfig,
+    gsd_units: f64,
+) -> Vec<usize> {
+    // cell -> (best priority, position of winning feature in `features`).
+    let mut grid: HashMap<CellKey, (Priority, usize)> = HashMap::new();
+
+    for (pos, feat) in features.iter().enumerate() {
+        // Visibility gate (points always pass).
+        let vis = config.visibility_factor(feat.kind);
+        if vis > 0.0 {
+            let gate = vis * gsd_units;
+            if feat.diag_sq() < gate * gate {
+                continue; // ineligible at this level
+            }
+        }
+
+        let cell_size = gsd_units * config.thinning_factor(feat.kind);
+        // Guard against a zero/negative cell size (bad GSD input); also
+        // reject NaN.
+        if cell_size <= 0.0 || cell_size.is_nan() {
+            continue;
+        }
+        let (cx, cy) = feat.center();
+        let key: CellKey = (
+            feat.kind.discriminant(),
+            (cx / cell_size).floor() as i64,
+            (cy / cell_size).floor() as i64,
+        );
+
+        let prio = Priority::new(feat, config.sort_direction);
+        grid.entry(key)
+            .and_modify(|slot| {
+                if prio.beats(&slot.0) {
+                    *slot = (prio, pos);
+                }
+            })
+            .or_insert((prio, pos));
+    }
+
+    grid.into_values().map(|(_prio, pos)| pos).collect()
+}
+
 /// Assign every feature its coarsest surviving level.
 ///
 /// - `features`: input features (any order; output is parallel to this slice).
@@ -361,51 +421,35 @@ pub fn assign_levels(
     let mut min_levels: Vec<u8> = vec![finest; features.len()];
 
     // Per level, coarse→fine, run one cell-winner pass. State is O(cells).
-    for (level_idx, &gsd_m) in level_gsds.iter().enumerate() {
+    //
+    // The finest level is skipped: `min_levels` already starts at `finest`, so
+    // its cell-winner pass can only re-assign winners to a level they already
+    // hold — pure dead work, and (crucially) its grid is the single largest
+    // one (at fine GSD nearly every feature wins its own cell), so skipping it
+    // also removes the biggest allocation. Only coarse levels can *lower* a
+    // feature's `min_level`.
+    //
+    // Parallelism (#264): each coarse level's grid is fully independent, so the
+    // per-level cell-winner passes run concurrently across rayon threads (no
+    // merge — each level owns one HashMap). This is the hot serial stage on
+    // large-feature / simple-geometry layers (issue #264). The concurrent grids
+    // live only during this phase, which precedes the pass-2 geometry buffers
+    // that set peak RSS, so overall peak memory is unaffected. The fold below
+    // is deterministic regardless of completion order: a feature takes the
+    // *coarsest* (smallest) level at which it wins.
+    let winners_per_level: Vec<Vec<usize>> = (0..finest as usize)
+        .into_par_iter()
+        .map(|level_idx| {
+            let gsd_units = gsd_to_coord_units(level_gsds[level_idx], crs);
+            level_winner_positions(features, config, gsd_units)
+        })
+        .collect();
+
+    for (level_idx, winners) in winners_per_level.iter().enumerate() {
         let level = level_idx as u8;
-        let gsd_units = gsd_to_coord_units(gsd_m, crs);
-
-        // cell -> (best priority, position of winning feature in `features`)
-        let mut grid: HashMap<CellKey, (Priority, usize)> = HashMap::new();
-
-        for (pos, feat) in features.iter().enumerate() {
-            // Visibility gate (points always pass).
-            let vis = config.visibility_factor(feat.kind);
-            if vis > 0.0 {
-                let gate = vis * gsd_units;
-                if feat.diag_sq() < gate * gate {
-                    continue; // ineligible at this level
-                }
-            }
-
-            let cell_size = gsd_units * config.thinning_factor(feat.kind);
-            // Guard against a zero/negative cell size (bad GSD input); also
-            // reject NaN.
-            if cell_size <= 0.0 || cell_size.is_nan() {
-                continue;
-            }
-            let (cx, cy) = feat.center();
-            let key: CellKey = (
-                feat.kind.discriminant(),
-                (cx / cell_size).floor() as i64,
-                (cy / cell_size).floor() as i64,
-            );
-
-            let prio = Priority::new(feat, config.sort_direction);
-            grid.entry(key)
-                .and_modify(|slot| {
-                    if prio.beats(&slot.0) {
-                        *slot = (prio, pos);
-                    }
-                })
-                .or_insert((prio, pos));
-        }
-
-        // Winners at this level take it as their min_level, unless a coarser
-        // level already claimed them (we only lower, never raise).
-        for (_prio, pos) in grid.values() {
-            if level < min_levels[*pos] {
-                min_levels[*pos] = level;
+        for &pos in winners {
+            if level < min_levels[pos] {
+                min_levels[pos] = level;
             }
         }
     }
@@ -876,6 +920,57 @@ mod tests {
         let out = assign_levels(&feats, &gsds, &AssignConfig::default(), Crs::Epsg3857);
         let at0 = out.duplicating_at_level(0);
         assert_eq!(at0.len(), 1, "one winner at coarsest level");
+    }
+
+    #[test]
+    fn parallel_grid_merge_is_deterministic_at_scale() {
+        // Stress the sharded map-reduce grid build (#264): enough features,
+        // spread across many cells with heavy same-cell contention, that rayon
+        // splits the work into multiple shards whose partial grids must merge
+        // to a single canonical result. The per-level `min_level` vector must
+        // be byte-identical across repeated runs (no dependence on shard or
+        // hashmap iteration order) and invariant to input order.
+        let mut feats: Vec<AssignFeature> = Vec::new();
+        // 50 coarse cells (5 km apart in EPSG:3857 meters), 400 polygons each
+        // of varying size sharing that cell → 20k features, every cell heavily
+        // contended so the winner selection actually exercises the merge.
+        let mut idx = 0usize;
+        for c in 0..50 {
+            let base = c as f64 * 5_000.0;
+            for k in 0..400 {
+                let span = 200.0 + (k as f64) * 50.0;
+                feats.push(poly(idx, base, base, base + span, base + span));
+                idx += 1;
+            }
+        }
+        let gsds = [gsd(4), gsd(8), gsd(12), gsd(14)];
+        let cfg = AssignConfig::default();
+
+        let baseline = assign_levels(&feats, &gsds, &cfg, Crs::Epsg3857);
+        let levels_of = |a: &Assignment| -> Vec<(usize, u8)> {
+            let mut v: Vec<(usize, u8)> = a
+                .assignments
+                .iter()
+                .map(|x| (x.index, x.min_level))
+                .collect();
+            v.sort_unstable();
+            v
+        };
+        let want = levels_of(&baseline);
+
+        // Repeated runs must be identical (parallel merge determinism).
+        for _ in 0..8 {
+            let got = assign_levels(&feats, &gsds, &cfg, Crs::Epsg3857);
+            assert_eq!(levels_of(&got), want, "assignment unstable across runs");
+        }
+        // Reversed input order must yield the same per-feature levels.
+        let mut rev = feats.clone();
+        rev.reverse();
+        assert_eq!(
+            levels_of(&assign_levels(&rev, &gsds, &cfg, Crs::Epsg3857)),
+            want,
+            "assignment must not depend on input order",
+        );
     }
 
     // ---- visibility gating per kind -----------------------------------------

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -47,12 +47,14 @@
 //! [`LevelWriteOutcome::SkippedEmpty`]: super::writer::LevelWriteOutcome::SkippedEmpty
 //! [`ConvertReport::skipped_empty_levels`]: super::convert::ConvertReport::skipped_empty_levels
 
-use std::cell::{Cell, RefCell};
+use std::cell::Cell;
 use std::collections::HashSet;
 use std::fs::File;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
+
+use crossbeam_channel::bounded;
 
 use arrow_array::{Array, RecordBatch, UInt32Array};
 use arrow_schema::{DataType, Schema, SchemaRef};
@@ -240,6 +242,8 @@ pub(crate) fn convert_streaming_strategy(
 
     let t_assign = Instant::now();
     let assignment = assign_levels(&features, &level_gsds, &options.assign, crs);
+    let assign_secs = t_assign.elapsed().as_secs_f64();
+    let t_budget = Instant::now();
     let assignment = if options.density.enabled {
         apply_density_budget(
             &assignment,
@@ -253,8 +257,10 @@ pub(crate) fn convert_streaming_strategy(
         assignment
     };
     log::debug!(
-        "[profile] assignment+budget: {:.2}s",
-        t_assign.elapsed().as_secs_f64()
+        "[profile] assignment+budget: {:.2}s (assign {:.2}s + budget {:.2}s)",
+        t_assign.elapsed().as_secs_f64(),
+        assign_secs,
+        t_budget.elapsed().as_secs_f64()
     );
     log::info!(
         "[convert] level assignment complete: {} level(s) in {:.1}s",
@@ -551,6 +557,7 @@ pub(crate) fn convert_streaming_strategy(
                     hints[i],
                     source,
                     options.read_batch_size,
+                    options.in_flight_batches,
                     selected_row_groups.as_deref(),
                     ctx,
                 )
@@ -586,6 +593,7 @@ pub(crate) fn convert_streaming_strategy(
                 hints[n - 1],
                 source,
                 options.read_batch_size,
+                options.in_flight_batches,
                 selected_row_groups.as_deref(),
                 &ctxs[n - 1],
             )?);
@@ -1219,85 +1227,128 @@ impl LevelStreamCtx<'_> {
 /// Stream one level from the input file into the writer. Returns the writer
 /// outcome (a level whose every candidate collapses during simplification is
 /// skipped, #211) plus `(rows_written, vertex_count)`.
+#[allow(clippy::too_many_arguments)]
 fn write_level_streaming(
     writer: &mut OverviewWriter<File>,
     level_idx: usize,
     hint: usize,
     source: &InputSource,
     read_batch_size: usize,
+    in_flight: usize,
     row_groups: Option<&[usize]>,
     ctx: &LevelStreamCtx<'_>,
 ) -> Result<(LevelWriteOutcome, usize, usize), ConvertError> {
-    let mut builder = source.open()?.with_batch_size(read_batch_size.max(1));
-    // Regional extract (#102): read the same bbox-selected row groups as
-    // pass 1, so the winner tables' global row indices line up.
-    if let Some(rgs) = row_groups {
-        builder = builder.with_row_groups(rgs.to_vec());
-    }
-    let mut reader = builder.build()?;
-
-    // `write_level` consumes an infallible batch iterator; errors inside the
-    // stream are parked in `err` (fusing the iterator) and re-raised after.
-    let err: RefCell<Option<ConvertError>> = RefCell::new(None);
     let rows = Cell::new(0usize);
     let vertices = Cell::new(0usize);
-    let mut row_offset = 0usize;
     let timers = Pass2Timers::default();
     let fallbacks_before = full_resolution_fallback_count();
     let t_level = Instant::now();
 
-    // Heartbeat (#242): the finest level re-streams the whole input; keep
-    // the operator informed on planet-scale files (quiet on small ones).
-    let mut last_progress = Instant::now();
-    let batches = std::iter::from_fn(|| loop {
-        if last_progress.elapsed().as_secs() >= 10 {
-            last_progress = Instant::now();
-            log::info!(
-                "[convert] level {level_idx}: {} input row(s) scanned, {} \
-                 row(s) written",
-                row_offset,
-                rows.get(),
-            );
-        }
-        let t_read = Instant::now();
-        let batch = match reader.next() {
-            None => return None,
-            Some(Err(e)) => {
-                *err.borrow_mut() = Some(e.into());
-                return None;
-            }
-            Some(Ok(b)) => b,
-        };
-        Pass2Timers::add(&timers.read, t_read);
-        let offset = row_offset;
-        row_offset += batch.num_rows();
-        match process_level_batch(&batch, offset, ctx, &timers) {
-            Ok(None) => continue, // no members of this level in the batch
-            Ok(Some((out, verts))) => {
-                rows.set(rows.get() + out.num_rows());
-                vertices.set(vertices.get() + verts);
-                return Some(out);
-            }
-            Err(e) => {
-                *err.borrow_mut() = Some(e);
-                return None;
-            }
-        }
-    });
-
-    let res = writer.write_level(level_idx, Some(hint), batches);
-    if let Some(e) = err.borrow_mut().take() {
-        return Err(e); // stream error takes precedence over the writer's
+    // One processed output batch handed from the producer to the writer.
+    struct Processed {
+        batch: RecordBatch,
+        verts: usize,
     }
-    let outcome = res?;
+
+    // Overlap decode→process with the single-threaded parquet writer (#264,
+    // extending the #213 pipeline discipline to the streamed finest level): a
+    // producer thread reads input batches and runs `process_level_batch`
+    // (read + geometry decode + simplify + assemble), pushing finished output
+    // batches over a bounded channel; the writer drains it on this thread.
+    // Batches stay in read order (FIFO channel, single producer), so output —
+    // and therefore row-group boundaries — are byte-identical to a serial
+    // build. Channel depth bounds read/compute run-ahead the same way the
+    // buffered engine's reader channel does.
+    let (tx, rx) = bounded::<Processed>(in_flight.max(1));
+    // Shared by reference into the producer thread (a `&Pass2Timers` is `Copy`,
+    // so the `move` closure copies the borrow and leaves `timers` owned here
+    // for the post-scope read).
+    let timers = &timers;
+    let outcome = std::thread::scope(|scope| -> Result<LevelWriteOutcome, ConvertError> {
+        // Producer: read + process, in order, until EOF or the writer
+        // hangs up. Returns the first stream/processing error, if any.
+        // `move` transfers ownership of `tx` into the thread so it is dropped
+        // when the producer finishes — that disconnect is what fuses the
+        // writer's `rx.recv()` loop below (otherwise `recv` blocks forever and
+        // deadlocks). Everything else the closure touches (`source`, `ctx`,
+        // `&timers`, `row_groups`, the `usize`s) is `Copy`, so the outer
+        // bindings — notably `timers`, read back after the scope — stay valid.
+        let producer = scope.spawn(move || -> Result<(), ConvertError> {
+            let mut builder = source.open()?.with_batch_size(read_batch_size.max(1));
+            // Regional extract (#102): read the same bbox-selected row
+            // groups as pass 1, so the winner tables' global row indices
+            // line up.
+            if let Some(rgs) = row_groups {
+                builder = builder.with_row_groups(rgs.to_vec());
+            }
+            let mut reader = builder.build()?;
+            let mut row_offset = 0usize;
+            // Heartbeat (#242): the finest level re-streams the whole
+            // input; keep the operator informed on planet-scale files
+            // (quiet on small ones).
+            let mut last_progress = Instant::now();
+            loop {
+                if last_progress.elapsed().as_secs() >= 10 {
+                    last_progress = Instant::now();
+                    log::info!(
+                        "[convert] level {level_idx}: {row_offset} input \
+                             row(s) scanned",
+                    );
+                }
+                let t_read = Instant::now();
+                let batch = match reader.next() {
+                    None => return Ok(()),
+                    Some(Err(e)) => return Err(e.into()),
+                    Some(Ok(b)) => b,
+                };
+                Pass2Timers::add(&timers.read, t_read);
+                let offset = row_offset;
+                row_offset += batch.num_rows();
+                match process_level_batch(&batch, offset, ctx, timers)? {
+                    None => continue, // no members of this level in the batch
+                    Some((out, verts)) => {
+                        // Writer gone (its side errored and dropped `rx`):
+                        // stop; the writer's error is reported below.
+                        if tx.send(Processed { batch: out, verts }).is_err() {
+                            return Ok(());
+                        }
+                    }
+                }
+            }
+        });
+
+        // Writer (this thread): drain processed batches in order. Dropping
+        // the producer's `tx` (EOF, error, or writer-gone) fuses `recv`.
+        let batches = std::iter::from_fn(|| match rx.recv() {
+            Ok(msg) => {
+                rows.set(rows.get() + msg.batch.num_rows());
+                vertices.set(vertices.get() + msg.verts);
+                Some(msg.batch)
+            }
+            Err(_) => None,
+        });
+        let res = writer.write_level(level_idx, Some(hint), batches);
+
+        // A producer error takes precedence over the writer's (the writer
+        // may merely observe a truncated stream). `join` cannot panic here:
+        // the closure only returns `Result`.
+        producer
+            .join()
+            .expect("finest-level producer thread panicked")?;
+        Ok(res?)
+    })?;
     let total = t_level.elapsed().as_secs_f64();
     let read_s = Pass2Timers::secs(&timers.read);
     let decode_s = Pass2Timers::secs(&timers.decode);
     let simplify_s = Pass2Timers::secs(&timers.simplify);
     let build_s = Pass2Timers::secs(&timers.build);
+    // Read/decode/simplify/build run on the producer thread and overlap the
+    // writer (#264), so these stage sums are core-seconds that overlap the
+    // `total` wall time — the writer's own cost is roughly
+    // `total - max(producer stages)`, not `total - sum`.
     log::debug!(
         "[profile] level {} ({}, {} rows): total={:.2}s read={:.2}s decode={:.2}s \
-         simplify={:.2}s build={:.2}s write={:.2}s",
+         simplify={:.2}s build={:.2}s (read/decode/simplify/build overlap the writer)",
         level_idx,
         if ctx.verbatim { "verbatim" } else { "simplify" },
         rows.get(),
@@ -1306,7 +1357,6 @@ fn write_level_streaming(
         decode_s,
         simplify_s,
         build_s,
-        (total - (read_s + decode_s + simplify_s + build_s)).max(0.0),
     );
     let fallbacks = full_resolution_fallback_count() - fallbacks_before;
     if fallbacks > 0 {


### PR DESCRIPTION
Closes #264.

## Problem

On large-feature / simple-geometry layers (country-scale buildings, roads) `convert` ran at **~1.4 cores of 16**. #213's per-batch pipeline parallelism only pays off when simplification is expensive (vertex-heavy admin polygons); when simplification is cheap, the remaining **serial** stages dominate.

## Profile (germany-segments, 19.2M lines, z0–14, duplicating, release, 16-core)

Baseline wall **147s @ 144% CPU**. Serial stages attributed via `RUST_LOG=gpq_tiles_core::overview=debug`:

| stage | wall | nature |
|---|---:|---|
| pass 1 (decode + bbox/kind + rank) | 13s | serial |
| **level assignment + density budget** | **39s** | **fully serial (no rayon)** |
| pass 2 buffered (levels 0–13) | 53s | ~16 core-s compute + serial parquet drain |
| **pass 2 finest (verbatim)** | **41s** | serial read+decode+build **+ 29s single-threaded writer** |

## Changes (both byte-equivalent)

**1. `assign_levels` — parallelize across levels.** Each level's cell-winner grid is independent. Skip the finest-level grid entirely (dead work: every feature already starts at `finest`, so its pass can only re-assign winners to the level they already hold — and it's the biggest grid), and build the remaining coarse levels' grids concurrently across rayon threads. A first attempt using a per-level sharded map-reduce *regressed* (HashMap merge tax: assign 30→38s); across-levels needs no merge. Deterministic — the per-cell winner is a strict total order and a feature takes the coarsest level it wins regardless of completion order.

**2. `write_level_streaming` — overlap producer with writer.** The streamed finest/canonical level did read → geometry decode → assemble → single-threaded parquet write all on one thread. A producer thread now runs read + `process_level_batch` and hands finished batches to the writer over a bounded `crossbeam` channel (`thread::scope`), extending #213's discipline to this level. A single FIFO producer preserves read order, so row-group boundaries stay identical.

## Equivalence

- **DuckDB per-level content hash** (order-independent `bit_xor(hash(geometry + properties))` + row count) — **all 15 levels identical** to the pre-change output on germany-segments.
- Unit tests: `pipelined_matches_serial`, all 8 `streaming_matches_*` (duplicating/partitioning/coalescing/clustering/auto-rank), empty-level, hostile, and a new `parallel_grid_merge_is_deterministic_at_scale` all pass.

## Results (release, 16-core)

| dataset | before | after |
|---|---|---|
| germany-segments (19.2M lines) | 147s @ **144%** CPU | **111s @ 195%** CPU (−24% wall, 1.4→2.0 cores) |
| germany-buildings (59M polys) | 240s @ **138%** CPU | **230s @ 183%** CPU; peak RSS 15.6 GB |

The across-level grids run before the pass-2 geometry buffers that set peak RSS, so they don't move the high-water mark (+3–4% transient).

## Remaining serial floors (follow-ups, not addressed here)

Buildings gains less wall than segments because it is dominated by:
- the **single-threaded parquet writer** (buffered drain + finest write ≈ 176s of 230s) — the real floor; parallel column/row-group encoding in `OverviewWriter` is a separate, larger effort.
- **pass-1 geometry decode** (~30s at 59M) — parallelizable, but the shared group-interner (coalescing) assigns IDs in first-seen order, a byte-equivalence hazard that warrants its own careful PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)