### PR TITLE
feat(core): configurable input-spill directory + free-space guard

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -623,6 +623,19 @@ struct ConvertTuningArgs {
         help_heading = "Memory & performance"
     )]
     in_flight_batches: usize,
+
+    /// Directory for the remote-input spill file (issues #219/#272).
+    ///
+    /// A remote convert stages every fetched column chunk in an anonymous
+    /// temp file — growing to ≈1× the touched input bytes (the whole object
+    /// for a full-file convert; only the covering row groups with --bbox) —
+    /// so later passes re-read from local disk instead of the network. By
+    /// default it lives under the process temp dir ($TMPDIR); point this at
+    /// a volume with enough room (a free-space preflight warns about a
+    /// projected shortfall). The directory must exist. Local inputs never
+    /// spill.
+    #[arg(long, value_name = "PATH", help_heading = "Memory & performance")]
+    spill_dir: Option<PathBuf>,
 }
 
 impl ConvertTuningArgs {
@@ -746,6 +759,7 @@ impl ConvertTuningArgs {
             coalesce_max_level_rows: self.coalesce_max_level_rows,
             coalesce_junction_angle: self.coalesce_junction_angle,
             bbox,
+            spill_dir: self.spill_dir.clone(),
         })
     }
 }

--- a/crates/cli/tests/tiles_facade.rs
+++ b/crates/cli/tests/tiles_facade.rs
@@ -88,3 +88,36 @@ fn bare_invocation_rewrites_to_tiles() {
     let bytes = std::fs::read(&output).expect("read output pmtiles");
     assert_eq!(&bytes[..PMTILES_MAGIC.len()], PMTILES_MAGIC);
 }
+
+/// #272: `--spill-dir` parses on both convert subcommands and reaches
+/// `ConvertOptions` — a nonexistent directory is rejected by core option
+/// validation (which runs before any input I/O, so no fixture is needed).
+#[test]
+fn spill_dir_flag_reaches_convert_options() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let input = dir.path().join("in.parquet");
+    std::fs::write(&input, b"not really parquet").unwrap();
+
+    for subcommand in ["overview", "tiles"] {
+        let out = dir.path().join(format!("{subcommand}-out"));
+        let output = Command::new(gpq_tiles_bin())
+            .args([
+                subcommand,
+                input.to_str().unwrap(),
+                out.to_str().unwrap(),
+                "--spill-dir",
+                "/nonexistent/gpq-tiles-spill-dir-272",
+            ])
+            .output()
+            .expect("run gpq-tiles");
+        assert!(
+            !output.status.success(),
+            "{subcommand}: nonexistent --spill-dir must be rejected"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("spill-dir") && stderr.contains("/nonexistent/gpq-tiles-spill-dir-272"),
+            "{subcommand}: error should name the option and path, got: {stderr}"
+        );
+    }
+}

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -25,6 +25,7 @@ remote = [
     "dep:aws-credential-types",
     "dep:async-trait",
     "dep:url",
+    "dep:fs4",
 ]
 
 [dependencies]
@@ -61,6 +62,7 @@ aws-credential-types = { version = "1", optional = true }
 async-trait = { version = "0.1", optional = true }
 url = { version = "2", optional = true }
 bytes = "1"
+fs4 = { version = "0.13", optional = true }
 
 [build-dependencies]
 prost-build = { workspace = true }

--- a/crates/core/src/input.rs
+++ b/crates/core/src/input.rs
@@ -217,6 +217,42 @@ impl InputSource {
             InputSource::Remote(r) => Some(r.fetched_ranges()),
         }
     }
