### PR TITLE
perf(core): bound remote re-reads to ~1× + full-file remote nudge (#219, #267)

### DIFF
--- a/crates/core/src/input.rs
+++ b/crates/core/src/input.rs
@@ -20,15 +20,25 @@
 //! object's bytes. [`InputSource::fetch_stats`] exposes request/byte
 //! counters so callers (and tests) can verify that property.
 //!
-//! The streaming pipeline re-reads the input across two passes. Each
-//! [`InputSource::open`] of a remote source reuses a cached parsed footer,
-//! and fetched column chunks stay in a bounded LRU-ish cache
-//! (insertion-order eviction), so within a pass the reader never re-fetches a
-//! chunk. The cache budget is sized to the largest row group's working set
-//! (floored at [`remote::CHUNK_CACHE_MAX_BYTES`]) so that a row group larger
-//! than the floor does not thrash — the fix for the per-page re-fetch of an
-//! oversized column chunk (issue #261). See `docs/remote-reads.md` for the
-//! fetch-count implications.
+//! The streaming pipeline re-reads the input across several passes (assign,
+//! coarse levels, finest streamed last). Each [`InputSource::open`] of a
+//! remote source reuses a cached parsed footer, and fetched column chunks are
+//! served from the cheapest tier that holds them:
+//!
+//! - **L1**, a bounded in-memory cache (insertion-order eviction) sized to the
+//!   largest row group's working set (floored at
+//!   [`remote::CHUNK_CACHE_MAX_BYTES`]), so a row group larger than the floor
+//!   does not thrash — the fix for the per-page re-fetch of an oversized column
+//!   chunk (issue #261);
+//! - **L2**, a local on-disk spill of every chunk ever fetched, so a chunk
+//!   evicted from L1 between passes is drained from local disk instead of the
+//!   network — this bounds remote traffic to ≈1× the object regardless of pass
+//!   or level count (issue #219; without it a full-file remote convert moved
+//!   ~3× the object);
+//! - **L3**, one network range request, taken only on the first touch of a
+//!   chunk.
+//!
+//! See `docs/remote-reads.md` for the fetch-count implications.
 //!
 //! Remote support is compiled behind the `remote` cargo feature; the CLI and
 //! Python bindings enable it by default. Without the feature, URL inputs
@@ -272,6 +282,8 @@ impl ChunkReader for InputReader {
 pub(crate) mod remote {
     //! Remote object-store backend (`remote` feature).
 
+    use std::fs::File;
+    use std::io::{Read, Seek, SeekFrom, Write};
     use std::ops::Range;
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::{Arc, Mutex, OnceLock};
@@ -360,6 +372,10 @@ pub(crate) mod remote {
         shared: Arc<SharedState>,
         metadata: OnceLock<ArrowReaderMetadata>,
         cache: Arc<Mutex<ChunkCache>>,
+        /// On-disk overflow for fetched column chunks (issue #219), shared by
+        /// every reader clone across the pipeline's passes so a chunk fetched
+        /// in one pass is drained from local disk in the next.
+        spill: Arc<Mutex<DiskSpill>>,
         /// Floor for the chunk-cache eviction budget. [`Self::open_builder`]
         /// raises the live cap to the largest row group's working set but
         /// never below this. Production uses [`CHUNK_CACHE_MAX_BYTES`]; tests
@@ -435,6 +451,7 @@ pub(crate) mod remote {
                 shared: Arc::new(SharedState::default()),
                 metadata: OnceLock::new(),
                 cache: Arc::new(Mutex::new(ChunkCache::new(cap_base))),
+                spill: Arc::new(Mutex::new(DiskSpill::default())),
                 cap_base,
             })
         }
@@ -516,6 +533,7 @@ pub(crate) mod remote {
                 size: self.size,
                 shared: Arc::clone(&self.shared),
                 cache: Arc::clone(&self.cache),
+                spill: Arc::clone(&self.spill),
             }
         }
 
@@ -638,6 +656,98 @@ pub(crate) mod remote {
     /// batch (issue #261). This constant is just the small-input floor.
     const CHUNK_CACHE_MAX_BYTES: u64 = 256 * 1024 * 1024;
 
+    /// On-disk overflow for fetched column chunks (issue #219).
+    ///
+    /// The in-memory [`ChunkCache`] holds only one row group's working set, so
+    /// across the streaming pipeline's multiple passes (assign, coarse levels,
+    /// finest streamed last) a chunk evicted from memory is otherwise
+    /// re-fetched over the network — paying remote bandwidth 2–3× for the bulk
+    /// of the file (measured 3.0× on fieldmaps-adm4). Spilling every fetched
+    /// chunk to a local temp file and draining re-reads from disk bounds remote
+    /// traffic to ≈1× the object, regardless of pass or level count.
+    ///
+    /// The temp file is anonymous ([`tempfile::tempfile`]): it is unlinked on
+    /// creation, so it never appears in the filesystem and the OS reclaims its
+    /// space when the last handle drops. Its directory follows `TMPDIR`; point
+    /// that at real disk if the default temp dir is a small tmpfs.
+    ///
+    /// Best-effort: if the temp file cannot be created or an I/O op fails, the
+    /// spill disables itself (logging once) and the reader falls back to
+    /// network re-fetch — correctness is unaffected, only the re-fetch cost
+    /// returns. Access is serialized by the enclosing `Mutex`; the pipeline's
+    /// passes read the input sequentially, so lock contention is negligible.
+    #[derive(Debug, Default)]
+    struct DiskSpill {
+        /// Lazily created on the first spilled chunk; `None` until then, or
+        /// left `None` after a spill error disables the cache.
+        file: Option<File>,
+        /// `chunk.start` → (offset within the spill file, byte length).
+        index: std::collections::HashMap<u64, (u64, usize)>,
+        /// Append cursor: total bytes written to the spill file so far.
+        write_offset: u64,
+        /// Set after a create/read/write error so we stop touching disk.
+        disabled: bool,
+    }
+
+    impl DiskSpill {
+        /// Serve a previously spilled chunk, if present. `None` means "not
+        /// spilled — fetch it over the network"; a read error disables the
+        /// spill and also returns `None` so the caller falls back to fetch.
+        fn get(&mut self, chunk_start: u64) -> Option<Bytes> {
+            if self.disabled {
+                return None;
+            }
+            let (offset, len) = *self.index.get(&chunk_start)?;
+            let file = self.file.as_mut()?;
+            let mut buf = vec![0u8; len];
+            match file
+                .seek(SeekFrom::Start(offset))
+                .and_then(|_| file.read_exact(&mut buf))
+            {
+                Ok(()) => Some(Bytes::from(buf)),
+                Err(e) => {
+                    log::warn!("input spill read failed ({e}); falling back to network re-fetch");
+                    self.disabled = true;
+                    None
+                }
+            }
+        }
+
+        /// Record a freshly fetched chunk on disk for later passes. No-op if
+        /// the spill is disabled or already holds this chunk; a create/write
+        /// error disables the spill.
+        fn put(&mut self, chunk_start: u64, data: &Bytes) {
+            if self.disabled || self.index.contains_key(&chunk_start) {
+                return;
+            }
+            if self.file.is_none() {
+                match tempfile::tempfile() {
+                    Ok(f) => self.file = Some(f),
+                    Err(e) => {
+                        log::warn!(
+                            "could not create input spill file ({e}); remote re-reads \
+                             will re-fetch over the network"
+                        );
+                        self.disabled = true;
+                        return;
+                    }
+                }
+            }
+            let offset = self.write_offset;
+            let file = self.file.as_mut().expect("spill file present");
+            if let Err(e) = file
+                .seek(SeekFrom::Start(offset))
+                .and_then(|_| file.write_all(data))
+            {
+                log::warn!("input spill write failed ({e}); falling back to network re-fetch");
+                self.disabled = true;
+                return;
+            }
+            self.write_offset += data.len() as u64;
+            self.index.insert(chunk_start, (offset, data.len()));
+        }
+    }
+
     /// Per-reader cache of whole column chunks, insertion-ordered for
     /// eviction. This is the "buffered range-fetch adapter": the page reader
     /// asks for a column chunk's bytes in many small pieces (a thrift page
@@ -682,6 +792,7 @@ pub(crate) mod remote {
         size: u64,
         shared: Arc<SharedState>,
         cache: Arc<Mutex<ChunkCache>>,
+        spill: Arc<Mutex<DiskSpill>>,
     }
 
     impl RemoteReader {
@@ -712,15 +823,38 @@ pub(crate) mod remote {
             (start >= chunk.start && end <= chunk.end).then(|| chunk.clone())
         }
 
-        /// Bytes of a whole column chunk, from cache or one range request.
+        /// Bytes of a whole column chunk, served from the cheapest tier that
+        /// holds it: the in-memory cache (L1), the local disk spill (L2, #219),
+        /// or a single network range request (L3). A byte therefore crosses the
+        /// network at most once across the pipeline's passes.
         fn chunk_data(&self, chunk: &Range<u64>) -> Result<Bytes, ParquetError> {
+            // L1: in-memory cache (hot, one row group's working set).
             {
                 let cache = self.cache.lock().expect("chunk cache lock");
                 if let Some((_, data)) = cache.entries.get(&chunk.start) {
                     return Ok(data.clone());
                 }
             }
+            // L2: local disk spill. A hit avoids re-fetching over the network on
+            // a later pass; re-warm L1 so same-pass touches stay in memory.
+            if let Some(data) = self.spill.lock().expect("spill lock").get(chunk.start) {
+                self.cache_insert(chunk, &data);
+                return Ok(data);
+            }
+            // L3: network. Fetch once, then spill the bytes for later passes.
             let data = self.fetch(chunk.clone())?;
+            self.spill
+                .lock()
+                .expect("spill lock")
+                .put(chunk.start, &data);
+            self.cache_insert(chunk, &data);
+            Ok(data)
+        }
+
+        /// Insert a chunk into the in-memory L1 cache, evicting in insertion
+        /// order until the working-set budget (`cap`, sized to the largest row
+        /// group in [`RemoteSource::open_builder`]) is respected.
+        fn cache_insert(&self, chunk: &Range<u64>, data: &Bytes) {
             let mut cache = self.cache.lock().expect("chunk cache lock");
             if !cache.entries.contains_key(&chunk.start) {
                 cache.total += data.len() as u64;
@@ -737,7 +871,6 @@ pub(crate) mod remote {
                     }
                 }
             }
-            Ok(data)
         }
 
         /// Exact-range read for [`parquet::file::reader::ChunkReader::get_bytes`].
@@ -1110,6 +1243,55 @@ mod tests {
                 object_size,
                 stats.bytes_fetched as f64 / object_size as f64,
             );
+        }
+
+        /// #219: across multiple passes over a remote input, each byte must
+        /// move over the network at most once. The streaming converter reads
+        /// the input several times (assign pass, coarse-level pass, finest
+        /// streamed last); the in-memory chunk cache holds only one row group's
+        /// working set, so without a local spill each pass re-fetches the bulk
+        /// of the file (measured 3.0× on fieldmaps-adm4). The disk spill drains
+        /// re-reads from local disk, bounding remote traffic to ≈1× the object
+        /// regardless of pass count. With a `cap_base` far below one row group
+        /// the in-memory cache cannot bridge passes, so only the spill keeps the
+        /// ratio down.
+        #[test]
+        fn multi_pass_reads_move_object_once() {
+            let bytes = multi_row_group_wide_parquet(4096, 3);
+            let object_size = bytes.len() as u64;
+            let source = super::super::test_memory_source_with_cap(bytes, "spill.parquet", 64);
+
+            // Three full in-order passes, mimicking the converter's assign +
+            // coarse-level + finest-streamed-last reads.
+            for _ in 0..3 {
+                let reader = source.open().unwrap().with_batch_size(64).build().unwrap();
+                let rows: usize = reader.map(|b| b.unwrap().num_rows()).sum();
+                assert_eq!(rows, 4096 * 3);
+            }
+
+            let stats = source.fetch_stats().unwrap();
+            assert_eq!(stats.object_size, object_size);
+            // Every column chunk is fetched over the network exactly once; the
+            // second and third passes drain from the local spill. Pre-spill,
+            // three passes moved ≈3× the object.
+            assert!(
+                stats.bytes_fetched <= object_size + object_size / 2,
+                "three passes moved {} bytes for a {}-byte object ({:.1}×) — the \
+                 disk spill must serve re-reads locally (#219)",
+                stats.bytes_fetched,
+                object_size,
+                stats.bytes_fetched as f64 / object_size as f64,
+            );
+
+            // No column-chunk range is fetched twice: re-touches hit the spill.
+            let fetched = source.fetched_ranges().unwrap();
+            let mut seen = std::collections::HashSet::new();
+            for r in &fetched {
+                assert!(
+                    seen.insert((r.start, r.end)),
+                    "range {r:?} fetched over the network more than once (#219)"
+                );
+            }
         }
 
         /// Like [`two_column_multipage_parquet`] but split into `groups` row

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -1482,6 +1482,61 @@ pub(super) fn warn_antimeridian_suspects(count: usize) {
     }
 }
 
