### PR TITLE
feat(ci): attach prebuilt CLI binaries and real release notes to GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,9 @@
 # Developer workflow:
 # 1. Accumulate changes via normal PR merges
 # 2. When ready to release: uv run cz bump --changelog && git push --tags
-# 3. Tag push triggers this workflow → publishes to crates.io, PyPI, GitHub
+# 3. Tag push triggers this workflow → publishes to crates.io, PyPI, and a
+#    GitHub Release with prebuilt CLI binaries (linux gnu/musl, macOS
+#    x86_64/aarch64, windows) and release notes extracted from CHANGELOG.md
 name: Release
 
 on:
@@ -24,6 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+      release_exists: ${{ steps.release_check.outputs.release_exists }}
     steps:
       # Credentials stay persisted here on purpose: this job pushes the
       # release tag back to the repo in the manual-dispatch recovery path.
@@ -95,16 +101,179 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-      - name: Create GitHub Release
-        if: steps.release_check.outputs.release_exists == 'false'
+  # Prebuilt CLI binaries for users without a Rust toolchain (cargo install
+  # needs Rust 1.75+ AND protoc — real friction for the GIS audience).
+  # Hand-rolled matrix rather than cargo-dist: cargo-dist wants to own the
+  # tag → release lifecycle, which conflicts with the recovery-mode logic in
+  # release-rust and the crates.io/PyPI publishing already living here.
+  build-binaries:
+    name: Build binary (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            # Cross-compiled from the arm64 runner: Intel macOS runners are
+            # retired, and clang + the universal macOS SDK cross-compile
+            # x86_64 from arm64 natively.
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+
+      - name: Install protoc (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Install protoc (macOS)
+        if: runner.os == 'macOS'
+        run: brew install protobuf
+
+      - name: Install protoc (Windows)
+        if: runner.os == 'Windows'
+        run: choco install protoc
+
+      - name: Install musl toolchain
+        # zstd-sys, aws-lc-sys, etc. need a musl-targeting C compiler
+        # (musl-gcc). The tree is rustls-based — no openssl to vendor.
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: sudo apt-get install -y musl-tools
+
+      - name: Extract version from Cargo.toml
+        id: version
+        shell: bash
+        run: |
+          VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Detected version: $VERSION"
+
+      - name: Build release binary
+        shell: bash
         env:
-          TAG: ${{ steps.version.outputs.tag }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET: ${{ matrix.target }}
+        run: cargo build --release --package gpq-tiles --target "$TARGET"
+
+      - name: Smoke test binary
+        # x86_64-apple-darwin is cross-compiled on the arm64 runner; running
+        # it would depend on Rosetta being present, so it is not smoke-tested.
+        if: matrix.target != 'x86_64-apple-darwin'
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          "./target/$TARGET/release/gpq-tiles" --version
+
+      - name: Package archive (Unix)
+        if: runner.os != 'Windows'
+        env:
+          TARGET: ${{ matrix.target }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          STAGE="gpq-tiles-$VERSION-$TARGET"
+          mkdir -p "dist/$STAGE"
+          cp "target/$TARGET/release/gpq-tiles" README.md LICENSE "dist/$STAGE/"
+          tar -C dist -czf "dist/$STAGE.tar.gz" "$STAGE"
+          rm -r "dist/${STAGE:?}"
+
+      - name: Package archive (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          TARGET: ${{ matrix.target }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          $stage = "gpq-tiles-$env:VERSION-$env:TARGET"
+          New-Item -ItemType Directory -Path "dist/$stage" | Out-Null
+          Copy-Item "target/$env:TARGET/release/gpq-tiles.exe" "dist/$stage/"
+          Copy-Item README.md, LICENSE "dist/$stage/"
+          Compress-Archive -Path "dist/$stage" -DestinationPath "dist/$stage.zip"
+          Remove-Item -Recurse "dist/$stage"
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: bin-${{ matrix.target }}
+          path: dist
+          if-no-files-found: error
+
+  # Creates the GitHub Release with binaries attached and the tagged
+  # version's CHANGELOG.md section as the release body. Runs only after
+  # crates.io publishing succeeds (same ordering as before, when release
+  # creation was the last step of release-rust) and only when the release
+  # does not already exist (recovery-mode re-runs skip it, as before).
+  github-release:
+    name: Create GitHub Release
+    needs: [release-rust, build-binaries]
+    if: needs.release-rust.outputs.release_exists == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Download binary artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: bin-*
+          path: dist
+          merge-multiple: true
+
+      - name: Generate checksums
+        env:
+          VERSION: ${{ needs.release-rust.outputs.version }}
+        run: |
+          cd dist
+          sha256sum -- *.tar.gz *.zip > "gpq-tiles-$VERSION-checksums.txt"
+          cat "gpq-tiles-$VERSION-checksums.txt"
+
+      - name: Extract release notes from CHANGELOG.md
+        env:
+          TAG: ${{ needs.release-rust.outputs.tag }}
           REPO: ${{ github.repository }}
         run: |
+          # Section headings look like "## v0.6.0 (2026-03-11)"; also accept
+          # a bare "## v0.7.0". $2 is the version token either way.
+          awk -v ver="$TAG" '
+            /^## / { if (found) exit; if ($2 == ver) { found=1; next } }
+            found { print }
+          ' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "::warning::No CHANGELOG.md section found for $TAG, falling back to link"
+            echo "See [CHANGELOG](https://github.com/$REPO/blob/main/CHANGELOG.md) for details." > release-notes.md
+          fi
+          echo "Release notes:"
+          cat release-notes.md
+
+      - name: Create GitHub Release
+        env:
+          TAG: ${{ needs.release-rust.outputs.tag }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
           gh release create "$TAG" \
+            --verify-tag \
             --title "$TAG" \
-            --notes "See [CHANGELOG](https://github.com/$REPO/blob/main/CHANGELOG.md) for details."
+            --notes-file release-notes.md \
+            dist/*
 
   build-wheels:
     name: Build wheels (${{ matrix.os }})


### PR DESCRIPTION
## What

Two additions to the tag-triggered release workflow:

1. **Prebuilt CLI binaries on GitHub Releases.** Users no longer need Rust 1.75+ and protoc to get the CLI — five archives (plus a checksums file) are attached to every release:

   | Target | Runner | Archive |
   |---|---|---|
   | `x86_64-unknown-linux-gnu` | ubuntu-latest | `.tar.gz` |
   | `x86_64-unknown-linux-musl` (fully static) | ubuntu-latest + musl-tools | `.tar.gz` |
   | `x86_64-apple-darwin` | macos-latest (cross-compiled from arm64) | `.tar.gz` |
   | `aarch64-apple-darwin` | macos-latest | `.tar.gz` |
   | `x86_64-pc-windows-msvc` | windows-latest | `.zip` |

   Naming: `gpq-tiles-<version>-<target>.<ext>` (binary + README + LICENSE inside), plus `gpq-tiles-<version>-checksums.txt` (sha256, generated in the release job after artifact download — Actions artifacts are byte-preserving).

2. **Real per-version release notes.** A small awk step extracts the tagged version's section from CHANGELOG.md (`## v0.6.0 (2026-03-11)` and bare `## v0.7.0` heading styles both handled; falls back to the old CHANGELOG link with a workflow warning if the section is missing) and feeds it to `gh release create --notes-file`.

## How it fits the existing workflow

- The crates.io and PyPI jobs are untouched except for one additive change: `release-rust` now exposes `version` / `tag` / `release_exists` as job outputs.
- The `gh release create` step moved from the tail of `release-rust` into a new `github-release` job with `needs: [release-rust, build-binaries]` — same ordering guarantee as before (release only after crates.io publish succeeds), same recovery-mode semantics (`release_exists == 'true'` re-runs skip release creation), but now the release is only created once **all five binaries built**, so a release never appears without its artifacts.
- `build-binaries` runs in parallel with `release-rust` (no `needs`), so wall-clock release time barely changes.
- Conventions kept: all actions SHA-pinned (reusing the exact pins already in the file), `dtolnay/rust-toolchain`, per-OS protoc install steps copied from the `build-wheels` job, `persist-credentials: false` on all new checkouts, all `${{ }}` passed through `env` in run steps.

## Why hand-rolled matrix, not cargo-dist

cargo-dist wants to own the tag → release lifecycle: it generates its own workflow, computes its own version/tag plan, and creates the GitHub Release itself. That collides head-on with this workflow's existing recovery-mode logic (`release_check`), the commitizen-driven tag creation, and the crates.io/PyPI publishing that must stay in place. Bolting cargo-dist alongside would mean two systems fighting over release creation; extracting just its build step buys little for a five-target matrix. The hand-rolled jobs are ~100 lines in the exact style the workflow already uses, and zizmor/actionlint gate them like everything else.

## Verified locally

- `cargo build --release --package gpq-tiles` on linux x86_64-gnu: builds, `--version` runs.
- **musl:** full build in a Docker container mirroring the CI job (rust:1-bookworm + `musl-tools protobuf-compiler cmake`, all preinstalled or apt-installed exactly as the job does): links successfully, `file` reports **static-pie linked** (fully static), binary runs. No openssl anywhere in the tree — TLS is rustls/aws-lc-rs, and aws-lc-sys + zstd-sys compile fine with musl-gcc. No Cargo.toml changes needed.
- Packaging simulated end-to-end with the real binary: tar layout, checksums file, re-extraction, `--version` from the extracted archive.
- CHANGELOG extraction tested against the real CHANGELOG.md for v0.6.0 / v0.5.0 / v0.1.0 (last-section-at-EOF case) plus a synthetic future `## v0.7.0` bare heading and a missing-version fallback.
- `actionlint` v1.7.7: clean. `zizmor` 1.26.1 (same version and flags as the CI Lint job): no findings.

## Deferred to the first real tag run

- macOS (both targets) and Windows builds — no local runners for those; the steps are copies of the proven `build-wheels` per-OS setup plus a `cargo build --target`.
- The x86_64-apple-darwin cross-compile from the arm64 runner (Intel macOS runners are retired). It is deliberately excluded from the smoke-test step since running it would depend on Rosetta.
- Actual `gh release create` with assets (can't be dry-run outside a tag).

## Notes / caveats

- Pre-existing recovery-mode limitation (unchanged by this PR): if a run fails *after* crates.io publish but *before* release creation, a re-run hits `cargo publish` for an already-published version and fails. Previously that window was "release-creation step fails"; it now also covers "a binary build fails". If that ever bites, the fix is a manual `gh release create` or a skip-if-published guard on the publish steps — kept out of scope here to avoid touching the crates.io job.
- musl binary is static-pie; checksums are computed once, in the release job, over the downloaded archives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)