+
+    /// Place the remote-input disk spill (#219) in `dir` instead of the
+    /// process temp dir (`$TMPDIR`) — issue #272. No-op for local inputs,
+    /// which never spill. Call before reading: chunks already spilled stay
+    /// in the previously created file; only the spill-file creation (lazy,
+    /// on the first spilled chunk) honors the directory.
+    #[cfg_attr(not(feature = "remote"), allow(unused_variables))]
+    pub fn set_spill_dir(&self, dir: Option<&Path>) {
+        #[cfg(feature = "remote")]
+        if let InputSource::Remote(r) = self {
+            r.set_spill_dir(dir);
+        }
+    }
+}
+
+/// Sum of the compressed byte sizes of the selected input row groups — the
+/// bytes a remote convert will touch, and therefore the projected size of
+/// the disk spill (#219): every touched chunk is staged locally exactly
+/// once, so the spill grows to ≈ this number (issue #272 free-space
+/// preflight). `None` selects every row group (a full-file read); indices
+/// out of range are ignored. Single-file shape on purpose (metadata +
+/// selection → bytes): a multi-partition source sums it across parts.
+pub fn selected_compressed_bytes(
+    metadata: &parquet::file::metadata::ParquetMetaData,
+    selected_row_groups: Option<&[usize]>,
+) -> u64 {
+    let group_bytes = |i: usize| -> u64 {
+        metadata
+            .row_groups()
+            .get(i)
+            .map_or(0, |rg| rg.compressed_size().max(0) as u64)
+    };
+    match selected_row_groups {
+        None => (0..metadata.num_row_groups()).map(group_bytes).sum(),
+        Some(selected) => selected.iter().map(|&i| group_bytes(i)).sum(),
+    }
 }
 
 /// Return the URL scheme of `input` if it is shaped like `scheme://rest`.
@@ -285,6 +321,7 @@ pub(crate) mod remote {
     use std::fs::File;
     use std::io::{Read, Seek, SeekFrom, Write};
     use std::ops::Range;
+    use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::{Arc, Mutex, OnceLock};
 
@@ -537,6 +574,14 @@ pub(crate) mod remote {
             }
         }
 