+/// Object-size threshold above which a *full-file* remote convert emits the
+/// #267 download-first nudge. Below ~1 GiB the local spill footprint and the
+/// second-pass disk read are cheap enough not to warrant a warning.
+pub(super) const FULL_FILE_REMOTE_WARN_BYTES: u64 = 1 << 30;
+
+/// #267 decision + message (pure, so it is unit-testable without capturing
+/// logs). Returns the one-line nudge to emit, or `None` to stay quiet.
+///
+/// Fires only for a *whole-file* remote convert of a large object: the disk
+/// spill (#219) already bounds network traffic to ≈1× the object, but a
+/// full-file remote convert still stages ≈the object's bytes under `$TMPDIR`
+/// and re-reads them from disk on the second pass. For a region of interest,
+/// `--bbox` fetches only the covering row groups and skips the spill entirely,
+/// so we point the user there (or to a download-first workflow). Stays quiet
+/// for local inputs (OS page cache), for effective bbox extracts (fewer row
+/// groups read than the file holds), and for objects below the threshold.
+pub(super) fn full_file_remote_warning(
+    is_remote: bool,
+    row_groups_read: usize,
+    row_groups_total: usize,
+    object_size: u64,
+) -> Option<String> {
+    if !is_remote || row_groups_read < row_groups_total || object_size < FULL_FILE_REMOTE_WARN_BYTES
+    {
+        return None;
+    }
+    Some(format!(
+        "full-file remote convert of a {:.1} GiB object: it is fetched once over \
+         the network (≈1× — the local spill keeps later passes off the network, \
+         #219) and staged under $TMPDIR. For a region of interest pass --bbox to \
+         fetch only the covering row groups (and skip the spill); otherwise \
+         downloading first (e.g. `aws s3 cp`) and converting locally avoids the \
+         second-pass disk read. Point $TMPDIR at fast local disk, not a small tmpfs.",
+        object_size as f64 / (1024.0 * 1024.0 * 1024.0),
+    ))
+}
+
+/// Emit the #267 nudge for a full-file remote convert, if warranted. Thin
+/// logging wrapper over [`full_file_remote_warning`].
+pub(super) fn warn_full_file_remote(
+    source: &InputSource,
+    row_groups_read: usize,
+    row_groups_total: usize,
+) {
+    let object_size = source.fetch_stats().map_or(0, |s| s.object_size);
+    if let Some(msg) = full_file_remote_warning(
+        source.is_remote(),
+        row_groups_read,
+        row_groups_total,
+        object_size,
+    ) {
+        log::warn!("{msg}");
+    }
+}
+
 /// Whether a decoded geometry can participate in level assignment: it must
 /// carry at least one coordinate and every coordinate must be finite.
 ///