+        /// Place the disk spill's (anonymous) file in `dir` — issue #272,
+        /// see [`InputSource::set_spill_dir`]. Shared by every reader clone.
+        ///
+        /// [`InputSource::set_spill_dir`]: super::InputSource::set_spill_dir
+        pub(crate) fn set_spill_dir(&self, dir: Option<&Path>) {
+            self.spill.lock().expect("spill lock").dir = dir.map(Path::to_path_buf);
+        }
+
         /// Snapshot of the fetch counters.
         pub fn fetch_stats(&self) -> FetchStats {
             FetchStats {
@@ -687,6 +732,10 @@ pub(crate) mod remote {
         write_offset: u64,
         /// Set after a create/read/write error so we stop touching disk.
         disabled: bool,
+        /// Directory for the (anonymous) spill file — `--spill-dir`, issue
+        /// #272. `None` follows the process temp dir (`$TMPDIR`). Honored
+        /// at file creation, i.e. on the first spilled chunk.
+        dir: Option<PathBuf>,
     }
 
     impl DiskSpill {
@@ -721,12 +770,22 @@ pub(crate) mod remote {
                 return;
             }
             if self.file.is_none() {
-                match tempfile::tempfile() {
+                let created = match self.dir.as_deref() {
+                    Some(d) => tempfile::tempfile_in(d),
+                    None => tempfile::tempfile(),
+                };
+                match created {
                     Ok(f) => self.file = Some(f),
                     Err(e) => {
+                        let dir = self
+                            .dir
+                            .clone()
+                            .unwrap_or_else(std::env::temp_dir)
+                            .display()
+                            .to_string();
                         log::warn!(
-                            "could not create input spill file ({e}); remote re-reads \
-                             will re-fetch over the network"
+                            "could not create input spill file in {dir} ({e}); remote \
+                             re-reads will re-fetch over the network"
                         );
                         self.disabled = true;
                         return;
@@ -962,6 +1021,48 @@ pub(crate) mod remote {
             out[..n].copy_from_slice(&self.buf[self.buf_offset..self.buf_offset + n]);
             self.buf_offset += n;
             Ok(n)
+        }
+    }
+
+    #[cfg(test)]
+    mod spill_dir_tests {
+        use super::*;
+
+        /// #272: a configured spill directory is where the spill file is
+        /// created. The file is anonymous (unlinked on creation), so the
+        /// dir is observed through behavior: with a valid dir the put/get
+        /// roundtrip works end to end.
+        #[test]
+        fn disk_spill_writes_into_configured_dir() {
+            let dir = tempfile::tempdir().unwrap();
+            let mut spill = DiskSpill {
+                dir: Some(dir.path().to_path_buf()),
+                ..DiskSpill::default()
+            };
+            spill.put(0, &Bytes::from_static(b"hello spill"));
+            assert_eq!(
+                spill.get(0).as_deref(),
+                Some(&b"hello spill"[..]),
+                "spill roundtrip through the configured dir"
+            );
+        }
+
+        /// #272 counterpart: a nonexistent configured dir makes file
+        /// creation fail, which disables the spill (best-effort, #219) —
+        /// proof the configured dir, not $TMPDIR, is what `put` uses.
+        #[test]
+        fn disk_spill_nonexistent_dir_disables_spill() {
+            let mut spill = DiskSpill {
+                dir: Some(std::path::PathBuf::from(
+                    "/nonexistent/gpq-tiles-spill-dir-272",
+                )),
+                ..DiskSpill::default()
+            };
+            spill.put(0, &Bytes::from_static(b"hello spill"));
+            assert!(
+                spill.get(0).is_none(),
+                "create failure must disable the spill"
+            );
         }
     }
 }
@@ -1292,6 +1393,95 @@ mod tests {
                     "range {r:?} fetched over the network more than once (#219)"
                 );
             }
+        }
+
+        /// #272: `set_spill_dir` threads through [`InputSource`] →
+        /// `RemoteSource` → `DiskSpill`. Observed through behavior: a
+        /// deliberately broken spill dir disables the spill (best-effort,
+        /// #219), so multi-pass reads degrade to per-pass network re-fetch —
+        /// proof the configured dir, not `$TMPDIR`, is what the spill uses
+        /// (with the default dir the same reads stay ≈1×, see
+        /// [`multi_pass_reads_move_object_once`]).
+        #[test]
+        fn spill_dir_reaches_disk_spill_via_source() {
+            let bytes = multi_row_group_wide_parquet(4096, 3);
+            let object_size = bytes.len() as u64;
+            let source = super::super::test_memory_source_with_cap(bytes, "spill-dir.parquet", 64);
+            source.set_spill_dir(Some(Path::new("/nonexistent/gpq-tiles-spill-dir-272")));
+
+            for _ in 0..3 {
+                let reader = source.open().unwrap().with_batch_size(64).build().unwrap();
+                let rows: usize = reader.map(|b| b.unwrap().num_rows()).sum();
+                assert_eq!(rows, 4096 * 3);
+            }
+
+            let stats = source.fetch_stats().unwrap();
+            assert!(
+                stats.bytes_fetched >= 2 * object_size,
+                "spill disabled by the broken dir: three passes must re-fetch \
+                 (moved {} bytes for a {}-byte object) — is the configured dir \
+                 actually reaching DiskSpill?",
+                stats.bytes_fetched,
+                object_size,
+            );
+        }
+
+        /// #272 positive counterpart: with a valid caller-chosen spill dir,
+        /// multi-pass reads keep the #219 ≈1× network bound.
+        #[test]
+        fn valid_spill_dir_keeps_one_pass_bound() {
+            let bytes = multi_row_group_wide_parquet(4096, 3);
+            let object_size = bytes.len() as u64;
+            let source =
+                super::super::test_memory_source_with_cap(bytes, "spill-dir-ok.parquet", 64);
+            let dir = tempfile::tempdir().unwrap();
+            source.set_spill_dir(Some(dir.path()));
+
+            for _ in 0..3 {
+                let reader = source.open().unwrap().with_batch_size(64).build().unwrap();
+                let rows: usize = reader.map(|b| b.unwrap().num_rows()).sum();
+                assert_eq!(rows, 4096 * 3);
+            }
+
+            let stats = source.fetch_stats().unwrap();
+            assert!(
+                stats.bytes_fetched <= object_size + object_size / 2,
+                "three passes moved {} bytes for a {}-byte object ({:.1}×) — the \
+                 spill in the configured dir must serve re-reads locally",
+                stats.bytes_fetched,
+                object_size,
+                stats.bytes_fetched as f64 / object_size as f64,
+            );
+        }
+
+        /// #272: the projected spill size is the Σ compressed bytes of the
+        /// selected row groups, straight from the parquet footer. Signature
+        /// is file-count-agnostic (metadata + selection → u64) so a
+        /// multi-partition source can sum it across parts.
+        #[test]
+        fn selected_compressed_bytes_sums_selection() {
+            let bytes = multi_row_group_wide_parquet(1024, 3);
+            let source = memory_source(bytes, "selected-bytes.parquet");
+            let builder = source.open().unwrap();
+            let md = builder.metadata();
+            let per_group: Vec<u64> = md
+                .row_groups()
+                .iter()
+                .map(|rg| rg.compressed_size() as u64)
+                .collect();
+            assert_eq!(per_group.len(), 3);
+            assert!(per_group.iter().all(|b| *b > 0));
+            assert_eq!(
+                selected_compressed_bytes(md, None),
+                per_group.iter().sum::<u64>(),
+                "no selection = whole file"
+            );
+            assert_eq!(
+                selected_compressed_bytes(md, Some(&[0, 2])),
+                per_group[0] + per_group[2],
+                "selection sums only the selected row groups"
+            );
+            assert_eq!(selected_compressed_bytes(md, Some(&[])), 0);
         }
 
         /// Like [`two_column_multipage_parquet`] but split into `groups` row

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -31,7 +31,7 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -387,6 +387,14 @@ pub struct ConvertOptions {
     /// identical either way. Default `None` (full-extent conversion,
     /// byte-identical output to a build without this option).
     pub bbox: Option<[f64; 4]>,
+    /// Directory for the remote-input disk spill (#219 / #272). A remote
+    /// convert stages every fetched column chunk in an anonymous temp file
+    /// (growing to ≈1× the touched input bytes) so later passes re-read
+    /// from local disk instead of the network. `None` (default) places it
+    /// under the process temp dir (`$TMPDIR`); set this to use a roomier
+    /// or faster volume instead. The directory must exist (validated up
+    /// front). Local inputs never spill, so this has no effect on them.
+    pub spill_dir: Option<PathBuf>,
 }
 
 /// Default rows per read batch for the streaming pipeline (H3).
@@ -427,6 +435,7 @@ impl Default for ConvertOptions {
             coalesce_max_level_rows: DEFAULT_COALESCE_MAX_LEVEL_ROWS,
             coalesce_junction_angle: DEFAULT_JUNCTION_ANGLE_DEG,
             bbox: None,
+            spill_dir: None,
         }
     }
 }
@@ -766,6 +775,17 @@ fn validate_options(options: &ConvertOptions) -> Result<(), ConvertError> {
             "in-flight-batches must be >= 1".to_string(),
         ));
     }
+    // #272: fail fast on a bad spill dir — the spill is best-effort, so a
+    // mid-convert creation failure would only surface as a silent degrade
+    // to network re-fetch.
+    if let Some(dir) = &options.spill_dir {
+        if !dir.is_dir() {
+            return Err(ConvertError::InvalidConfig(format!(
+                "spill-dir {} is not an existing directory",
+                dir.display()
+            )));
+        }
+    }
     Ok(())
 }
 
@@ -880,6 +900,9 @@ pub(crate) fn convert_to_overviews_source_strategy(
 ) -> Result<ConvertReport, ConvertError> {
     // Knob sanity (H4), shared by both pipelines.
     validate_options(options)?;
+    // #272: place the remote-input disk spill (#219) where the caller asked
+    // (no-op for local inputs, which never spill).
+    source.set_spill_dir(options.spill_dir.as_deref());
     // Clustering option sanity (Q4), shared by both pipelines: partitioning
     // mode cannot represent per-level counts (see the error's rationale), and
     // aggregation is meaningless without clustering.
@@ -1514,7 +1537,8 @@ pub(super) fn full_file_remote_warning(
          #219) and staged under $TMPDIR. For a region of interest pass --bbox to \
          fetch only the covering row groups (and skip the spill); otherwise \
          downloading first (e.g. `aws s3 cp`) and converting locally avoids the \
-         second-pass disk read. Point $TMPDIR at fast local disk, not a small tmpfs.",
+         second-pass disk read. Point --spill-dir (or $TMPDIR) at fast local disk \
+         with room for it, not a small tmpfs.",
         object_size as f64 / (1024.0 * 1024.0 * 1024.0),
     ))
 }