@@ -2383,6 +2438,32 @@ mod tests {
     use parquet::arrow::ArrowWriter;
 
     use crate::batch_processor::extract_geometries_from_array;
+
+    /// #267: the download-first nudge fires only for a large *whole-file*
+    /// remote convert, and stays quiet for local inputs, effective bbox
+    /// extracts, and small objects.
+    #[test]
+    fn full_file_remote_warning_gated_on_large_unpruned_remote() {
+        const BIG: u64 = 4 << 30; // 4 GiB, above the 1 GiB threshold
+                                  // Local input: re-reads hit the OS page cache — never warn.
+        assert!(full_file_remote_warning(false, 8, 8, BIG).is_none());
+        // Effective bbox extract (fewer row groups read): never warn.
+        assert!(full_file_remote_warning(true, 2, 8, BIG).is_none());
+        // Small remote object: below threshold — never warn.
+        assert!(full_file_remote_warning(true, 8, 8, 100 << 20).is_none());
+        // Just below the threshold: still quiet.
+        assert!(full_file_remote_warning(true, 8, 8, FULL_FILE_REMOTE_WARN_BYTES - 1).is_none());
+        // At the threshold: warns (guard is a strict `<`).
+        assert!(full_file_remote_warning(true, 8, 8, FULL_FILE_REMOTE_WARN_BYTES).is_some());
+        // Large full-file remote: warns, and the nudge names the cheaper paths.
+        let msg = full_file_remote_warning(true, 8, 8, BIG)
+            .expect("large full-file remote convert should warn");
+        assert!(msg.contains("--bbox"), "nudge should mention --bbox: {msg}");
+        assert!(
+            msg.contains("4.0 GiB"),
+            "nudge should state the object size: {msg}"
+        );
+    }
 
     // --- synthetic GeoParquet input builders --------------------------------
 

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -177,6 +177,9 @@ pub(crate) fn convert_streaming_strategy(
     if selected_row_groups.is_some() {
         log::info!("bbox filter: reading {row_groups_read}/{row_groups_total} input row groups");
     }
+    // #267: nudge toward --bbox / download-first for a large whole-file remote
+    // convert (quiet for local inputs and effective bbox extracts).
+    super::convert::warn_full_file_remote(source, row_groups_read, row_groups_total);
     drop(builder);
 
     if input_schema

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -22,7 +22,8 @@ multi-GB inputs, measured on current `main`.
 - **Convert:** `gpq-tiles overview <in> <out> --min-zoom 0 --max-zoom 14`,
   default knobs, wall/RSS/CPU from `/usr/bin/time -v`.
 - Timing is measured reading **local** files. Reading over the network
-  adds re-fetch cost that inflates wall time — see
+  moves ≈1× the object's bytes (the disk spill keeps re-reads local) but
+  still adds fetch latency and a second-pass disk read — see
   [Remote selective read](#remote-selective-read) below.
 
 ## Convert throughput by geometry type
@@ -90,20 +91,36 @@ gpq-tiles overview \
 fetches **52 MB — 0.74 % of the file — in 0.83 s**. No other tiler does
 selective remote extraction like this.
 
-The caveat is the mirror image: a **full-file** remote convert re-fetches
-the input, because the streaming engine re-reads it per level and large
-selections overflow the 256 MiB chunk cache. Measured bytes moved ÷ file
-size, full file vs bbox:
+A **full-file** remote convert re-reads the input several times (the
+assign pass, the coarse-level write pass, and a finest-level canonical
+re-read). Historically each pass re-fetched the input over the network,
+so bytes moved ÷ file size climbed well above 1×. Two fixes closed that
+gap:
 
-| call | bytes moved | ÷ file |
-|---|---:|---:|
-| points-nyc (full) | 30.8 MB | 1.00× |
-| germany-segments (full) | 6.82 GB | 2.67× |
-| germany-buildings (full) | 18.1 GB | 2.59× |
-| fieldmaps-adm4 (full) | 278 GB | 96× |
-| germany-buildings `--bbox` | 52 MB | **0.0074×** |
+| stage | fieldmaps-adm4 (2.90 GB, z0–14) | cause / fix |
+|---|---:|---|
+| before #261 | **96×** | oversized geometry chunk evicted-on-insert, re-fetched per page |
+| after [#261](https://github.com/geoparquet-io/gpq-tiles/issues/261) | **3.0×** | chunk cache sized to the largest row group — no re-fetch *within* a pass, but each pass still re-fetched |
+| after [#219](https://github.com/geoparquet-io/gpq-tiles/issues/219) | **≈1×** | fetched chunks spilled to local disk; later passes drain from disk, so each byte crosses the network once |
 
-So `--bbox` extraction is the remote superpower; for a *whole-file*
-remote conversion, download first (`aws s3 cp` + local convert) or expect
-the re-fetch. Reducing that full-file cost is tracked in
-[#261](https://github.com/geoparquet-io/gpq-tiles/issues/261).
+The ≈1× bound is verified deterministically by an input-level regression
+test (`multi_pass_reads_move_object_once`); a full-corpus wall-clock
+re-measurement (segments/buildings over `http://`) is the pending
+follow-up. `--bbox` extraction remains the remote superpower — pruned row
+groups are never fetched at all (germany-buildings `--bbox`: 52 MB,
+**0.0074×** of the file), and the disk spill only ever holds the chunks
+that would have been fetched once anyway.
+
+The residual full-file cost is now local, not network: the passes still
+re-*read* the spilled bytes from disk (seek latency) and re-*decode*
+them. For latency-sensitive whole-file conversions, downloading first
+(`aws s3 cp` + local convert) still avoids the second-pass disk read; the
+disk spill lives under `TMPDIR`, so point that at fast local disk (not a
+small tmpfs) when converting large remote files.
+
+The converter makes this actionable at runtime: a whole-file remote
+convert of an object ≥ 1 GiB logs a one-line warning
+([#267](https://github.com/geoparquet-io/gpq-tiles/issues/267)) steering
+you to `--bbox` or a download-first workflow and reminding you to place
+`$TMPDIR` on fast disk. `--bbox` extracts stay quiet — they already fetch
+only a fraction of the object.

--- a/docs/remote-reads.md
+++ b/docs/remote-reads.md
@@ -61,14 +61,16 @@ What to know:
   on a city extract). The cache budget is sized to the largest row
   group's working set (floored at 256 MiB), so a single row group whose
   column chunks exceed the floor — e.g. a multi-GB geometry chunk — is
-  no longer evicted mid-read and re-fetched per page (issue #261). What
-  remains is the multi-pass baseline: a full-file conversion reads the
-  input a few times — the assign pass, the write pass, and (at higher
-  zoom) a finest-level canonical re-read — so a full-file remote
-  conversion moves a small constant multiple of the object's bytes.
-  Measured on fieldmaps-adm4 (2.90 GB, z0–14): **96× before #261, 3.0×
-  after**. Eliminating the finest-level re-read to approach ~1× is
-  tracked in #219; if the residual matters today, download first.
+  no longer evicted mid-read and re-fetched per page (issue #261).
+  Beyond the in-memory cache, every fetched chunk is also spilled to a
+  local temp file, so a chunk evicted between passes — the assign pass,
+  the write pass, and (at higher zoom) a finest-level canonical re-read —
+  is drained from local disk rather than re-fetched over the network.
+  This bounds a full-file remote conversion to ≈1× the object's bytes
+  regardless of pass or level count (issue #219). Measured on
+  fieldmaps-adm4 (2.90 GB, z0–14): **96× before #261, 3.0× after #261,
+  ≈1× after #219**. The spill file lives under `TMPDIR`; point that at
+  real disk if your default temp dir is a small tmpfs.
 - **Latency vs bytes** — requests are issued sequentially, so on a
   fast link a plain `aws s3 cp` + local convert can still win on wall
   time (92 MB corpus file, residential fiber: ~3 s download+convert


### PR DESCRIPTION
Closes #219. Closes #267.

Two related remote-read improvements, bundled.

## #219 — spill remote input to disk (bound re-reads to ≈1×)

### Problem
The streaming converter reads a remote input several times — the assign pass, the coarse-level write pass, and (at higher zoom) a finest-level canonical re-read. The in-memory chunk cache holds only **one row group's** working set (sized in #261), so it cannot bridge passes: each pass re-fetched the bulk of the object over the network. Measured **3.0×** on fieldmaps-adm4 (2.90 GB, z0–14) after #261 — exactly this issue's residual.

### Fix
Add a local **on-disk spill (L2)** between the in-memory cache (L1) and the network (L3) in `RemoteReader::chunk_data`:

```
L1  in-memory cache (hot, one row group)        -> hit: return
L2  local disk spill (anonymous tempfile, #219)  -> hit: re-warm L1, return
L3  one network range request                    -> fetch once, spill, return
```

Every chunk fetched over the network is written to an anonymous temp file; a later touch (next pass/level) drains from local disk. **Bounds remote traffic to ≈1× the object** regardless of pass or level count.

- **Best-effort**: on any create/read/write error it disables itself (logs once) and falls back to network re-fetch — correctness is never affected.
- **Self-cleaning**: `tempfile::tempfile()` is unlinked on creation, reclaimed when the last `RemoteSource` drops; dir follows `$TMPDIR`.
- **Composes** with #261 (L1 still hot) and `--bbox` pruning (only touched chunks spill).

### Test (TDD)
`multi_pass_reads_move_object_once`: three passes with the L1 cap forced below one row group. **Red = 3.0×** (matched the measured residual); **green = ≈1×**, and no chunk range is fetched over the network twice.

## #267 — runtime nudge for large full-file remote convert

Post-#219 the network is ≈1×, but a whole-file remote convert still stages ≈the object's bytes under `$TMPDIR` and re-reads them from disk on the second pass. When a full-file (unpruned) remote convert runs on an object **≥ 1 GiB**, emit a one-line warning steering the user to `--bbox` or a download-first workflow, and to point `$TMPDIR` at fast disk.

- Decision is a pure, unit-tested predicate (`full_file_remote_warning`); the streaming pass logs it once after row-group selection.
- Stays quiet for local inputs, effective `--bbox` extracts, and small objects.
- Test: `full_file_remote_warning_gated_on_large_unpruned_remote`.

## Docs
`docs/performance.md` and `docs/remote-reads.md` updated: the 96× -> 3.0× -> ≈1× progression, the `$TMPDIR` guidance, and the new runtime nudge.

## Follow-up (not in this PR)
Full-corpus **wall-clock** re-measurement (segments/buildings over `http://`) to confirm the byte-count win translates to wall time — the ≈1× byte bound is proven deterministically here, but real-scale timing isn't.

All existing remote tests (#210 bbox, #261, #262/#266 HTTP) pass unchanged; clippy clean; pre-commit gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)