@@ -1532,6 +1556,95 @@ pub(super) fn warn_full_file_remote(
         row_groups_read,
         row_groups_total,
         object_size,
+    ) {
+        log::warn!("{msg}");
+    }
+}
+
+/// #272 spill-preflight safety margin: warn when the spill volume's free
+/// space is below the projected spill size plus 1/20th (5%) of it — spill
+/// bookkeeping is exact but the volume is shared with everything else the
+/// process (and host) writes during the convert.
+const SPILL_MARGIN_DENOM: u64 = 20;
+
+/// #272 decision + message (pure, so it is unit-testable without touching
+/// a filesystem). Returns the warning to emit when the projected input
+/// spill (≈ the selected input bytes, see
+/// [`crate::input::selected_compressed_bytes`]) plus a 5% safety margin
+/// exceeds `available_bytes` on the spill volume, or `None` when it fits.
+pub(super) fn spill_space_warning(
+    estimated_spill_bytes: u64,
+    available_bytes: u64,
+    spill_dir: &Path,
+) -> Option<String> {
+    let need = estimated_spill_bytes + estimated_spill_bytes / SPILL_MARGIN_DENOM;
+    if available_bytes >= need {
+        return None;
+    }
+    let gib = |b: u64| b as f64 / (1024.0 * 1024.0 * 1024.0);
+    Some(format!(
+        "projected input spill (≈{:.1} GiB — the selected input bytes are \
+         staged on local disk so later passes stay off the network, #219) may \
+         not fit: {} has {:.1} GiB free ({:.1} GiB short, including a 5% \
+         margin). If the volume fills mid-convert the spill degrades to \
+         network re-fetch; pass --spill-dir (spill_dir) to place it on a \
+         roomier volume, or free up space first.",
+        gib(estimated_spill_bytes),
+        spill_dir.display(),
+        gib(available_bytes),
+        gib(need - available_bytes),
+    ))
+}
+
+/// #272 preflight gate over [`spill_space_warning`], with the free-space
+/// probe injected so the gating is unit-testable with a fake probe. Only a
+/// remote input spills, so for local inputs (and an empty selection) the
+/// probe is never even called; a failed probe (`None` — unsupported
+/// filesystem, permission error) stays quiet rather than crying wolf.
+pub(super) fn spill_space_check(
+    is_remote: bool,
+    estimated_spill_bytes: u64,
+    spill_dir: &Path,
+    probe: impl FnOnce(&Path) -> Option<u64>,
+) -> Option<String> {
+    if !is_remote || estimated_spill_bytes == 0 {
+        return None;
+    }
+    let available = probe(spill_dir)?;
+    spill_space_warning(estimated_spill_bytes, available, spill_dir)
+}
+
+/// Free bytes available to the current user on the volume holding `dir`
+/// (statvfs / GetDiskFreeSpaceEx via `fs4`), or `None` if the probe fails.
+/// Compiled to a stub without the `remote` feature — nothing spills there,
+/// and [`spill_space_check`] never probes for a local input.
+fn probe_available_space(dir: &Path) -> Option<u64> {
+    #[cfg(feature = "remote")]
+    {
+        fs4::available_space(dir).ok()
+    }
+    #[cfg(not(feature = "remote"))]
+    {
+        let _ = dir;
+        None
+    }
+}
+
+/// Emit the #272 spill free-space preflight warning, if warranted. Thin
+/// logging wrapper over [`spill_space_check`] with the real filesystem
+/// probe; `spill_dir = None` means the process temp dir, exactly where the
+/// spill file would go.
+pub(super) fn warn_spill_space(
+    source: &InputSource,
+    estimated_spill_bytes: u64,
+    spill_dir: Option<&Path>,
+) {
+    let dir = spill_dir.map_or_else(std::env::temp_dir, Path::to_path_buf);
+    if let Some(msg) = spill_space_check(
+        source.is_remote(),
+        estimated_spill_bytes,
+        &dir,
+        probe_available_space,
     ) {
         log::warn!("{msg}");
     }
@@ -2462,6 +2575,76 @@ mod tests {
         assert!(
             msg.contains("4.0 GiB"),
             "nudge should state the object size: {msg}"
+        );
+    }
+
+    /// #272: the spill free-space preflight warns when the projected spill
+    /// (≈ the selected input bytes, plus a 5% safety margin) exceeds the
+    /// free space on the spill volume — naming the directory, the shortfall,
+    /// and the `--spill-dir` escape hatch.
+    #[test]
+    fn spill_space_warning_names_dir_and_shortfall() {
+        let dir = Path::new("/mnt/scratch");
+        let msg = spill_space_warning(10 << 30, 1 << 30, dir).expect("shortfall should warn");
+        assert!(
+            msg.contains("/mnt/scratch"),
+            "warning names the spill dir: {msg}"
+        );
+        assert!(
+            msg.contains("--spill-dir"),
+            "warning suggests --spill-dir: {msg}"
+        );
+        // need = 10 GiB + 5% = 10.5 GiB; available 1 GiB → 9.5 GiB short.
+        assert!(
+            msg.contains("9.5 GiB"),
+            "warning states the shortfall: {msg}"
+        );
+    }
+
+    /// #272: ample space stays quiet, and the margin boundary is exact —
+    /// available == estimated + 5% is enough, one byte less is not.
+    #[test]
+    fn spill_space_warning_quiet_with_ample_space() {
+        let dir = Path::new("/tmp");
+        assert!(spill_space_warning(1 << 30, 20 << 30, dir).is_none());
+        let est: u64 = 20 << 20;
+        let need = est + est / 20;
+        assert!(spill_space_warning(est, need, dir).is_none());
+        assert!(spill_space_warning(est, need - 1, dir).is_some());
+    }
+
+    /// #272: local inputs never spill, so the free-space probe must not
+    /// even run for them; a failed probe (None) stays quiet rather than
+    /// crying wolf; a zero estimate (empty selection) stays quiet too.
+    #[test]
+    fn spill_space_check_gating() {
+        let dir = Path::new("/tmp");
+        assert!(spill_space_check(false, 10 << 30, dir, |_| panic!(
+            "free-space probe must not run for local inputs"
+        ))
+        .is_none());
+        assert!(spill_space_check(true, 10 << 30, dir, |_| None).is_none());
+        assert!(spill_space_check(true, 0, dir, |_| Some(0)).is_none());
+        assert!(spill_space_check(true, 10 << 30, dir, |_| Some(1)).is_some());
+    }
+
+    /// #272: a configured spill dir must exist — fail fast at option
+    /// validation instead of silently degrading to network re-fetch when
+    /// the spill file cannot be created mid-convert.
+    #[test]
+    fn validate_options_rejects_missing_spill_dir() {
+        let opts = ConvertOptions {
+            spill_dir: Some(std::path::PathBuf::from(
+                "/nonexistent/gpq-tiles-spill-dir-272",
+            )),
+            ..Default::default()
+        };
+        let err = validate_options(&opts).expect_err("missing spill dir must be rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("spill-dir"), "error names the option: {msg}");
+        assert!(
+            msg.contains("/nonexistent/gpq-tiles-spill-dir-272"),
+            "error names the path: {msg}"
         );
     }
 

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -180,6 +180,16 @@ pub(crate) fn convert_streaming_strategy(
     // #267: nudge toward --bbox / download-first for a large whole-file remote
     // convert (quiet for local inputs and effective bbox extracts).
     super::convert::warn_full_file_remote(source, row_groups_read, row_groups_total);
+    // #272: preflight the spill volume. The disk spill (#219) grows to ≈ the
+    // selected input bytes — known exactly here, the first moment after
+    // row-group selection — so compare it against the free space where the
+    // spill will live and warn up front (naming the dir and the shortfall)
+    // instead of silently degrading to network re-fetch mid-convert.
+    super::convert::warn_spill_space(
+        source,
+        crate::input::selected_compressed_bytes(builder.metadata(), selected_row_groups.as_deref()),
+        options.spill_dir.as_deref(),
+    );
     drop(builder);
 
     if input_schema

--- a/crates/python/gpq_tiles.pyi
+++ b/crates/python/gpq_tiles.pyi
@@ -3,6 +3,7 @@
 # Kept honest by CI: `python -m mypy.stubtest gpq_tiles` verifies these
 # signatures against the compiled module on every PR. If you change a
 # #[pyo3(signature = ...)] in crates/python/src/lib.rs, update this file.
+from pathlib import Path
 from typing import Any
 
 __all__ = ["convert", "export_pmtiles", "overview", "validate"]
@@ -56,6 +57,7 @@ def overview(
     bbox: tuple[float, float, float, float] | None = None,
     profile: str = "auto",
     in_flight_batches: int = 4,
+    spill_dir: str | Path | None = None,
 ) -> dict[str, Any]: ...
 def export_pmtiles(
     input: str,

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -17,7 +17,7 @@ use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Convert GeoParquet to PMTiles in one shot (overview facade).
 ///
@@ -325,6 +325,13 @@ fn convert_report_to_dict(py: Python<'_>, report: &ConvertReport) -> PyResult<Py
 ///         the pass-2 pipeline at once (read/compute-overlap knob). Higher
 ///         improves core utilization at proportionally more peak memory.
 ///         Defaults to 4.
+///     spill_dir (str or os.PathLike, optional): Directory for the
+///         remote-input spill file. A remote convert stages every fetched
+///         chunk on local disk (≈1x the touched input bytes) so later passes
+///         re-read from disk instead of the network; a free-space preflight
+///         warns if the projected spill may not fit there. The directory
+///         must exist. Local inputs never spill. Defaults to None (the
+///         process temp dir, $TMPDIR).
 ///
 /// Returns:
 ///     dict: Conversion report with keys "mode", "levels" (list of dicts with
@@ -393,6 +400,7 @@ fn convert_report_to_dict(py: Python<'_>, report: &ConvertReport) -> PyResult<Py
     bbox=None,
     profile="auto",
     in_flight_batches=4,
+    spill_dir=None,
 ))]
 #[allow(clippy::too_many_arguments)] // Python API mirrors CLI flags; grouping into struct would hurt usability
 fn overview(
@@ -435,6 +443,7 @@ fn overview(
     bbox: Option<(f64, f64, f64, f64)>,
     profile: &str,
     in_flight_batches: usize,
+    spill_dir: Option<PathBuf>,
 ) -> PyResult<Py<PyDict>> {
     let mode = match mode {
         "duplicating" => Mode::Duplicating,
@@ -581,6 +590,7 @@ fn overview(
         coalesce_max_level_rows,
         coalesce_junction_angle,
         bbox: bbox.map(|(xmin, ymin, xmax, ymax)| [xmin, ymin, xmax, ymax]),
+        spill_dir,
     };
 
     let input_path = Path::new(input).to_path_buf();

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -53,6 +53,7 @@ Commands:
 | `--read-batch-size <N>` | `8192` | Rows per Arrow read batch (streaming) |
 | `--profile <MODE>` | `auto` | Pass-2 buffering: `speed` (in-RAM), `bounded` (spill to temp Arrow IPC), `auto` (per mode + size). Output is byte-identical across profiles |
 | `--in-flight-batches <N>` | `4` | Read/compute overlap depth in pass 2 (higher = better core use, proportionally more peak memory) |
+| `--spill-dir <PATH>` | `$TMPDIR` | Directory for the remote-input spill file (≈1× the touched input bytes; a free-space preflight warns on a projected shortfall). Must exist; local inputs never spill |
 | `--report <PATH>` | — | Write the JSON conversion report |
 
 ### `gpq-tiles export-pmtiles <INPUT> <OUTPUT>`
@@ -190,6 +191,7 @@ report = overview(
     bbox: tuple[float, float, float, float] | None = None,
     profile: str = "auto",
     in_flight_batches: int = 4,
+    spill_dir: str | os.PathLike | None = None,
 ) -> dict  # the JSON conversion report
 ```
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -115,12 +115,23 @@ The residual full-file cost is now local, not network: the passes still
 re-*read* the spilled bytes from disk (seek latency) and re-*decode*
 them. For latency-sensitive whole-file conversions, downloading first
 (`aws s3 cp` + local convert) still avoids the second-pass disk read; the
-disk spill lives under `TMPDIR`, so point that at fast local disk (not a
-small tmpfs) when converting large remote files.
+disk spill lives under `TMPDIR` by default, and `--spill-dir <path>`
+(Python: `spill_dir=`,
+[#272](https://github.com/geoparquet-io/gpq-tiles/issues/272)) moves it
+to a volume of your choosing — fast local disk, not a small tmpfs, when
+converting large remote files.
 
-The converter makes this actionable at runtime: a whole-file remote
+The converter makes this actionable at runtime. A whole-file remote
 convert of an object ≥ 1 GiB logs a one-line warning
 ([#267](https://github.com/geoparquet-io/gpq-tiles/issues/267)) steering
 you to `--bbox` or a download-first workflow and reminding you to place
-`$TMPDIR` on fast disk. `--bbox` extracts stay quiet — they already fetch
-only a fraction of the object.
+the spill on fast disk. And because the spill grows to ≈1× the *touched*
+input bytes — a number known exactly from the parquet footer once the
+`--bbox` row-group selection is made — the converter also preflights the
+spill volume ([#272](https://github.com/geoparquet-io/gpq-tiles/issues/272)):
+if the projected spill (plus a 5% margin) exceeds the free space where
+the spill will live, it warns up front, naming the directory and the
+shortfall, instead of letting the spill silently degrade to network
+re-fetch when the volume fills mid-convert. `--bbox` extracts stay quiet
+in both cases — they already fetch (and spill) only a fraction of the
+object.

--- a/docs/remote-reads.md
+++ b/docs/remote-reads.md
@@ -69,8 +69,18 @@ What to know:
   This bounds a full-file remote conversion to ≈1× the object's bytes
   regardless of pass or level count (issue #219). Measured on
   fieldmaps-adm4 (2.90 GB, z0–14): **96× before #261, 3.0× after #261,
-  ≈1× after #219**. The spill file lives under `TMPDIR`; point that at
-  real disk if your default temp dir is a small tmpfs.
+  ≈1× after #219**. The spill file lives under `TMPDIR` by default;
+  `--spill-dir <path>` (Python: `spill_dir=`) places it on a volume of
+  your choosing instead (issue #272) — point it at real disk if your
+  default temp dir is a small tmpfs. The spill grows to ≈1× the
+  *touched* input bytes (the whole object for a full-file convert, only
+  the covering row groups with `--bbox`); before pass 1 the converter
+  compares that projection against the free space on the spill volume
+  and logs a warning naming the directory and the shortfall if it may
+  not fit. The spill stays best-effort either way: if the volume fills
+  mid-convert (or the file can't be created), the spill disables itself
+  with a log line and later passes fall back to network re-fetch —
+  correctness is preserved, only the ≈1× bound degrades.
 - **Latency vs bytes** — requests are issued sequentially, so on a
   fast link a plain `aws s3 cp` + local convert can still win on wall
   time (92 MB corpus file, residential fiber: ~3 s download+convert


### PR DESCRIPTION
Closes #272. Follow-up to #219 (PR #270) and #267.

## What

The remote-input disk spill (#219) grows to ≈1× the **touched** input bytes, fixed under `$TMPDIR`, with no up-front signal when the volume is too small — a large remote convert could die on a cryptic disk-full error or silently degrade to network re-fetch mid-run. This PR makes the location configurable and the cost visible before pass 1:

- **`--spill-dir <PATH>`** on `overview` and `tiles` (shared `ConvertTuningArgs`), **`ConvertOptions.spill_dir`** in core, **`overview(spill_dir=...)`** in Python. Threaded `InputSource::set_spill_dir` → `RemoteSource` → `DiskSpill` (`tempfile::tempfile_in`); default behavior unchanged (`$TMPDIR`, anonymous file). The directory must exist — validated in `validate_options` so a bad dir fails fast instead of surfacing as a silent mid-convert degrade.
- **Free-space preflight** in `convert_streaming_strategy`, immediately after `--bbox` row-group selection — the first moment the touched input bytes are known. Projected spill = Σ compressed bytes of the selected row groups (`input::selected_compressed_bytes`, footer-only); if free space on the spill volume < that + a 5% margin, a **warning** (not an error) names the directory, the shortfall, and `--spill-dir`. Warning-not-error matches #219's best-effort design: a full volume already degrades gracefully to network re-fetch, so the guard's job is to make that visible up front. Local inputs never probe; a failed probe stays quiet.
- The spill-disable log line now names the directory it failed in, and the #267 full-file nudge now points at `--spill-dir` alongside `$TMPDIR`.
- `selected_compressed_bytes(metadata, selection) -> u64` is deliberately file-count-agnostic so the upcoming multi-partition `ConvertSource` can sum it across parts.

## Free-space probe crate choice

`fs4` (v0.13, optional dep of the `remote` feature — pure-local library builds stay dependency-free). Rationale: release CI builds Windows wheels, so unix-only `rustix::fs::statvfs` doesn't suffice; `fs4` is the maintained `fs2` fork wrapping `statvfs`/`GetDiskFreeSpaceEx` over `rustix`/`windows-sys`, both already in the tree transitively; `sysinfo` is far heavier for one syscall.

## Tests (TDD — red verified before implementation)

- `input.rs`: `DiskSpill` put/get roundtrip through a configured dir; nonexistent dir disables the spill (proves `tempfile_in` uses the configured dir, since the file itself is anonymous); `set_spill_dir` threading proven behaviorally end-to-end (broken dir ⇒ multi-pass re-fetch ≥2×, valid dir ⇒ ≈1× bound holds); `selected_compressed_bytes` sums full file / subset / empty selection.
- `convert.rs`: pure guard fns mirror the #267 test pattern — shortfall message names dir + shortfall + `--spill-dir`; exact margin boundary; injected probe proves local inputs never probe (panicking probe), failed probe and zero estimate stay quiet; `validate_options` rejects a missing spill dir.
- CLI: `--spill-dir` parses on both `overview` and `tiles` and reaches `ConvertOptions` (nonexistent dir rejected by core validation, error names option + path).

All targeted tests green (`input::` 23 passed, guard/spill 8 passed, streaming parity smoke passed); `cargo clippy --workspace --all-targets` clean; core compiles with and without the `remote` feature.

## Docs

`docs/remote-reads.md` and `docs/performance.md` #219 sections updated for `--spill-dir` + the preflight, including the small-tmpfs caveat (tmpfs *detection* is the separate follow-up #273); `docs/api-reference.md` flag table + Python signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)