### PR TITLE
feat(core): multi-partition input — ConvertSource + local dir/glob (1/3)

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -63,6 +63,7 @@ async-trait = { version = "0.1", optional = true }
 url = { version = "2", optional = true }
 bytes = "1"
 fs4 = { version = "0.13", optional = true }
+glob = "0.3"
 
 [build-dependencies]
 prost-build = { workspace = true }

--- a/crates/core/src/batch_processor.rs
+++ b/crates/core/src/batch_processor.rs
@@ -19,16 +19,23 @@ use crate::{Error, Result};
 /// Resolve a path to a list of parquet files.
 ///
 /// If the path is a file, returns it as a single-element vector.
-/// If the path is a directory, recursively collects all .parquet files.
+/// If the path is a directory, recursively collects all .parquet files
+/// (sorted; `.`/`_`-prefixed basenames such as `_SUCCESS` are skipped —
+/// the collection lives in [`crate::input_set::list_parquet_files`], shared
+/// with the multi-partition [`crate::input_set::ConvertSource`]).
 pub fn resolve_parquet_files(path: &Path) -> Result<Vec<PathBuf>> {
     if path.is_file() {
         return Ok(vec![path.to_path_buf()]);
     }
 
     if path.is_dir() {
-        let mut files = Vec::new();
-        collect_parquet_files(path, &mut files)?;
-        files.sort(); // Deterministic order
+        let files = crate::input_set::list_parquet_files(path).map_err(|e| {
+            Error::GeoParquetRead(format!(
+                "Failed to read directory {}: {}",
+                path.display(),
+                e
+            ))
+        })?;
         if files.is_empty() {
             return Err(Error::GeoParquetRead(format!(
                 "No .parquet files found in directory: {}",
@@ -42,24 +49,6 @@ pub fn resolve_parquet_files(path: &Path) -> Result<Vec<PathBuf>> {
         "Path does not exist: {}",
         path.display()
     )))
-}
-
-/// Recursively collect .parquet files from a directory.
-fn collect_parquet_files(dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
-    let entries = std::fs::read_dir(dir).map_err(|e| {
-        Error::GeoParquetRead(format!("Failed to read directory {}: {}", dir.display(), e))
-    })?;
-
-    for entry in entries {
-        let entry = entry.map_err(|e| Error::GeoParquetRead(e.to_string()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_parquet_files(&path, files)?;
-        } else if path.extension().is_some_and(|ext| ext == "parquet") {
-            files.push(path);
-        }
-    }
-    Ok(())
 }
 
 /// Extract geometries from a GeoArrow array into a Vec.

--- a/crates/core/src/input.rs
+++ b/crates/core/src/input.rs
@@ -98,6 +98,44 @@ pub enum InputError {
     #[cfg(feature = "remote")]
     #[error("{0}")]
     RemoteConfig(String),
+    /// Arrow error surfaced while decoding record batches from a stream.
+    #[error("arrow error: {0}")]
+    Arrow(#[from] arrow_schema::ArrowError),
+    /// A partition of a multi-file input does not match the first partition
+    /// (schema shape, geometry extension metadata, or CRS).
+    #[error("incompatible input partition {offender:?}: {detail} (first partition: {first:?})")]
+    IncompatiblePartition {
+        /// Display name of the reference (first) partition.
+        first: String,
+        /// Display name of the partition that failed validation.
+        offender: String,
+        /// What differs.
+        detail: String,
+    },
+    /// A directory or glob input matched no `.parquet` files.
+    #[error("no .parquet files found for input {input:?}")]
+    NoParquetInputs {
+        /// The original input string (directory path or glob pattern).
+        input: String,
+    },
+    /// A remote URL that is not a single `.parquet` object (a bucket prefix /
+    /// "directory"). Listing remote prefixes lands later in this release.
+    #[error(
+        "remote prefix input {url:?} is not yet supported (single .parquet object \
+         URLs are; remote prefix listing is coming later in this release)"
+    )]
+    RemotePrefixUnsupported {
+        /// The rejected URL.
+        url: String,
+    },
+    /// A glob input string is not a valid glob pattern.
+    #[error("invalid glob pattern {pattern:?}: {message}")]
+    GlobPattern {
+        /// The pattern as supplied.
+        pattern: String,
+        /// The glob crate's error message.
+        message: String,
+    },
 }
 
 /// Byte/request counters for a remote input. `Serialize` so conversion
@@ -113,7 +151,11 @@ pub struct FetchStats {
 }
 
 /// A conversion input: a local parquet file or a remote parquet object.
-#[derive(Debug)]
+///
+/// `Clone` is cheap: the local variant clones a path, the remote variant
+/// clones `Arc` handles — clones share the fetch counters, chunk cache,
+/// disk spill, and cached footer of the original.
+#[derive(Debug, Clone)]
 pub enum InputSource {
     /// A local filesystem path (the historical behavior).
     Local(PathBuf),
@@ -230,6 +272,20 @@ impl InputSource {
             r.set_spill_dir(dir);
         }
     }
+
+    /// Release the in-memory read cache (no-op for local files). For a
+    /// remote source this clears the L1 chunk cache but KEEPS the disk
+    /// spill and the cached footer, so a later touch of the same chunk is
+    /// served from local disk, not the network. Called by multi-partition
+    /// streams on part transitions to bound resident memory to one part's
+    /// working set.
+    pub fn release_read_cache(&self) {
+        match self {
+            InputSource::Local(_) => {}
+            #[cfg(feature = "remote")]
+            InputSource::Remote(r) => r.release_read_cache(),
+        }
+    }
 }
 
 /// Sum of the compressed byte sizes of the selected input row groups — the
@@ -255,8 +311,15 @@ pub fn selected_compressed_bytes(
     }
 }
 
+/// Whether `scheme` is one of the recognized remote URL schemes.
+pub(crate) fn is_remote_scheme(scheme: &str) -> bool {
+    REMOTE_SCHEMES
+        .iter()
+        .any(|s| scheme.eq_ignore_ascii_case(s))
+}
+
 /// Return the URL scheme of `input` if it is shaped like `scheme://rest`.
-fn url_scheme(input: &str) -> Option<&str> {
+pub(crate) fn url_scheme(input: &str) -> Option<&str> {
     let (scheme, _) = input.split_once("://")?;
     if scheme.is_empty() {
         return None;
@@ -400,7 +463,10 @@ pub(crate) mod remote {
 
     /// A remote parquet object: store handle, resolved location, object
     /// size, fetch counters, and (after the first open) the parsed footer.
-    #[derive(Debug)]
+    ///
+    /// `Clone` shares the counters, caches, spill, and cached footer via the
+    /// inner `Arc`s (a clone is a second handle to the same object).
+    #[derive(Debug, Clone)]
     pub struct RemoteSource {
         url: String,
         store: Arc<dyn ObjectStore>,
@@ -594,6 +660,18 @@ pub(crate) mod remote {
         /// The byte ranges fetched so far, in request order.
         pub fn fetched_ranges(&self) -> Vec<Range<u64>> {
             self.shared.ranges.lock().expect("ranges lock").clone()
+        }
+
+        /// Drop the in-memory (L1) chunk cache. The disk spill (L2) and the
+        /// cached footer are KEPT: a later pass re-reads spilled chunks from
+        /// local disk, never the network. Multi-partition streams call this
+        /// on part transitions so resident memory stays O(one part's row
+        /// group) instead of O(parts × cap) (v0.7 multi-partition input).
+        pub fn release_read_cache(&self) {
+            let mut cache = self.cache.lock().expect("chunk cache lock");
+            cache.entries.clear();
+            cache.order.clear();
+            cache.total = 0;
         }
     }
 

--- a/crates/core/src/input.rs
+++ b/crates/core/src/input.rs
@@ -312,6 +312,7 @@ pub fn selected_compressed_bytes(
 }
 
 /// Whether `scheme` is one of the recognized remote URL schemes.
+#[cfg(feature = "remote")]
 pub(crate) fn is_remote_scheme(scheme: &str) -> bool {
     REMOTE_SCHEMES
         .iter()

--- a/crates/core/src/input_set.rs
+++ b/crates/core/src/input_set.rs
@@ -221,6 +221,14 @@ impl ConvertSource {
         self.parts().iter().any(InputSource::is_remote)
     }
 
+    /// Place the remote-input disk spill in `dir` for every part (#272).
+    /// No-op for local parts, which never spill.
+    pub fn set_spill_dir(&self, dir: Option<&Path>) {
+        for part in self.parts() {
+            part.set_spill_dir(dir);
+        }
+    }
+
     /// Human-readable input name: the path/URL for a single source,
     /// `"<root> (N partitions)"` for a multi source.
     pub fn display_name(&self) -> String {
@@ -282,19 +290,26 @@ impl ConvertSource {
         Ok(RowGroupSelection(per_part))
     }
 
-    /// Total *compressed* bytes of the selected row groups — the input-cost
-    /// figure a future full-read guard (#272) will consult.
-    pub fn selected_input_bytes(&self, selection: &RowGroupSelection) -> Result<u64, InputError> {
+    /// Total *compressed* bytes of the selected row groups (`None` = every
+    /// row group of every part) — the projected disk-spill size the #272
+    /// free-space preflight consults. Per-part sums come from the shared
+    /// single-file helper [`crate::input::selected_compressed_bytes`].
+    pub fn selected_input_bytes(
+        &self,
+        selection: Option<&RowGroupSelection>,
+    ) -> Result<u64, InputError> {
         let metas = self.metas()?;
-        debug_assert_eq!(metas.len(), selection.0.len());
+        if let Some(sel) = selection {
+            debug_assert_eq!(metas.len(), sel.0.len());
+        }
         Ok(metas
             .iter()
-            .zip(&selection.0)
-            .map(|(m, groups)| {
-                groups
-                    .iter()
-                    .map(|&g| m.parquet.row_group(g).compressed_size().max(0) as u64)
-                    .sum::<u64>()
+            .enumerate()
+            .map(|(pi, m)| {
+                crate::input::selected_compressed_bytes(
+                    &m.parquet,
+                    selection.map(|s| s.0[pi].as_slice()),
+                )
             })
             .sum())
     }
@@ -620,7 +635,7 @@ mod tests {
         let batch = RecordBatch::try_new(schema.clone(), columns).unwrap();
         let props = max_row_group_size.map(|n| {
             WriterProperties::builder()
-                .set_max_row_group_size(n)
+                .set_max_row_group_row_count(Some(n))
                 .build()
         });
         let file = File::create(path).unwrap();
@@ -912,11 +927,14 @@ mod tests {
         };
         assert_eq!(stream_ids(&src, &plan), vec![12, 13]);
 
-        // selected_input_bytes = the one selected group's compressed size.
-        let bytes = src.selected_input_bytes(&sel).unwrap();
+        // selected_input_bytes = the one selected group's compressed size;
+        // None means every row group of every part.
+        let bytes = src.selected_input_bytes(Some(&sel)).unwrap();
         assert!(bytes > 0);
         let all = RowGroupSelection::from_parts(vec![vec![0, 1], vec![0, 1]]);
-        assert!(src.selected_input_bytes(&all).unwrap() > bytes);
+        let all_bytes = src.selected_input_bytes(Some(&all)).unwrap();
+        assert!(all_bytes > bytes);
+        assert_eq!(src.selected_input_bytes(None).unwrap(), all_bytes);
     }
 
     #[test]

--- a/crates/core/src/input_set.rs
+++ b/crates/core/src/input_set.rs
@@ -1,0 +1,951 @@
+//! Multi-partition conversion input: [`ConvertSource`] (v0.7).
+//!
+//! Real-world GeoParquet datasets frequently arrive as a *set* of parquet
+//! files (Hive/Spark `part-*.parquet` directories, Overture-style
+//! partitions). This module generalizes the converter's single
+//! [`InputSource`] into a [`ConvertSource`] that is either one file/object
+//! or an ordered set of local partitions resolved from a directory or a
+//! glob pattern.
+//!
+//! # The row-order invariant (load-bearing)
+//!
+//! The streaming converter reads its input **several times** (pass 1
+//! assignment scan, buffered coarse levels, canonical finest level) and
+//! keys its winner tables by **global row offset**. Every pass must
+//! therefore see *the same rows in the same order*. A `ConvertSource`
+//! guarantees this by construction:
+//!
+//! - partitions are sorted lexicographically at resolve time and never
+//!   reordered;
+//! - [`ConvertSource::open_stream`] concatenates the parts' batches in
+//!   part order, part `i + 1` opening only after part `i` is exhausted;
+//! - per-part row-group selections ([`RowGroupSelection`]) are computed
+//!   once and applied identically on every open.
+//!
+//! # Compatibility validation
+//!
+//! All partitions must be mutually compatible ([`MultiSource`] validates
+//! against partition 0 at construction): identical field names, types, and
+//! order; identical field (extension) metadata — geometry encoding must
+//! match; and an identical detected CRS. Nullability is the one permitted
+//! difference: the exposed schema unions it (any-nullable ⇒ nullable).
+//!
+//! Remote *prefixes* (e.g. `s3://bucket/dataset/`) are rejected with a
+//! clear error for now; remote prefix listing lands later in this release.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use arrow_array::RecordBatch;
+use arrow_schema::{Field, Schema, SchemaRef};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReader;
+use parquet::arrow::ProjectionMask;
+use parquet::file::metadata::{KeyValue, ParquetMetaData};
+
+use crate::input::{is_remote_scheme, url_scheme, FetchStats, InputError, InputSource};
+
+/// A resolved conversion input: one parquet file/object, or an ordered set
+/// of local parquet partitions read as one logical dataset.
+#[derive(Debug)]
+pub enum ConvertSource {
+    /// A single parquet file or remote object (the historical input shape).
+    Single(InputSource),
+    /// An ordered, validated set of local parquet partitions.
+    Multi(MultiSource),
+}
+
+/// Footer-derived metadata of one partition.
+#[derive(Debug, Clone)]
+struct PartMeta {
+    /// Arrow schema decoded from the part's footer.
+    schema: SchemaRef,
+    /// Parsed parquet metadata (row groups, key-value metadata).
+    parquet: Arc<ParquetMetaData>,
+}
+
+/// An ordered set of local parquet partitions with footers loaded and
+/// validated up front (see the module docs for the compatibility rules).
+#[derive(Debug)]
+pub struct MultiSource {
+    /// The original input string (directory path or glob pattern).
+    root: String,
+    /// The partitions, sorted lexicographically. Ordering is load-bearing:
+    /// global row offsets are assigned in this order.
+    parts: Vec<InputSource>,
+    /// Per-part footer metadata, parallel to `parts`.
+    metas: Vec<PartMeta>,
+    /// The unioned schema: partition 0's fields with nullability OR-ed
+    /// across all partitions.
+    schema: SchemaRef,
+}
+
+/// Per-part row-group selection: the multi-file analogue of the single-file
+/// `selected_row_groups: Option<&[usize]>` (bbox pruning, #102). Entry `i`
+/// holds part `i`'s *local* row-group indices; an empty entry skips the
+/// part entirely.
+#[derive(Debug, Clone)]
+pub struct RowGroupSelection(Vec<Vec<usize>>);
+
+impl RowGroupSelection {
+    /// Build from per-part local row-group index lists.
+    pub fn from_parts(parts: Vec<Vec<usize>>) -> Self {
+        RowGroupSelection(parts)
+    }
+
+    /// Per-part selections, in part order.
+    pub fn parts(&self) -> &[Vec<usize>] {
+        &self.0
+    }
+
+    /// Total number of selected row groups across all parts.
+    pub fn total_selected(&self) -> usize {
+        self.0.iter().map(Vec::len).sum()
+    }
+}
+
+/// How to read a [`ConvertSource`]: batch size, optional root-column
+/// projection (identical schemas make one index set valid for every part),
+/// and optional per-part row-group selection.
+#[derive(Debug, Clone, Copy)]
+pub struct ReadPlan<'a> {
+    /// Rows per record batch (clamped to >= 1).
+    pub batch_size: usize,
+    /// Root (top-level) column indices to read; `None` = all columns.
+    pub projection: Option<&'a [usize]>,
+    /// Per-part row-group selection; `None` = all row groups.
+    pub row_groups: Option<&'a RowGroupSelection>,
+}
+
+/// Sequential record-batch stream over all parts of a [`ConvertSource`],
+/// in part order. Part `i + 1`'s reader is opened lazily when part `i` is
+/// exhausted; on each part transition the finished part's in-memory read
+/// cache is released ([`InputSource::release_read_cache`]) so resident
+/// memory stays bounded by one part's working set.
+pub struct SourceStream<'a> {
+    parts: &'a [InputSource],
+    projection: Option<Vec<usize>>,
+    row_groups: Option<Vec<Vec<usize>>>,
+    batch_size: usize,
+    part_idx: usize,
+    current: Option<ParquetRecordBatchReader>,
+    done: bool,
+}
+
+impl ConvertSource {
+    /// Wrap an already-constructed [`InputSource`] (single file/object).
+    pub fn single(source: InputSource) -> Self {
+        ConvertSource::Single(source)
+    }
+
+    /// Resolve a CLI-style input string:
+    ///
+    /// - existing local file → `Single` (byte-identical behavior to today);
+    /// - existing local directory → recursive `.parquet` collection
+    ///   (sorted; `_`/`.`-prefixed basenames such as `_SUCCESS` skipped);
+    /// - string containing glob metacharacters (`*?[`) → glob expansion,
+    ///   filtered to `.parquet` files, sorted, deduplicated;
+    /// - remote URL ending in `.parquet` → `Single` (unchanged);
+    /// - remote prefix → [`InputError::RemotePrefixUnsupported`] (for now);
+    /// - a single resolved partition collapses to `Single`;
+    /// - an empty directory/glob result → [`InputError::NoParquetInputs`].
+    pub fn resolve(input: &str) -> Result<Self, InputError> {
+        if let Some(scheme) = url_scheme(input) {
+            if !scheme.eq_ignore_ascii_case("file")
+                && is_remote_scheme(scheme)
+                && !remote_is_parquet_object(input)
+            {
+                return Err(InputError::RemotePrefixUnsupported {
+                    url: input.to_string(),
+                });
+            }
+            // `file://` maps to a local path, remote `.parquet` objects stay
+            // single, unsupported schemes get the standard error — all
+            // exactly as before.
+            return Ok(ConvertSource::Single(InputSource::from_str_input(input)?));
+        }
+        let path = Path::new(input);
+        if path.is_file() {
+            // Existing local file: byte-identical behavior to today.
+            return Ok(ConvertSource::Single(InputSource::Local(
+                path.to_path_buf(),
+            )));
+        }
+        if path.is_dir() {
+            let files = list_parquet_files(path)?;
+            return Self::from_local_files(input, files);
+        }
+        if has_glob_meta(input) {
+            let files = expand_glob(input)?;
+            return Self::from_local_files(input, files);
+        }
+        // Nonexistent plain path: keep today's behavior (the io error
+        // surfaces at open time).
+        Ok(ConvertSource::Single(InputSource::Local(
+            path.to_path_buf(),
+        )))
+    }
+
+    /// `Single` for one file, `Multi` for several, a clear error for none.
+    fn from_local_files(input: &str, mut files: Vec<PathBuf>) -> Result<Self, InputError> {
+        match files.len() {
+            0 => Err(InputError::NoParquetInputs {
+                input: input.to_string(),
+            }),
+            1 => Ok(ConvertSource::Single(InputSource::Local(files.remove(0)))),
+            _ => Ok(ConvertSource::Multi(MultiSource::from_local_files(
+                input.to_string(),
+                files,
+            )?)),
+        }
+    }
+
+    /// [`ConvertSource::resolve`] for `Path` inputs (non-UTF-8 paths fall
+    /// back to a single local source, as [`InputSource::from_path`] does).
+    pub fn resolve_path(path: &Path) -> Result<Self, InputError> {
+        match path.to_str() {
+            Some(s) => Self::resolve(s),
+            None => Ok(ConvertSource::Single(InputSource::from_path(path)?)),
+        }
+    }
+
+    /// The underlying parts, in read order (a single source is one part).
+    pub fn parts(&self) -> &[InputSource] {
+        match self {
+            ConvertSource::Single(s) => std::slice::from_ref(s),
+            ConvertSource::Multi(m) => &m.parts,
+        }
+    }
+
+    /// Whether any part is remote.
+    pub fn is_remote(&self) -> bool {
+        self.parts().iter().any(InputSource::is_remote)
+    }
+
+    /// Human-readable input name: the path/URL for a single source,
+    /// `"<root> (N partitions)"` for a multi source.
+    pub fn display_name(&self) -> String {
+        match self {
+            ConvertSource::Single(s) => s.display_name(),
+            ConvertSource::Multi(m) => {
+                format!("{} ({} partitions)", m.root, m.parts.len())
+            }
+        }
+    }
+
+    /// The Arrow schema of the dataset. For a multi source this is the
+    /// validated union schema (nullability OR-ed across parts).
+    pub fn schema(&self) -> Result<SchemaRef, InputError> {
+        match self {
+            ConvertSource::Single(s) => Ok(load_part_meta(s)?.schema),
+            ConvertSource::Multi(m) => Ok(m.schema.clone()),
+        }
+    }
+
+    /// Parquet key-value metadata of partition 0 (the `geo` metadata used
+    /// for CRS detection; construction validated all parts agree).
+    pub fn key_value_metadata(&self) -> Result<Option<Vec<KeyValue>>, InputError> {
+        match self {
+            ConvertSource::Single(s) => Ok(load_part_meta(s)?
+                .parquet
+                .file_metadata()
+                .key_value_metadata()
+                .cloned()),
+            ConvertSource::Multi(m) => Ok(m.metas[0]
+                .parquet
+                .file_metadata()
+                .key_value_metadata()
+                .cloned()),
+        }
+    }
+
+    /// Total number of row groups across all parts.
+    pub fn num_row_groups_total(&self) -> Result<usize, InputError> {
+        Ok(self
+            .metas()?
+            .iter()
+            .map(|m| m.parquet.num_row_groups())
+            .sum())
+    }
+
+    /// Per-part bbox row-group selection (#102): applies the single-file
+    /// covering-statistics pruning to each part independently.
+    /// `bbox_units` is `[xmin, ymin, xmax, ymax]` in the file CRS units.
+    pub fn select_row_groups(
+        &self,
+        bbox_units: &[f64; 4],
+    ) -> Result<RowGroupSelection, InputError> {
+        let per_part = self
+            .metas()?
+            .iter()
+            .map(|m| crate::overview::convert::select_input_row_groups(&m.parquet, bbox_units))
+            .collect();
+        Ok(RowGroupSelection(per_part))
+    }
+
+    /// Total *compressed* bytes of the selected row groups — the input-cost
+    /// figure a future full-read guard (#272) will consult.
+    pub fn selected_input_bytes(&self, selection: &RowGroupSelection) -> Result<u64, InputError> {
+        let metas = self.metas()?;
+        debug_assert_eq!(metas.len(), selection.0.len());
+        Ok(metas
+            .iter()
+            .zip(&selection.0)
+            .map(|(m, groups)| {
+                groups
+                    .iter()
+                    .map(|&g| m.parquet.row_group(g).compressed_size().max(0) as u64)
+                    .sum::<u64>()
+            })
+            .sum())
+    }
+
+    /// Fetch counters summed over remote parts (`None` when no part is
+    /// remote). `object_size` is the summed size of the remote objects.
+    pub fn fetch_stats(&self) -> Option<FetchStats> {
+        let mut total: Option<FetchStats> = None;
+        for part in self.parts() {
+            if let Some(s) = part.fetch_stats() {
+                let t = total.get_or_insert(FetchStats::default());
+                t.requests += s.requests;
+                t.bytes_fetched += s.bytes_fetched;
+                t.object_size += s.object_size;
+            }
+        }
+        total
+    }
+
+    /// Open a sequential batch stream over all parts (see [`SourceStream`]).
+    pub fn open_stream(&self, plan: &ReadPlan<'_>) -> Result<SourceStream<'_>, InputError> {
+        let parts = self.parts();
+        if let Some(sel) = plan.row_groups {
+            debug_assert_eq!(
+                sel.0.len(),
+                parts.len(),
+                "row-group selection must cover every part"
+            );
+        }
+        Ok(SourceStream {
+            parts,
+            projection: plan.projection.map(<[usize]>::to_vec),
+            row_groups: plan.row_groups.map(|s| s.0.clone()),
+            batch_size: plan.batch_size.max(1),
+            part_idx: 0,
+            current: None,
+            done: false,
+        })
+    }
+
+    /// Footer metadata per part: borrowed for `Multi` (loaded at
+    /// construction), loaded on demand for `Single`.
+    fn metas(&self) -> Result<std::borrow::Cow<'_, [PartMeta]>, InputError> {
+        match self {
+            ConvertSource::Single(s) => Ok(std::borrow::Cow::Owned(vec![load_part_meta(s)?])),
+            ConvertSource::Multi(m) => Ok(std::borrow::Cow::Borrowed(&m.metas)),
+        }
+    }
+}
+
+/// Load one part's footer: Arrow schema + parsed parquet metadata. Cheap
+/// for local files (OS page cache); remote sources reuse their cached
+/// footer after the first open.
+fn load_part_meta(source: &InputSource) -> Result<PartMeta, InputError> {
+    let builder = source.open()?;
+    Ok(PartMeta {
+        schema: builder.schema().clone(),
+        parquet: builder.metadata().clone(),
+    })
+}
+
+impl MultiSource {
+    /// Build and validate a multi source over local partition files.
+    fn from_local_files(root: String, files: Vec<PathBuf>) -> Result<Self, InputError> {
+        Self::from_sources(root, files.into_iter().map(InputSource::Local).collect())
+    }
+
+    /// Build a multi source over already-constructed parts: load every
+    /// part's footer and validate compatibility against part 0 (see the
+    /// module docs). `parts` must be non-empty and already ordered.
+    pub fn from_sources(root: String, parts: Vec<InputSource>) -> Result<Self, InputError> {
+        assert!(!parts.is_empty(), "MultiSource requires at least one part");
+        let metas = parts
+            .iter()
+            .map(load_part_meta)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let first_name = parts[0].display_name();
+        // The reference CRS: `Ok(crs)` per detect_crs_from_kv, `None` for an
+        // unsupported/undetectable CRS. Parts must AGREE; supportedness
+        // itself is enforced by the pipeline (against part 0), so a set
+        // that consistently carries an unsupported CRS still errors with
+        // the standard UnsupportedCrs message.
+        let crs_of = |m: &PartMeta| {
+            crate::overview::convert::detect_crs_from_kv(
+                m.parquet.file_metadata().key_value_metadata(),
+            )
+            .ok()
+        };
+        let first_crs = crs_of(&metas[0]);
+
+        for (part, meta) in parts.iter().zip(&metas).skip(1) {
+            let incompatible = |detail: String| InputError::IncompatiblePartition {
+                first: first_name.clone(),
+                offender: part.display_name(),
+                detail,
+            };
+            validate_schema_shape(&metas[0].schema, &meta.schema).map_err(&incompatible)?;
+            let crs = crs_of(meta);
+            if crs != first_crs {
+                return Err(incompatible(format!(
+                    "CRS mismatch: partition detects {crs:?} but the first partition \
+                     detects {first_crs:?} (all partitions must share one CRS)"
+                )));
+            }
+        }
+
+        let schema = union_schema(&metas);
+        Ok(MultiSource {
+            root,
+            parts,
+            metas,
+            schema,
+        })
+    }
+}
+
+/// Validate that `other` matches `first` in field count, names, types,
+/// order, and field (extension) metadata — everything except nullability,
+/// which the union schema absorbs. Returns a human-readable detail on the
+/// first difference.
+fn validate_schema_shape(first: &Schema, other: &Schema) -> Result<(), String> {
+    if first.fields().len() != other.fields().len() {
+        return Err(format!(
+            "column count differs: {} vs {} in the first partition",
+            other.fields().len(),
+            first.fields().len()
+        ));
+    }
+    for (ci, (f0, fi)) in first.fields().iter().zip(other.fields()).enumerate() {
+        if f0.name() != fi.name() {
+            return Err(format!(
+                "column {ci} is named {:?} but the first partition has {:?} \
+                 (columns must match in name and order)",
+                fi.name(),
+                f0.name()
+            ));
+        }
+        if f0.data_type() != fi.data_type() {
+            return Err(format!(
+                "column {:?} has type {:?} but the first partition has {:?}",
+                fi.name(),
+                fi.data_type(),
+                f0.data_type()
+            ));
+        }
+        if f0.metadata() != fi.metadata() {
+            return Err(format!(
+                "column {:?} carries different field (extension) metadata than \
+                 the first partition — geometry encoding/CRS metadata must match",
+                fi.name()
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Partition 0's schema with nullability OR-ed across all parts
+/// (any-nullable ⇒ nullable); schema-level metadata from partition 0.
+fn union_schema(metas: &[PartMeta]) -> SchemaRef {
+    let first = &metas[0].schema;
+    let fields: Vec<Field> = first
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(ci, f0)| {
+            let nullable = metas.iter().any(|m| m.schema.field(ci).is_nullable());
+            f0.as_ref().clone().with_nullable(nullable)
+        })
+        .collect();
+    Arc::new(Schema::new_with_metadata(fields, first.metadata().clone()))
+}
+
+impl SourceStream<'_> {
+    /// Open part `i`'s reader with this stream's projection / row-group
+    /// selection / batch size. Schemas are identical across parts, so the
+    /// root-column projection indices are valid for every part.
+    fn open_part(&self, i: usize) -> Result<ParquetRecordBatchReader, InputError> {
+        let mut builder = self.parts[i].open()?;
+        if let Some(cols) = &self.projection {
+            let mask = ProjectionMask::roots(builder.parquet_schema(), cols.iter().copied());
+            builder = builder.with_projection(mask);
+        }
+        if let Some(sel) = &self.row_groups {
+            builder = builder.with_row_groups(sel[i].clone());
+        }
+        Ok(builder.with_batch_size(self.batch_size).build()?)
+    }
+}
+
+impl Iterator for SourceStream<'_> {
+    type Item = Result<RecordBatch, InputError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+        loop {
+            if let Some(reader) = &mut self.current {
+                match reader.next() {
+                    Some(Ok(batch)) => return Some(Ok(batch)),
+                    Some(Err(e)) => {
+                        self.done = true;
+                        return Some(Err(InputError::Arrow(e)));
+                    }
+                    None => {
+                        // Part exhausted. Release its in-memory read cache
+                        // before moving on (bounds resident memory to one
+                        // part's working set); a single-part stream never
+                        // releases, preserving the single-file multi-pass
+                        // cache behavior.
+                        self.current = None;
+                        if self.part_idx + 1 < self.parts.len() {
+                            self.parts[self.part_idx].release_read_cache();
+                        }
+                        self.part_idx += 1;
+                    }
+                }
+                continue;
+            }
+            if self.part_idx >= self.parts.len() {
+                self.done = true;
+                return None;
+            }
+            // Skip parts whose row-group selection is empty without opening
+            // them at all (a bbox-pruned remote part is never touched).
+            if let Some(sel) = &self.row_groups {
+                if sel[self.part_idx].is_empty() {
+                    self.part_idx += 1;
+                    continue;
+                }
+            }
+            match self.open_part(self.part_idx) {
+                Ok(reader) => self.current = Some(reader),
+                Err(e) => {
+                    self.done = true;
+                    return Some(Err(e));
+                }
+            }
+        }
+    }
+}
+
+/// Whether `input` contains glob metacharacters (`*`, `?`, `[`).
+fn has_glob_meta(input: &str) -> bool {
+    input.contains(['*', '?', '['])
+}
+
+/// Whether a remote URL names a single `.parquet` object (query string and
+/// fragment ignored; trailing `/` means prefix).
+fn remote_is_parquet_object(url: &str) -> bool {
+    let no_fragment = url.split('#').next().unwrap_or(url);
+    let no_query = no_fragment.split('?').next().unwrap_or(no_fragment);
+    !no_query.ends_with('/') && no_query.to_ascii_lowercase().ends_with(".parquet")
+}
+
+/// Recursively collect `.parquet` files under `dir`, sorted
+/// lexicographically. Basenames starting with `.` or `_` (files *and*
+/// directories — `_SUCCESS`, `.crc`, `_temporary/`) are skipped.
+pub(crate) fn list_parquet_files(dir: &Path) -> Result<Vec<PathBuf>, InputError> {
+    fn hidden(path: &Path) -> bool {
+        path.file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.starts_with('.') || n.starts_with('_'))
+    }
+    fn collect(dir: &Path, files: &mut Vec<PathBuf>) -> Result<(), InputError> {
+        for entry in std::fs::read_dir(dir)? {
+            let path = entry?.path();
+            if hidden(&path) {
+                continue;
+            }
+            if path.is_dir() {
+                collect(&path, files)?;
+            } else if path.extension().is_some_and(|ext| ext == "parquet") {
+                files.push(path);
+            }
+        }
+        Ok(())
+    }
+    let mut files = Vec::new();
+    collect(dir, &mut files)?;
+    files.sort();
+    Ok(files)
+}
+
+/// Expand a glob pattern to `.parquet` files: matched files filtered by
+/// extension, sorted lexicographically, deduplicated.
+pub(crate) fn expand_glob(pattern: &str) -> Result<Vec<PathBuf>, InputError> {
+    let paths = glob::glob(pattern).map_err(|e| InputError::GlobPattern {
+        pattern: pattern.to_string(),
+        message: e.to_string(),
+    })?;
+    let mut files = Vec::new();
+    for entry in paths {
+        let path = entry.map_err(|e| InputError::Io(e.into_error()))?;
+        if path.is_file() && path.extension().is_some_and(|ext| ext == "parquet") {
+            files.push(path);
+        }
+    }
+    files.sort();
+    files.dedup();
+    Ok(files)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::{ArrayRef, Int64Array, StringArray};
+    use arrow_schema::DataType;
+    use parquet::arrow::ArrowWriter;
+    use parquet::file::properties::WriterProperties;
+    use std::fs::File;
+
+    /// Write a small parquet file with the given fields/columns and row
+    /// group size (None = single row group).
+    fn write_parquet(
+        path: &Path,
+        fields: Vec<Field>,
+        columns: Vec<ArrayRef>,
+        max_row_group_size: Option<usize>,
+    ) {
+        let schema = Arc::new(Schema::new(fields));
+        let batch = RecordBatch::try_new(schema.clone(), columns).unwrap();
+        let props = max_row_group_size.map(|n| {
+            WriterProperties::builder()
+                .set_max_row_group_size(n)
+                .build()
+        });
+        let file = File::create(path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, schema, props).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+    }
+
+    /// Standard two-column fixture: `id: Int64 (non-null)`, `name: Utf8`.
+    fn write_standard(path: &Path, ids: Vec<i64>, nullable_id: bool) {
+        let n = ids.len();
+        write_parquet(
+            path,
+            vec![
+                Field::new("id", DataType::Int64, nullable_id),
+                Field::new("name", DataType::Utf8, true),
+            ],
+            vec![
+                Arc::new(Int64Array::from(ids)),
+                Arc::new(StringArray::from(
+                    (0..n).map(|i| format!("r{i}")).collect::<Vec<_>>(),
+                )),
+            ],
+            None,
+        );
+    }
+
+    fn tmpdir() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    // --- resolution ---------------------------------------------------------
+
+    #[test]
+    fn resolve_existing_file_is_single() {
+        let dir = tmpdir();
+        let f = dir.path().join("a.parquet");
+        write_standard(&f, vec![1, 2], false);
+        let src = ConvertSource::resolve(f.to_str().unwrap()).unwrap();
+        assert!(matches!(src, ConvertSource::Single(_)));
+        assert_eq!(src.display_name(), f.display().to_string());
+        assert_eq!(src.parts().len(), 1);
+    }
+
+    #[test]
+    fn resolve_directory_recursive_sorted_multi() {
+        let dir = tmpdir();
+        let sub = dir.path().join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        write_standard(&dir.path().join("b.parquet"), vec![1], false);
+        write_standard(&sub.join("a.parquet"), vec![2], false);
+        std::fs::write(dir.path().join("readme.txt"), "x").unwrap();
+
+        let src = ConvertSource::resolve(dir.path().to_str().unwrap()).unwrap();
+        let ConvertSource::Multi(m) = &src else {
+            panic!("directory with 2 parquet files must resolve to Multi");
+        };
+        assert_eq!(m.parts.len(), 2);
+        // Lexicographic: "b.parquet" < "sub/a.parquet".
+        assert!(src.parts()[0].display_name().ends_with("b.parquet"));
+        assert!(src.parts()[1].display_name().ends_with("a.parquet"));
+        assert!(src.display_name().contains("(2 partitions)"));
+    }
+
+    #[test]
+    fn list_parquet_files_skips_hidden_and_success_markers() {
+        let dir = tmpdir();
+        write_standard(&dir.path().join("part-0.parquet"), vec![1], false);
+        write_standard(&dir.path().join("part-1.parquet"), vec![2], false);
+        // Markers and hidden files/dirs must be skipped.
+        std::fs::write(dir.path().join("_SUCCESS"), "").unwrap();
+        write_standard(&dir.path().join("_stale.parquet"), vec![9], false);
+        write_standard(&dir.path().join(".hidden.parquet"), vec![9], false);
+        let hidden_dir = dir.path().join("_temporary");
+        std::fs::create_dir(&hidden_dir).unwrap();
+        write_standard(&hidden_dir.join("x.parquet"), vec![9], false);
+
+        let files = list_parquet_files(dir.path()).unwrap();
+        assert_eq!(files.len(), 2, "only visible .parquet files: {files:?}");
+        assert!(files.windows(2).all(|w| w[0] <= w[1]), "sorted: {files:?}");
+        assert!(files[0].ends_with("part-0.parquet"));
+        assert!(files[1].ends_with("part-1.parquet"));
+    }
+
+    #[test]
+    fn resolve_empty_directory_errors_naming_input() {
+        let dir = tmpdir();
+        std::fs::write(dir.path().join("_SUCCESS"), "").unwrap();
+        let err = ConvertSource::resolve(dir.path().to_str().unwrap()).unwrap_err();
+        match err {
+            InputError::NoParquetInputs { input } => {
+                assert_eq!(input, dir.path().to_str().unwrap());
+            }
+            other => panic!("expected NoParquetInputs, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_glob_sorted_dedup_and_single_collapse() {
+        let dir = tmpdir();
+        write_standard(&dir.path().join("p2.parquet"), vec![1], false);
+        write_standard(&dir.path().join("p1.parquet"), vec![2], false);
+        std::fs::write(dir.path().join("p3.txt"), "x").unwrap();
+
+        let pattern = format!("{}/p*.parquet", dir.path().display());
+        let files = expand_glob(&pattern).unwrap();
+        assert_eq!(files.len(), 2);
+        assert!(files[0].ends_with("p1.parquet"));
+        assert!(files[1].ends_with("p2.parquet"));
+
+        let src = ConvertSource::resolve(&pattern).unwrap();
+        assert!(matches!(src, ConvertSource::Multi(_)));
+
+        // A single-match glob collapses to Single.
+        let single = format!("{}/p1*.parquet", dir.path().display());
+        let src = ConvertSource::resolve(&single).unwrap();
+        assert!(matches!(src, ConvertSource::Single(_)));
+
+        // A no-match glob errors, naming the pattern.
+        let none = format!("{}/zzz*.parquet", dir.path().display());
+        let err = ConvertSource::resolve(&none).unwrap_err();
+        assert!(matches!(err, InputError::NoParquetInputs { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn resolve_remote_prefix_rejected() {
+        for url in [
+            "s3://bucket/dataset/",
+            "s3://bucket/dataset",
+            "https://example.com/data/",
+            "gs://bucket/prefix",
+        ] {
+            let err = ConvertSource::resolve(url).unwrap_err();
+            assert!(
+                matches!(err, InputError::RemotePrefixUnsupported { .. }),
+                "{url} → {err:?}"
+            );
+        }
+    }
+
+    // --- compatibility validation -------------------------------------------
+
+    #[test]
+    fn schema_mismatch_names_offending_partition() {
+        let dir = tmpdir();
+        write_standard(&dir.path().join("a.parquet"), vec![1], false);
+        // Different column name in the second partition.
+        write_parquet(
+            &dir.path().join("b.parquet"),
+            vec![
+                Field::new("id2", DataType::Int64, false),
+                Field::new("name", DataType::Utf8, true),
+            ],
+            vec![
+                Arc::new(Int64Array::from(vec![1i64])),
+                Arc::new(StringArray::from(vec!["x"])),
+            ],
+            None,
+        );
+        let err = ConvertSource::resolve(dir.path().to_str().unwrap()).unwrap_err();
+        match err {
+            InputError::IncompatiblePartition {
+                first,
+                offender,
+                detail,
+            } => {
+                assert!(first.ends_with("a.parquet"), "first: {first}");
+                assert!(offender.ends_with("b.parquet"), "offender: {offender}");
+                assert!(detail.contains("id2") || detail.contains("id"), "{detail}");
+            }
+            other => panic!("expected IncompatiblePartition, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn type_mismatch_rejected() {
+        let dir = tmpdir();
+        write_standard(&dir.path().join("a.parquet"), vec![1], false);
+        write_parquet(
+            &dir.path().join("b.parquet"),
+            vec![
+                Field::new("id", DataType::Utf8, false), // Int64 in part a
+                Field::new("name", DataType::Utf8, true),
+            ],
+            vec![
+                Arc::new(StringArray::from(vec!["1"])),
+                Arc::new(StringArray::from(vec!["x"])),
+            ],
+            None,
+        );
+        let err = ConvertSource::resolve(dir.path().to_str().unwrap()).unwrap_err();
+        assert!(
+            matches!(err, InputError::IncompatiblePartition { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn nullability_difference_unions_to_nullable() {
+        let dir = tmpdir();
+        write_standard(&dir.path().join("a.parquet"), vec![1], false); // id non-null
+        write_standard(&dir.path().join("b.parquet"), vec![2], true); // id nullable
+        let src = ConvertSource::resolve(dir.path().to_str().unwrap()).unwrap();
+        let schema = src.schema().unwrap();
+        let id = schema.field_with_name("id").unwrap();
+        assert!(
+            id.is_nullable(),
+            "any-nullable must union to nullable: {schema:?}"
+        );
+    }
+
+    // --- streaming ------------------------------------------------------------
+
+    /// Row `id`s seen across the whole stream, in order.
+    fn stream_ids(src: &ConvertSource, plan: &ReadPlan<'_>) -> Vec<i64> {
+        let mut out = Vec::new();
+        for batch in src.open_stream(plan).unwrap() {
+            let batch = batch.unwrap();
+            let ids = batch
+                .column(batch.schema().index_of("id").unwrap())
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .clone();
+            out.extend(ids.values().iter().copied());
+        }
+        out
+    }
+
+    #[test]
+    fn stream_concatenates_parts_in_order() {
+        let dir = tmpdir();
+        write_standard(&dir.path().join("p0.parquet"), vec![0, 1, 2], false);
+        write_standard(&dir.path().join("p1.parquet"), vec![3, 4], false);
+        write_standard(&dir.path().join("p2.parquet"), vec![5], false);
+        let src = ConvertSource::resolve(dir.path().to_str().unwrap()).unwrap();
+        let plan = ReadPlan {
+            batch_size: 2,
+            projection: None,
+            row_groups: None,
+        };
+        assert_eq!(stream_ids(&src, &plan), vec![0, 1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn stream_skips_zero_row_partition() {
+        let dir = tmpdir();
+        write_standard(&dir.path().join("p0.parquet"), vec![0, 1], false);
+        write_standard(&dir.path().join("p1.parquet"), vec![], false); // 0 rows
+        write_standard(&dir.path().join("p2.parquet"), vec![2, 3], false);
+        let src = ConvertSource::resolve(dir.path().to_str().unwrap()).unwrap();
+        let plan = ReadPlan {
+            batch_size: 1024,
+            projection: None,
+            row_groups: None,
+        };
+        assert_eq!(stream_ids(&src, &plan), vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn stream_honors_per_part_row_group_selection() {
+        let dir = tmpdir();
+        // Two row groups per part (max_row_group_size = 2, 4 rows each).
+        let f0 = dir.path().join("p0.parquet");
+        let f1 = dir.path().join("p1.parquet");
+        for (f, base) in [(&f0, 0i64), (&f1, 10i64)] {
+            write_parquet(
+                f,
+                vec![Field::new("id", DataType::Int64, false)],
+                vec![Arc::new(Int64Array::from(vec![
+                    base,
+                    base + 1,
+                    base + 2,
+                    base + 3,
+                ]))],
+                Some(2),
+            );
+        }
+        let src = ConvertSource::resolve(dir.path().to_str().unwrap()).unwrap();
+        assert_eq!(src.num_row_groups_total().unwrap(), 4);
+
+        // Part 0: skip entirely (empty selection); part 1: second group only.
+        let sel = RowGroupSelection::from_parts(vec![vec![], vec![1]]);
+        assert_eq!(sel.total_selected(), 1);
+        let plan = ReadPlan {
+            batch_size: 1024,
+            projection: None,
+            row_groups: Some(&sel),
+        };
+        assert_eq!(stream_ids(&src, &plan), vec![12, 13]);
+
+        // selected_input_bytes = the one selected group's compressed size.
+        let bytes = src.selected_input_bytes(&sel).unwrap();
+        assert!(bytes > 0);
+        let all = RowGroupSelection::from_parts(vec![vec![0, 1], vec![0, 1]]);
+        assert!(src.selected_input_bytes(&all).unwrap() > bytes);
+    }
+
+    #[test]
+    fn stream_projection_applies_to_every_part() {
+        let dir = tmpdir();
+        write_standard(&dir.path().join("p0.parquet"), vec![0], false);
+        write_standard(&dir.path().join("p1.parquet"), vec![1], false);
+        let src = ConvertSource::resolve(dir.path().to_str().unwrap()).unwrap();
+        let cols = [0usize]; // id only
+        let plan = ReadPlan {
+            batch_size: 8,
+            projection: Some(&cols),
+            row_groups: None,
+        };
+        for batch in src.open_stream(&plan).unwrap() {
+            let batch = batch.unwrap();
+            assert_eq!(batch.num_columns(), 1);
+            assert_eq!(batch.schema().field(0).name(), "id");
+        }
+    }
+
+    // --- Send (the pipeline moves streams into reader threads) ---------------
+
+    #[test]
+    fn source_stream_is_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<SourceStream<'static>>();
+        // Scoped reader threads capture &ConvertSource.
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<ConvertSource>();
+    }
+}

--- a/crates/core/src/input_set.rs
+++ b/crates/core/src/input_set.rs
@@ -42,16 +42,53 @@ use parquet::arrow::arrow_reader::ParquetRecordBatchReader;
 use parquet::arrow::ProjectionMask;
 use parquet::file::metadata::{KeyValue, ParquetMetaData};
 
-use crate::input::{is_remote_scheme, url_scheme, FetchStats, InputError, InputSource};
+#[cfg(feature = "remote")]
+use crate::input::is_remote_scheme;
+use crate::input::{url_scheme, FetchStats, InputError, InputSource};
 
 /// A resolved conversion input: one parquet file/object, or an ordered set
 /// of local parquet partitions read as one logical dataset.
 #[derive(Debug)]
 pub enum ConvertSource {
     /// A single parquet file or remote object (the historical input shape).
-    Single(InputSource),
+    Single(SingleSource),
     /// An ordered, validated set of local parquet partitions.
     Multi(MultiSource),
+}
+
+/// One parquet file/object plus its lazily cached footer metadata, so the
+/// header phase's accessors (schema, kv metadata, row-group counts,
+/// selection) parse the footer ONCE — matching the pre-v0.7 single-open
+/// header cost.
+#[derive(Debug)]
+pub struct SingleSource {
+    source: InputSource,
+    meta: std::sync::OnceLock<PartMeta>,
+}
+
+impl SingleSource {
+    fn new(source: InputSource) -> Self {
+        SingleSource {
+            source,
+            meta: std::sync::OnceLock::new(),
+        }
+    }
+
+    /// The wrapped input.
+    pub fn input(&self) -> &InputSource {
+        &self.source
+    }
+
+    /// Footer metadata, parsed on first access and cached.
+    fn meta(&self) -> Result<&PartMeta, InputError> {
+        if let Some(m) = self.meta.get() {
+            return Ok(m);
+        }
+        let m = load_part_meta(&self.source)?;
+        // A concurrent load may have won the race; either copy is
+        // equivalent (same footer).
+        Ok(self.meta.get_or_init(|| m))
+    }
 }
 
 /// Footer-derived metadata of one partition.
@@ -134,7 +171,7 @@ pub struct SourceStream<'a> {
 impl ConvertSource {
     /// Wrap an already-constructed [`InputSource`] (single file/object).
     pub fn single(source: InputSource) -> Self {
-        ConvertSource::Single(source)
+        ConvertSource::Single(SingleSource::new(source))
     }
 
     /// Resolve a CLI-style input string:
@@ -144,29 +181,40 @@ impl ConvertSource {
     ///   (sorted; `_`/`.`-prefixed basenames such as `_SUCCESS` skipped);
     /// - string containing glob metacharacters (`*?[`) → glob expansion,
     ///   filtered to `.parquet` files, sorted, deduplicated;
-    /// - remote URL ending in `.parquet` → `Single` (unchanged);
-    /// - remote prefix → [`InputError::RemotePrefixUnsupported`] (for now);
+    /// - remote single-object URL (no trailing slash — including
+    ///   extension-less presigned/API URLs) → `Single` (unchanged);
+    /// - remote prefix (path ending `/`) →
+    ///   [`InputError::RemotePrefixUnsupported`] when the `remote` feature
+    ///   is on (for now); without the feature, the standard
+    ///   [`InputError::RemoteDisabled`] as before;
     /// - a single resolved partition collapses to `Single`;
     /// - an empty directory/glob result → [`InputError::NoParquetInputs`].
     pub fn resolve(input: &str) -> Result<Self, InputError> {
-        if let Some(scheme) = url_scheme(input) {
-            if !scheme.eq_ignore_ascii_case("file")
-                && is_remote_scheme(scheme)
-                && !remote_is_parquet_object(input)
+        if let Some(_scheme) = url_scheme(input) {
+            // A remote *prefix* ("directory", trailing `/`) is recognized
+            // only when remote support is compiled in; without the feature
+            // every remote URL fails with the standard `RemoteDisabled`
+            // error exactly as before. Extension-less non-slash URLs
+            // (presigned / API endpoints that serve parquet) are single
+            // objects, matching pre-v0.7 behavior.
+            #[cfg(feature = "remote")]
+            if !_scheme.eq_ignore_ascii_case("file")
+                && is_remote_scheme(_scheme)
+                && remote_url_is_prefix(input)
             {
                 return Err(InputError::RemotePrefixUnsupported {
                     url: input.to_string(),
                 });
             }
-            // `file://` maps to a local path, remote `.parquet` objects stay
-            // single, unsupported schemes get the standard error — all
-            // exactly as before.
-            return Ok(ConvertSource::Single(InputSource::from_str_input(input)?));
+            // `file://` maps to a local path, remote objects stay single,
+            // unsupported schemes get the standard error — all exactly as
+            // before.
+            return Ok(ConvertSource::single(InputSource::from_str_input(input)?));
         }
         let path = Path::new(input);
         if path.is_file() {
             // Existing local file: byte-identical behavior to today.
-            return Ok(ConvertSource::Single(InputSource::Local(
+            return Ok(ConvertSource::single(InputSource::Local(
                 path.to_path_buf(),
             )));
         }
@@ -180,7 +228,7 @@ impl ConvertSource {
         }
         // Nonexistent plain path: keep today's behavior (the io error
         // surfaces at open time).
-        Ok(ConvertSource::Single(InputSource::Local(
+        Ok(ConvertSource::single(InputSource::Local(
             path.to_path_buf(),
         )))
     }
@@ -191,7 +239,7 @@ impl ConvertSource {
             0 => Err(InputError::NoParquetInputs {
                 input: input.to_string(),
             }),
-            1 => Ok(ConvertSource::Single(InputSource::Local(files.remove(0)))),
+            1 => Ok(ConvertSource::single(InputSource::Local(files.remove(0)))),
             _ => Ok(ConvertSource::Multi(MultiSource::from_local_files(
                 input.to_string(),
                 files,
@@ -204,14 +252,14 @@ impl ConvertSource {
     pub fn resolve_path(path: &Path) -> Result<Self, InputError> {
         match path.to_str() {
             Some(s) => Self::resolve(s),
-            None => Ok(ConvertSource::Single(InputSource::from_path(path)?)),
+            None => Ok(ConvertSource::single(InputSource::from_path(path)?)),
         }
     }
 
     /// The underlying parts, in read order (a single source is one part).
     pub fn parts(&self) -> &[InputSource] {
         match self {
-            ConvertSource::Single(s) => std::slice::from_ref(s),
+            ConvertSource::Single(s) => std::slice::from_ref(s.input()),
             ConvertSource::Multi(m) => &m.parts,
         }
     }
@@ -233,7 +281,7 @@ impl ConvertSource {
     /// `"<root> (N partitions)"` for a multi source.
     pub fn display_name(&self) -> String {
         match self {
-            ConvertSource::Single(s) => s.display_name(),
+            ConvertSource::Single(s) => s.input().display_name(),
             ConvertSource::Multi(m) => {
                 format!("{} ({} partitions)", m.root, m.parts.len())
             }
@@ -244,7 +292,7 @@ impl ConvertSource {
     /// validated union schema (nullability OR-ed across parts).
     pub fn schema(&self) -> Result<SchemaRef, InputError> {
         match self {
-            ConvertSource::Single(s) => Ok(load_part_meta(s)?.schema),
+            ConvertSource::Single(s) => Ok(s.meta()?.schema.clone()),
             ConvertSource::Multi(m) => Ok(m.schema.clone()),
         }
     }
@@ -253,7 +301,8 @@ impl ConvertSource {
     /// for CRS detection; construction validated all parts agree).
     pub fn key_value_metadata(&self) -> Result<Option<Vec<KeyValue>>, InputError> {
         match self {
-            ConvertSource::Single(s) => Ok(load_part_meta(s)?
+            ConvertSource::Single(s) => Ok(s
+                .meta()?
                 .parquet
                 .file_metadata()
                 .key_value_metadata()
@@ -354,7 +403,9 @@ impl ConvertSource {
     /// construction), loaded on demand for `Single`.
     fn metas(&self) -> Result<std::borrow::Cow<'_, [PartMeta]>, InputError> {
         match self {
-            ConvertSource::Single(s) => Ok(std::borrow::Cow::Owned(vec![load_part_meta(s)?])),
+            ConvertSource::Single(s) => {
+                Ok(std::borrow::Cow::Borrowed(std::slice::from_ref(s.meta()?)))
+            }
             ConvertSource::Multi(m) => Ok(std::borrow::Cow::Borrowed(&m.metas)),
         }
     }
@@ -391,13 +442,25 @@ impl MultiSource {
         // The reference CRS: `Ok(crs)` per detect_crs_from_kv, `None` for an
         // unsupported/undetectable CRS. Parts must AGREE; supportedness
         // itself is enforced by the pipeline (against part 0), so a set
-        // that consistently carries an unsupported CRS still errors with
+        // that consistently carries one unsupported CRS still errors with
         // the standard UnsupportedCrs message.
         let crs_of = |m: &PartMeta| {
             crate::overview::convert::detect_crs_from_kv(
                 m.parquet.file_metadata().key_value_metadata(),
             )
             .ok()
+        };
+        // Raw CRS descriptor from the `geo` metadata: disambiguates two
+        // *different* unsupported CRSs, which both detect to `None` and
+        // would otherwise "agree" here only to error later naming just
+        // part 0's CRS.
+        let raw_crs_of = |m: &PartMeta| -> String {
+            crate::quality::crs_info_from_kv_metadata(
+                m.parquet.file_metadata().key_value_metadata(),
+            )
+            .ok()
+            .and_then(|info| info.identifier.or(info.name))
+            .unwrap_or_else(|| "unknown".to_string())
         };
         let first_crs = crs_of(&metas[0]);
 
@@ -411,9 +474,23 @@ impl MultiSource {
             let crs = crs_of(meta);
             if crs != first_crs {
                 return Err(incompatible(format!(
-                    "CRS mismatch: partition detects {crs:?} but the first partition \
-                     detects {first_crs:?} (all partitions must share one CRS)"
+                    "CRS mismatch: partition declares {:?} but the first partition \
+                     declares {:?} (all partitions must share one CRS)",
+                    raw_crs_of(meta),
+                    raw_crs_of(&metas[0]),
                 )));
+            }
+            if crs.is_none() {
+                // Both undetectable: still require the RAW declarations to
+                // agree, so the eventual UnsupportedCrs error is truthful.
+                let (a, b) = (raw_crs_of(&metas[0]), raw_crs_of(meta));
+                if a != b {
+                    return Err(incompatible(format!(
+                        "CRS mismatch: partition declares {b:?} but the first \
+                         partition declares {a:?} (all partitions must share \
+                         one CRS)"
+                    )));
+                }
             }
         }
 
@@ -459,12 +536,56 @@ fn validate_schema_shape(first: &Schema, other: &Schema) -> Result<(), String> {
         if f0.metadata() != fi.metadata() {
             return Err(format!(
                 "column {:?} carries different field (extension) metadata than \
-                 the first partition — geometry encoding/CRS metadata must match",
-                fi.name()
+                 the first partition ({}) — geometry encoding/CRS metadata must \
+                 match",
+                fi.name(),
+                describe_metadata_diff(f0.metadata(), fi.metadata())
             ));
         }
     }
     Ok(())
+}
+
+/// Human-readable first difference between two field-metadata maps:
+/// the mismatching key plus a truncated value diff (or which side is
+/// missing the key). Byte-exact comparison can false-reject cross-writer
+/// partitions (e.g. semantically equal PROJJSON serialized differently),
+/// so the error must show the user exactly what to reconcile.
+fn describe_metadata_diff(
+    first: &std::collections::HashMap<String, String>,
+    other: &std::collections::HashMap<String, String>,
+) -> String {
+    fn trunc(s: &str) -> String {
+        const MAX: usize = 80;
+        if s.chars().count() > MAX {
+            let cut: String = s.chars().take(MAX).collect();
+            format!("{cut:?}…")
+        } else {
+            format!("{s:?}")
+        }
+    }
+    let mut keys: Vec<&String> = first.keys().chain(other.keys()).collect();
+    keys.sort();
+    keys.dedup();
+    for key in keys {
+        match (first.get(key), other.get(key)) {
+            (Some(a), Some(b)) if a != b => {
+                return format!(
+                    "key {key:?}: first partition has {} but this partition has {}",
+                    trunc(a),
+                    trunc(b)
+                );
+            }
+            (Some(_), None) => {
+                return format!("key {key:?} is present only in the first partition");
+            }
+            (None, Some(_)) => {
+                return format!("key {key:?} is present only in this partition");
+            }
+            _ => {}
+        }
+    }
+    "maps differ".to_string()
 }
 
 /// Partition 0's schema with nullability OR-ed across all parts
@@ -558,12 +679,17 @@ fn has_glob_meta(input: &str) -> bool {
     input.contains(['*', '?', '['])
 }
 
-/// Whether a remote URL names a single `.parquet` object (query string and
-/// fragment ignored; trailing `/` means prefix).
-fn remote_is_parquet_object(url: &str) -> bool {
+/// Whether a remote URL names a *prefix* ("directory"): its path component
+/// — query string and fragment stripped — ends with `/`. Everything else,
+/// including extension-less presigned/API URLs that serve parquet, is a
+/// single object (the pre-v0.7 classification).
+// Used by `resolve` only when remote support is compiled in; the pure
+// classification is unit-tested under every feature set.
+#[cfg_attr(not(feature = "remote"), allow(dead_code))]
+fn remote_url_is_prefix(url: &str) -> bool {
     let no_fragment = url.split('#').next().unwrap_or(url);
     let no_query = no_fragment.split('?').next().unwrap_or(no_fragment);
-    !no_query.ends_with('/') && no_query.to_ascii_lowercase().ends_with(".parquet")
+    no_query.ends_with('/')
 }
 
 /// Recursively collect `.parquet` files under `dir`, sorted
@@ -760,17 +886,60 @@ mod tests {
         assert!(matches!(err, InputError::NoParquetInputs { .. }), "{err:?}");
     }
 
+    /// Pure prefix classification: ONLY a trailing-slash path is a prefix.
+    /// Extension-less non-slash URLs (presigned / API download endpoints
+    /// that serve parquet) must stay single objects, as on main.
+    #[test]
+    fn remote_prefix_is_trailing_slash_only() {
+        assert!(remote_url_is_prefix("s3://bucket/dataset/"));
+        assert!(remote_url_is_prefix("gs://bucket/prefix/"));
+        assert!(remote_url_is_prefix("https://example.com/data/?list=1"));
+        assert!(remote_url_is_prefix("https://example.com/data/#frag"));
+        assert!(!remote_url_is_prefix("s3://bucket/key.parquet"));
+        assert!(!remote_url_is_prefix(
+            "https://h/k.parquet?X-Amz-Signature=abc"
+        ));
+        assert!(!remote_url_is_prefix(
+            "https://host/api/datasets/42/download"
+        ));
+        assert!(!remote_url_is_prefix("s3://bucket/dataset"));
+    }
+
+    /// With the `remote` feature compiled in, only trailing-slash URLs are
+    /// rejected as prefixes (before any network touch); everything else
+    /// proceeds to the single-object path.
+    #[cfg(feature = "remote")]
     #[test]
     fn resolve_remote_prefix_rejected() {
         for url in [
             "s3://bucket/dataset/",
-            "s3://bucket/dataset",
             "https://example.com/data/",
-            "gs://bucket/prefix",
+            "gs://bucket/prefix/",
         ] {
             let err = ConvertSource::resolve(url).unwrap_err();
             assert!(
                 matches!(err, InputError::RemotePrefixUnsupported { .. }),
+                "{url} → {err:?}"
+            );
+        }
+    }
+
+    /// Without the `remote` feature every remote URL — prefix-shaped or
+    /// not — keeps main's behavior: `RemoteDisabled`, never the misleading
+    /// "prefix listing coming later" message. An extension-less URL
+    /// reaching `RemoteDisabled` also proves it was classified as a single
+    /// object (the prefix arm would have returned earlier).
+    #[cfg(not(feature = "remote"))]
+    #[test]
+    fn remote_disabled_behavior_unchanged() {
+        for url in [
+            "s3://bucket/prefix/",
+            "s3://bucket/key.parquet",
+            "https://host/api/datasets/42/download",
+        ] {
+            let err = ConvertSource::resolve(url).unwrap_err();
+            assert!(
+                matches!(err, InputError::RemoteDisabled(_)),
                 "{url} → {err:?}"
             );
         }
@@ -831,6 +1000,81 @@ mod tests {
             matches!(err, InputError::IncompatiblePartition { .. }),
             "{err:?}"
         );
+    }
+
+    /// Two partitions with *different unsupported* CRSs must be rejected at
+    /// set-construction time (naming both raw values), not "agree on
+    /// undetectable" and error later with only part 0's CRS.
+    #[test]
+    fn different_unsupported_crs_rejected_with_both_values() {
+        let dir = tmpdir();
+        let geo = |epsg: u32| {
+            format!(
+                r#"{{"version":"1.0.0","primary_column":"geometry","columns":{{"geometry":{{"crs":"EPSG:{epsg}"}}}}}}"#
+            )
+        };
+        for (file, epsg) in [("a.parquet", 32633u32), ("b.parquet", 32634u32)] {
+            let path = dir.path().join(file);
+            let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+            let batch = RecordBatch::try_new(
+                schema.clone(),
+                vec![Arc::new(Int64Array::from(vec![1i64])) as ArrayRef],
+            )
+            .unwrap();
+            let file = File::create(&path).unwrap();
+            let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
+            writer.write(&batch).unwrap();
+            writer.append_key_value_metadata(parquet::file::metadata::KeyValue::new(
+                "geo".to_string(),
+                geo(epsg),
+            ));
+            writer.close().unwrap();
+        }
+        let err = ConvertSource::resolve(dir.path().to_str().unwrap()).unwrap_err();
+        match err {
+            InputError::IncompatiblePartition {
+                offender, detail, ..
+            } => {
+                assert!(offender.ends_with("b.parquet"), "offender: {offender}");
+                assert!(
+                    detail.contains("32633") && detail.contains("32634"),
+                    "detail must name both raw CRS values: {detail}"
+                );
+            }
+            other => panic!("expected IncompatiblePartition, got {other:?}"),
+        }
+    }
+
+    /// A field-metadata mismatch must say WHAT differs: the key and a
+    /// (truncated) value diff, so cross-writer CRS/encoding differences are
+    /// actionable instead of a bare "metadata differs".
+    #[test]
+    fn metadata_mismatch_detail_names_key_and_values() {
+        let dir = tmpdir();
+        for (file, val) in [("a.parquet", "value-one"), ("b.parquet", "value-two")] {
+            let md: std::collections::HashMap<String, String> =
+                [("ARROW:extension:name".to_string(), val.to_string())].into();
+            write_parquet(
+                &dir.path().join(file),
+                vec![Field::new("id", DataType::Int64, false).with_metadata(md)],
+                vec![Arc::new(Int64Array::from(vec![1i64]))],
+                None,
+            );
+        }
+        let err = ConvertSource::resolve(dir.path().to_str().unwrap()).unwrap_err();
+        match err {
+            InputError::IncompatiblePartition { detail, .. } => {
+                assert!(
+                    detail.contains("ARROW:extension:name"),
+                    "detail must name the differing key: {detail}"
+                );
+                assert!(
+                    detail.contains("value-one") && detail.contains("value-two"),
+                    "detail must show both values: {detail}"
+                );
+            }
+            other => panic!("expected IncompatiblePartition, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -45,6 +45,7 @@ pub mod covering;
 pub mod decode;
 pub mod dedup;
 pub mod input;
+pub mod input_set;
 pub mod ioverlay_clip;
 pub mod mvt;
 pub mod overview;

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -46,6 +46,7 @@ use geoarrow_array::GeoArrowArray;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 
 use crate::input::InputSource;
+use crate::input_set::ConvertSource;
 use serde::Serialize;
 
 use crate::batch_processor::extract_geometries_opt_from_array;
@@ -670,6 +671,13 @@ pub enum ConvertError {
     /// `--accumulate-attribute` was supplied without `--cluster`.
     #[error("--accumulate-attribute requires --cluster")]
     AccumulateWithoutCluster,
+    /// Multi-partition input (directory / glob) reached the in-memory
+    /// reference pipeline, which reads through a single parquet builder.
+    #[error(
+        "multi-partition input requires the streaming pipeline; \
+         remove --no-streaming"
+    )]
+    MultiPartitionRequiresStreaming,
     /// An `--accumulate-attribute` column is not present in the input schema.
     #[error("accumulate-attribute column {name:?} not found in input schema")]
     AccumulateColumnMissing {
@@ -794,12 +802,20 @@ pub fn convert_to_overviews(
     output_path: impl AsRef<Path>,
     options: &ConvertOptions,
 ) -> Result<ConvertReport, ConvertError> {
-    // Local path or remote URL (s3://, https://, gs:// — #210): remote
-    // objects are read with byte-range requests through the same sync
-    // parquet plumbing, composing with the bbox row-group pruning below so
-    // pruned row groups are never downloaded at all.
-    let source = InputSource::from_path(input_path.as_ref())?;
-    convert_to_overviews_source(&source, output_path.as_ref(), options)
+    // Local path, remote URL (s3://, https://, gs:// — #210), or a
+    // multi-partition directory / glob pattern (v0.7): directories and
+    // globs resolve to an ordered, validated set of local partitions read
+    // as one logical dataset; remote objects are read with byte-range
+    // requests through the same sync parquet plumbing, composing with the
+    // bbox row-group pruning below so pruned row groups are never
+    // downloaded at all.
+    let source = ConvertSource::resolve_path(input_path.as_ref())?;
+    convert_to_overviews_source_strategy(
+        &source,
+        output_path.as_ref(),
+        options,
+        super::stream::Pass2Strategy::Pipelined,
+    )
 }
 
 /// [`convert_to_overviews`] over an already-resolved [`InputSource`] — the
@@ -810,8 +826,9 @@ pub fn convert_to_overviews_source(
     output_path: &Path,
     options: &ConvertOptions,
 ) -> Result<ConvertReport, ConvertError> {
+    // `InputSource` clones are cheap handles sharing caches and counters.
     convert_to_overviews_source_strategy(
-        source,
+        &ConvertSource::single(source.clone()),
         output_path,
         options,
         super::stream::Pass2Strategy::Pipelined,
@@ -830,7 +847,7 @@ pub(crate) fn convert_to_overviews_strategy(
     options: &ConvertOptions,
     strategy: super::stream::Pass2Strategy,
 ) -> Result<ConvertReport, ConvertError> {
-    let source = InputSource::from_path(input_path.as_ref())?;
+    let source = ConvertSource::resolve_path(input_path.as_ref())?;
     convert_to_overviews_source_strategy(&source, output_path.as_ref(), options, strategy)
 }
 
@@ -893,7 +910,7 @@ fn decode_and_filter_geometries(
 /// Runs the full option normalization (validation, cluster/accumulate checks,
 /// the partitioning-coalesce-inert rewrite) before dispatching.
 pub(crate) fn convert_to_overviews_source_strategy(
-    source: &InputSource,
+    source: &ConvertSource,
     output_path: &Path,
     options: &ConvertOptions,
     strategy: super::stream::Pass2Strategy,
@@ -941,6 +958,14 @@ pub(crate) fn convert_to_overviews_source_strategy(
         return super::stream::convert_streaming_strategy(source, output_path, options, strategy);
     }
 
+    // The in-memory reference path below predates multi-partition input
+    // (v0.7) and reads through one parquet builder; multi sources are
+    // streaming-only.
+    let source_single: &InputSource = match source {
+        ConvertSource::Single(s) => s,
+        ConvertSource::Multi(_) => return Err(ConvertError::MultiPartitionRequiresStreaming),
+    };
+
     let start = Instant::now();
 
     // A numeric sort key and a categorical class ranking are mutually
@@ -951,7 +976,7 @@ pub(crate) fn convert_to_overviews_source_strategy(
 
     // --- Read the input footer, preserving the full property schema. ---------
     // (For a remote source, the footer is range-fetched once and cached.)
-    let builder = source.open()?;
+    let builder = source_single.open()?;
     let input_schema = builder.schema().clone();
 
     // --- CRS detection + rejection (spec Q3) — footer metadata only. ---------
@@ -1345,8 +1370,9 @@ pub(crate) fn convert_to_overviews_source_strategy(
 }
 
 /// Snapshot (and `log::info!`) the remote fetch counters at the end of a
-/// conversion; `None` (and silent) for local inputs.
-pub(super) fn log_remote_fetch(source: &InputSource) -> Option<crate::input::FetchStats> {
+/// conversion; `None` (and silent) when no part of the input is remote.
+/// Multi-part sources report counters summed over their remote parts.
+pub(super) fn log_remote_fetch(source: &ConvertSource) -> Option<crate::input::FetchStats> {
     let stats = source.fetch_stats()?;
     let pct = if stats.object_size > 0 {
         100.0 * stats.bytes_fetched as f64 / stats.object_size as f64
@@ -1544,9 +1570,10 @@ pub(super) fn full_file_remote_warning(
 }
 
 /// Emit the #267 nudge for a full-file remote convert, if warranted. Thin
-/// logging wrapper over [`full_file_remote_warning`].
+/// logging wrapper over [`full_file_remote_warning`] (for a multi source,
+/// `object_size` is summed over the remote parts).
 pub(super) fn warn_full_file_remote(
-    source: &InputSource,
+    source: &ConvertSource,
     row_groups_read: usize,
     row_groups_total: usize,
 ) {
@@ -1635,7 +1662,7 @@ fn probe_available_space(dir: &Path) -> Option<u64> {
 /// probe; `spill_dir = None` means the process temp dir, exactly where the
 /// spill file would go.
 pub(super) fn warn_spill_space(
-    source: &InputSource,
+    source: &ConvertSource,
     estimated_spill_bytes: u64,
     spill_dir: Option<&Path>,
 ) {
@@ -2800,6 +2827,254 @@ mod tests {
             }
         }
         out
+    }
+
+    // --- multi-partition input (v0.7) ----------------------------------------
+
+    /// Write a valid GeoParquet partition holding `geoms[range]` with the
+    /// SAME global id/name/rank values [`write_input`] assigns, so the
+    /// concatenation of partitions equals the single file row-for-row.
+    /// `row_group_rows` caps rows per row group (None = single row group).
+    fn write_input_partition(
+        path: &Path,
+        geoms: &[Geometry<f64>],
+        range: std::ops::Range<usize>,
+        row_group_rows: Option<usize>,
+    ) {
+        use parquet::file::properties::WriterProperties;
+        let total = geoms.len();
+        let idx: Vec<usize> = range.collect();
+        let id = Int64Array::from(idx.iter().map(|&i| i as i64).collect::<Vec<_>>());
+        let name = StringArray::from(idx.iter().map(|&i| format!("f{i}")).collect::<Vec<_>>());
+        let rank = Float64Array::from(idx.iter().map(|&i| (total - i) as f64).collect::<Vec<_>>());
+        let part_geoms: Vec<Geometry<f64>> = idx.iter().map(|&i| geoms[i].clone()).collect();
+        let geom_arr = build_geometry_array(&part_geoms);
+        let geom_field = geom_arr.data_type().to_field("geometry", true);
+
+        let fields = vec![
+            Arc::new(Field::new("id", DataType::Int64, false)),
+            Arc::new(Field::new("name", DataType::Utf8, false)),
+            Arc::new(Field::new("rank", DataType::Float64, false)),
+            Arc::new(geom_field),
+        ];
+        let columns: Vec<Arc<dyn Array>> = vec![
+            Arc::new(id),
+            Arc::new(name),
+            Arc::new(rank),
+            geom_arr.to_array_ref(),
+        ];
+        let schema = Arc::new(Schema::new(fields));
+        let batch = RecordBatch::try_new(schema.clone(), columns).unwrap();
+
+        let gpq_options = GeoParquetWriterOptionsBuilder::default()
+            .set_encoding(GeoParquetWriterEncoding::WKB)
+            .set_generate_covering(true)
+            .build();
+        let mut encoder = GeoParquetRecordBatchEncoder::try_new(&schema, &gpq_options).unwrap();
+        let target_schema = encoder.target_schema();
+        let props = row_group_rows.map(|n| {
+            WriterProperties::builder()
+                .set_max_row_group_row_count(Some(n))
+                .build()
+        });
+        let file = std::fs::File::create(path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, target_schema, props).unwrap();
+        let encoded = encoder.encode_record_batch(&batch).unwrap();
+        writer.write(&encoded).unwrap();
+        writer.append_key_value_metadata(encoder.into_keyvalue().unwrap());
+        writer.close().unwrap();
+    }
+
+    /// Convert `input` and export to PMTiles; returns the archive bytes.
+    /// PMTiles export is byte-deterministic (unlike the overview parquet
+    /// footer), so multi/single equivalence is asserted on these bytes.
+    fn convert_and_export(input: &Path, workdir: &Path, opts: &ConvertOptions) -> Vec<u8> {
+        use crate::overview::export::{export_pmtiles, ExportOptions};
+        let stem = input
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .replace('.', "_");
+        let overview = workdir.join(format!("{stem}-overview.parquet"));
+        let pmtiles = workdir.join(format!("{stem}.pmtiles"));
+        convert_to_overviews(input, &overview, opts).unwrap();
+        export_pmtiles(&overview, &pmtiles, &ExportOptions::default()).unwrap();
+        std::fs::read(&pmtiles).unwrap()
+    }
+
+    fn multi_test_options() -> ConvertOptions {
+        ConvertOptions {
+            mode: Mode::Duplicating,
+            levels: LevelPlan::ZoomRange {
+                min_zoom: 2,
+                max_zoom: 8,
+            },
+            ..Default::default()
+        }
+    }
+
+    /// THE anchor: identical rows as (a) one parquet file and (b) three
+    /// partition files must produce byte-identical PMTiles. All passes see
+    /// the same rows in the same order (winner tables are keyed by global
+    /// row offset), so the outputs match exactly.
+    #[test]
+    fn multi_partition_output_matches_single_file() {
+        let geoms = synthetic_geometries();
+        let n = geoms.len();
+        let dir = tempfile::tempdir().unwrap();
+        let single = dir.path().join("single.parquet");
+        write_input_partition(&single, &geoms, 0..n, None);
+        let parts = dir.path().join("parts");
+        std::fs::create_dir(&parts).unwrap();
+        write_input_partition(&parts.join("part-000.parquet"), &geoms, 0..5, None);
+        write_input_partition(&parts.join("part-001.parquet"), &geoms, 5..9, None);
+        write_input_partition(&parts.join("part-002.parquet"), &geoms, 9..n, None);
+
+        let opts = multi_test_options();
+        let report =
+            convert_to_overviews(&parts, dir.path().join("probe-overview.parquet"), &opts).unwrap();
+        assert_eq!(report.input_features, n);
+        assert_eq!(report.row_groups_total, 3, "one row group per partition");
+
+        let pm_single = convert_and_export(&single, dir.path(), &opts);
+        let pm_multi = convert_and_export(&parts, dir.path(), &opts);
+        assert!(
+            pm_single == pm_multi,
+            "multi-partition output must be byte-identical to single-file \
+             ({} vs {} bytes)",
+            pm_single.len(),
+            pm_multi.len()
+        );
+    }
+
+    /// A 0-row partition mid-set is skipped cleanly: global row offsets are
+    /// unaffected and the output still matches the single-file equivalent.
+    #[test]
+    fn multi_partition_zero_row_part_matches_single_file() {
+        let geoms = synthetic_geometries();
+        let n = geoms.len();
+        let dir = tempfile::tempdir().unwrap();
+        let single = dir.path().join("single.parquet");
+        write_input_partition(&single, &geoms, 0..n, None);
+        let parts = dir.path().join("parts");
+        std::fs::create_dir(&parts).unwrap();
+        write_input_partition(&parts.join("part-000.parquet"), &geoms, 0..5, None);
+        write_input_partition(&parts.join("part-001.parquet"), &geoms, 5..5, None); // 0 rows
+        write_input_partition(&parts.join("part-002.parquet"), &geoms, 5..n, None);
+
+        let opts = multi_test_options();
+        let pm_single = convert_and_export(&single, dir.path(), &opts);
+        let pm_multi = convert_and_export(&parts, dir.path(), &opts);
+        assert!(
+            pm_single == pm_multi,
+            "0-row partition must not shift rows or offsets"
+        );
+    }
+
+    /// bbox row-group pruning (#102) composes with multi-partition input:
+    /// the selection is per part, offsets stay aligned across the pruned
+    /// read, and the output matches the single-file bbox extract.
+    #[test]
+    fn multi_partition_bbox_selection_matches_single_file() {
+        let geoms = synthetic_geometries();
+        let n = geoms.len();
+        let dir = tempfile::tempdir().unwrap();
+        let single = dir.path().join("single.parquet");
+        write_input_partition(&single, &geoms, 0..n, Some(2));
+        let parts = dir.path().join("parts");
+        std::fs::create_dir(&parts).unwrap();
+        write_input_partition(&parts.join("part-000.parquet"), &geoms, 0..6, Some(2));
+        write_input_partition(&parts.join("part-001.parquet"), &geoms, 6..10, Some(2));
+        write_input_partition(&parts.join("part-002.parquet"), &geoms, 10..n, Some(2));
+
+        // Points (x 0..25) and polygons (x -78..-15) only; the lines
+        // (x 40..96) fall outside, so their row groups prune away.
+        let bbox = Some([-100.0, -70.0, 30.0, 20.0]);
+        let opts = ConvertOptions {
+            bbox,
+            ..multi_test_options()
+        };
+        let report =
+            convert_to_overviews(&parts, dir.path().join("probe-overview.parquet"), &opts).unwrap();
+        assert!(
+            report.row_groups_read < report.row_groups_total,
+            "bbox must prune row groups across parts: {}/{}",
+            report.row_groups_read,
+            report.row_groups_total
+        );
+
+        let pm_single = convert_and_export(&single, dir.path(), &opts);
+        let pm_multi = convert_and_export(&parts, dir.path(), &opts);
+        assert!(
+            pm_single == pm_multi,
+            "per-part bbox selection must keep offsets aligned"
+        );
+    }
+
+    /// The in-memory reference path (`--no-streaming`) does not support
+    /// multi-partition input; it must fail with a clear error.
+    #[test]
+    fn multi_partition_requires_streaming_pipeline() {
+        let geoms = synthetic_geometries();
+        let dir = tempfile::tempdir().unwrap();
+        let parts = dir.path().join("parts");
+        std::fs::create_dir(&parts).unwrap();
+        write_input_partition(&parts.join("part-000.parquet"), &geoms, 0..5, None);
+        write_input_partition(
+            &parts.join("part-001.parquet"),
+            &geoms,
+            5..geoms.len(),
+            None,
+        );
+
+        let opts = ConvertOptions {
+            streaming: false,
+            ..multi_test_options()
+        };
+        let err = convert_to_overviews(&parts, dir.path().join("out.parquet"), &opts).unwrap_err();
+        assert!(
+            matches!(err, ConvertError::MultiPartitionRequiresStreaming),
+            "expected MultiPartitionRequiresStreaming, got {err:?}"
+        );
+    }
+
+    /// Partitions disagreeing on CRS are rejected at resolve time with an
+    /// error naming the offending file.
+    #[test]
+    fn multi_partition_crs_mismatch_rejected() {
+        let geoms = synthetic_geometries();
+        let dir = tempfile::tempdir().unwrap();
+        let parts = dir.path().join("parts");
+        std::fs::create_dir(&parts).unwrap();
+        write_input(&parts.join("a.parquet"), &geoms, false, None);
+        // EPSG:32633 in the second partition (also differs in geometry
+        // extension metadata — either check may fire; both name the file).
+        let projjson = serde_json::json!({
+            "type": "ProjectedCRS",
+            "name": "UTM zone 33N",
+            "id": { "authority": "EPSG", "code": 32633 }
+        });
+        let md = geoarrow::datatypes::Metadata::new(
+            geoarrow::datatypes::Crs::from_projjson(projjson),
+            None,
+        );
+        write_input(&parts.join("b.parquet"), &geoms, false, Some(md));
+
+        let err = convert_to_overviews(
+            &parts,
+            dir.path().join("out.parquet"),
+            &multi_test_options(),
+        )
+        .unwrap_err();
+        match err {
+            ConvertError::Input(crate::input::InputError::IncompatiblePartition {
+                offender,
+                ..
+            }) => {
+                assert!(offender.ends_with("b.parquet"), "offender: {offender}");
+            }
+            other => panic!("expected IncompatiblePartition, got {other:?}"),
+        }
     }
 
     // --- tests --------------------------------------------------------------

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -1370,7 +1370,7 @@ pub(super) fn log_remote_fetch(source: &InputSource) -> Option<crate::input::Fet
 /// Detect the input CRS from parsed parquet key-value metadata and map it to
 /// [`Crs`], rejecting anything that is not EPSG:4326 or EPSG:3857 (spec Q3).
 /// Metadata-only so remote inputs (#210) pay no extra footer fetch.
-pub(super) fn detect_crs_from_kv(
+pub(crate) fn detect_crs_from_kv(
     kv: Option<&Vec<parquet::file::metadata::KeyValue>>,
 ) -> Result<Crs, ConvertError> {
     let info = crate::quality::crs_info_from_kv_metadata(kv)?;
@@ -1440,7 +1440,7 @@ pub(super) fn bboxes_intersect(a: &[f64; 4], b: &[f64; 4]) -> bool {
 /// pages are touched. Row groups with missing/unparseable covering
 /// statistics are conservatively KEPT (graceful degradation — the exact
 /// per-feature bbox filter downstream guarantees correctness either way).
-pub(super) fn select_input_row_groups(
+pub(crate) fn select_input_row_groups(
     metadata: &parquet::file::metadata::ParquetMetaData,
     bbox_units: &[f64; 4],
 ) -> Vec<usize> {

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -962,7 +962,7 @@ pub(crate) fn convert_to_overviews_source_strategy(
     // (v0.7) and reads through one parquet builder; multi sources are
     // streaming-only.
     let source_single: &InputSource = match source {
-        ConvertSource::Single(s) => s,
+        ConvertSource::Single(s) => s.input(),
         ConvertSource::Multi(_) => return Err(ConvertError::MultiPartitionRequiresStreaming),
     };
 

--- a/crates/core/src/overview/pipeline.rs
+++ b/crates/core/src/overview/pipeline.rs
@@ -44,7 +44,7 @@ use crossbeam_channel::bounded;
 use rayon::prelude::*;
 use tempfile::NamedTempFile;
 
-use crate::input::InputSource;
+use crate::input_set::{ConvertSource, ReadPlan, RowGroupSelection};
 
 use super::convert::ConvertError;
 use super::level::{MemoryProfile, Mode};
@@ -176,9 +176,9 @@ pub(super) fn run_pass2_buffered(
     writer: &mut OverviewWriter<File>,
     ctxs: &[LevelStreamCtx<'_>],
     hints: &[usize],
-    source: &InputSource,
+    source: &ConvertSource,
     read_batch_size: usize,
-    selected_row_groups: Option<&[usize]>,
+    selected_row_groups: Option<&RowGroupSelection>,
     in_flight: usize,
     backing: SinkBacking,
     out_schema: &Schema,
@@ -196,106 +196,115 @@ pub(super) fn run_pass2_buffered(
     let mut rows = vec![0usize; num_levels];
     let mut verts = vec![0usize; num_levels];
 
-    // Build the single-pass reader here (bbox-selected row groups, #102 — the
-    // same selection both passes use, so global row indices stay aligned), then
-    // hand the owned reader to a dedicated reader thread. A synchronous Parquet
-    // reader driven from a dedicated thread (not the rayon pool) keeps reads
-    // from being head-of-line blocked behind compute work.
-    let mut builder = source.open()?.with_batch_size(read_batch_size.max(1));
-    if let Some(rgs) = selected_row_groups {
-        builder = builder.with_row_groups(rgs.to_vec());
-    }
-    let mut reader = builder.build()?;
+    // Build the single-pass stream here (per-part bbox-selected row groups,
+    // #102 — the same selection both passes use, so global row indices stay
+    // aligned), then hand it to a dedicated reader thread. A synchronous
+    // Parquet reader driven from a dedicated thread (not the rayon pool)
+    // keeps reads from being head-of-line blocked behind compute work. The
+    // stream borrows `source` (multi-partition sources open part i+1 lazily),
+    // so the reader runs on a scoped thread.
+    let mut reader = source.open_stream(&ReadPlan {
+        batch_size: read_batch_size.max(1),
+        projection: None,
+        row_groups: selected_row_groups,
+    })?;
 
     let (tx, rx) = bounded::<ReadMsg>(in_flight.max(1));
-    let reader_handle = std::thread::spawn(move || -> Result<(), ConvertError> {
-        let mut row_offset = 0usize;
-        loop {
-            let t_read = Instant::now();
-            match reader.next() {
-                None => break,
-                Some(Ok(batch)) => {
-                    let read_dur = t_read.elapsed();
-                    let offset = row_offset;
-                    row_offset += batch.num_rows();
-                    if tx
-                        .send(ReadMsg {
-                            row_offset: offset,
-                            batch,
-                            read_dur,
-                        })
-                        .is_err()
-                    {
-                        break; // consumer dropped the receiver (error path)
+    // Consumer state borrowed mutably by the in-scope consumer below.
+    let (rows_ref, verts_ref, sinks_ref) = (&mut rows, &mut verts, &mut sinks);
+    let timers_ref = &timers;
+    std::thread::scope(|scope| -> Result<(), ConvertError> {
+        let reader_handle = scope.spawn(move || -> Result<(), ConvertError> {
+            let mut row_offset = 0usize;
+            loop {
+                let t_read = Instant::now();
+                match reader.next() {
+                    None => break,
+                    Some(Ok(batch)) => {
+                        let read_dur = t_read.elapsed();
+                        let offset = row_offset;
+                        row_offset += batch.num_rows();
+                        if tx
+                            .send(ReadMsg {
+                                row_offset: offset,
+                                batch,
+                                read_dur,
+                            })
+                            .is_err()
+                        {
+                            break; // consumer dropped the receiver (error path)
+                        }
+                    }
+                    Some(Err(e)) => return Err(e.into()),
+                }
+            }
+            Ok(())
+        });
+
+        // Consumer: process batches in read order; parallelize within each
+        // batch. Because batches arrive in order and are appended before the
+        // next is pulled, each sink stays in input order without a reorder
+        // buffer.
+        //
+        // Cascading (#218, duplicating default): one call decodes the batch's
+        // member geometries once and folds each feature fine→coarse, so level
+        // k reuses level k+1's output instead of re-simplifying canonical
+        // geometry. Otherwise (cascade off, or partitioning where every
+        // feature lands on exactly one level) fan out per level as before.
+        let cascade = ctxs.first().is_some_and(|c| c.is_cascading_duplicating());
+        // Heartbeat (#242): a planet-scale pass 2 runs for minutes-to-hours;
+        // without this the phase is silent at info level. Time-based so small
+        // inputs stay quiet.
+        let mut last_progress = Instant::now();
+        let consume: Result<(), ConvertError> = (|| {
+            for msg in rx.iter() {
+                Pass2Timers::add_dur(timers_ref.read_cell(), msg.read_dur);
+                let batch = &msg.batch;
+                let row_offset = msg.row_offset;
+                let per_level: Vec<Option<(RecordBatch, usize)>> = if cascade {
+                    process_batch_cascade(batch, row_offset, ctxs, timers_ref)?
+                } else {
+                    let results: Vec<Result<Option<(RecordBatch, usize)>, ConvertError>> = (0
+                        ..num_levels)
+                        .into_par_iter()
+                        .map(|li| process_level_batch(batch, row_offset, &ctxs[li], timers_ref))
+                        .collect();
+                    let mut v = Vec::with_capacity(num_levels);
+                    for res in results {
+                        v.push(res?);
+                    }
+                    v
+                };
+                for (li, out) in per_level.into_iter().enumerate() {
+                    if let Some((out, v)) = out {
+                        rows_ref[li] += out.num_rows();
+                        verts_ref[li] += v;
+                        sinks_ref[li].push(out)?;
                     }
                 }
-                Some(Err(e)) => return Err(e.into()),
-            }
-        }
-        Ok(())
-    });
-
-    // Consumer: process batches in read order; parallelize within each batch.
-    // Because batches arrive in order and are appended before the next is
-    // pulled, each sink stays in input order without a reorder buffer.
-    //
-    // Cascading (#218, duplicating default): one call decodes the batch's
-    // member geometries once and folds each feature fine→coarse, so level k
-    // reuses level k+1's output instead of re-simplifying canonical
-    // geometry. Otherwise (cascade off, or partitioning where every feature
-    // lands on exactly one level) fan out per level as before.
-    let cascade = ctxs.first().is_some_and(|c| c.is_cascading_duplicating());
-    // Heartbeat (#242): a planet-scale pass 2 runs for minutes-to-hours;
-    // without this the phase is silent at info level. Time-based so small
-    // inputs stay quiet.
-    let mut last_progress = Instant::now();
-    let consume: Result<(), ConvertError> = (|| {
-        for msg in rx.iter() {
-            Pass2Timers::add_dur(timers.read_cell(), msg.read_dur);
-            let batch = &msg.batch;
-            let row_offset = msg.row_offset;
-            let per_level: Vec<Option<(RecordBatch, usize)>> = if cascade {
-                process_batch_cascade(batch, row_offset, ctxs, &timers)?
-            } else {
-                let results: Vec<Result<Option<(RecordBatch, usize)>, ConvertError>> = (0
-                    ..num_levels)
-                    .into_par_iter()
-                    .map(|li| process_level_batch(batch, row_offset, &ctxs[li], &timers))
-                    .collect();
-                let mut v = Vec::with_capacity(num_levels);
-                for res in results {
-                    v.push(res?);
-                }
-                v
-            };
-            for (li, out) in per_level.into_iter().enumerate() {
-                if let Some((out, v)) = out {
-                    rows[li] += out.num_rows();
-                    verts[li] += v;
-                    sinks[li].push(out)?;
+                if last_progress.elapsed().as_secs() >= 10 {
+                    last_progress = Instant::now();
+                    log::info!(
+                        "[convert] pass 2: {} input row(s) processed ({} output \
+                         row(s) buffered across {num_levels} level(s))",
+                        row_offset + batch.num_rows(),
+                        rows_ref.iter().sum::<usize>(),
+                    );
                 }
             }
-            if last_progress.elapsed().as_secs() >= 10 {
-                last_progress = Instant::now();
-                log::info!(
-                    "[convert] pass 2: {} input row(s) processed ({} output \
-                     row(s) buffered across {num_levels} level(s))",
-                    row_offset + batch.num_rows(),
-                    rows.iter().sum::<usize>(),
-                );
-            }
-        }
-        Ok(())
-    })();
-    drop(rx); // ensure the reader thread can stop if the consumer errored
+            Ok(())
+        })();
+        drop(rx); // ensure the reader thread can stop if the consumer errored
 
-    // Join the reader before propagating: a reader error is the more likely
-    // root cause and takes precedence over a downstream consume error.
-    match reader_handle.join() {
-        Ok(read_result) => read_result?,
-        Err(payload) => std::panic::resume_unwind(payload),
-    }
-    consume?;
+        // Join the reader before propagating: a reader error is the more
+        // likely root cause and takes precedence over a downstream consume
+        // error.
+        match reader_handle.join() {
+            Ok(read_result) => read_result?,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
+        consume
+    })?;
 
     // Drain each level's sink into the writer, in level order. An empty
     // buffered level is skipped and renumbered by the writer (#211); the

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -61,11 +61,10 @@ use arrow_schema::{DataType, Schema, SchemaRef};
 use arrow_select::take::take;
 use geo::Geometry;
 use geoarrow::array::from_arrow_array;
-use parquet::arrow::ProjectionMask;
 use rayon::prelude::*;
 
 use crate::batch_processor::{extract_geometries_from_array, extract_geometries_opt_from_array};
-use crate::input::InputSource;
+use crate::input_set::{ConvertSource, ReadPlan, RowGroupSelection};
 
 use super::assign::{apply_density_budget, assign_levels, AssignFeature, FeatureKind};
 use super::cluster::{build_cluster_tables, verify_sum_invariant, ClusterEntry, ClusterTables};
@@ -136,7 +135,7 @@ fn log_validation_skips(skips_before: u64) {
 }
 
 pub(crate) fn convert_streaming_strategy(
-    source: &InputSource,
+    source: &ConvertSource,
     output_path: &Path,
     options: &ConvertOptions,
     strategy: Pass2Strategy,
@@ -147,33 +146,35 @@ pub(crate) fn convert_streaming_strategy(
         return Err(ConvertError::RankingConflict);
     }
 
-    // Schema checks (level column, geometry column) — footer-only read.
+    // Schema checks (level column, geometry column) — footer-only reads.
     // (For a remote source, #210, the footer is range-fetched once here and
-    // cached across the passes below.)
-    let builder = source.open()?;
-    let input_schema: SchemaRef = builder.schema().clone();
+    // cached across the passes below. For a multi-partition source the
+    // schema is the validated union schema and the key-value metadata is
+    // partition 0's — construction proved all parts agree.)
+    let input_schema: SchemaRef = source.schema()?;
 
     // CRS detection + rejection (spec Q3) — footer metadata only.
-    let crs = super::convert::detect_crs_from_kv(
-        builder.metadata().file_metadata().key_value_metadata(),
-    )?;
+    let kv = source.key_value_metadata()?;
+    let crs = super::convert::detect_crs_from_kv(kv.as_ref())?;
 
     // Regional extract (#102): prune input row groups by bbox covering
     // statistics — footer metadata only, no data pages of skipped groups are
-    // ever read. Both passes read the SAME selection, so the global row
-    // indices addressing the winner tables stay aligned. Groups without
-    // stats are kept; the exact per-feature filter in pass 1 guarantees
-    // identical output either way.
-    let row_groups_total = builder.metadata().num_row_groups();
+    // ever read. The selection is PER PART and every pass reads the same
+    // selection in the same part order, so the global row indices addressing
+    // the winner tables stay aligned. Groups without stats are kept; the
+    // exact per-feature filter in pass 1 guarantees identical output either
+    // way.
+    let row_groups_total = source.num_row_groups_total()?;
     let bbox_units = options
         .bbox
         .map(|b| super::convert::bbox_to_crs_units(&b, crs));
-    let selected_row_groups: Option<Vec<usize>> = bbox_units
-        .as_ref()
-        .map(|bb| super::convert::select_input_row_groups(builder.metadata(), bb));
+    let selected_row_groups: Option<RowGroupSelection> = match bbox_units.as_ref() {
+        Some(bb) => Some(source.select_row_groups(bb)?),
+        None => None,
+    };
     let row_groups_read = selected_row_groups
         .as_ref()
-        .map_or(row_groups_total, Vec::len);
+        .map_or(row_groups_total, RowGroupSelection::total_selected);
     if selected_row_groups.is_some() {
         log::info!("bbox filter: reading {row_groups_read}/{row_groups_total} input row groups");
     }
@@ -182,15 +183,15 @@ pub(crate) fn convert_streaming_strategy(
     super::convert::warn_full_file_remote(source, row_groups_read, row_groups_total);
     // #272: preflight the spill volume. The disk spill (#219) grows to ≈ the
     // selected input bytes — known exactly here, the first moment after
-    // row-group selection — so compare it against the free space where the
-    // spill will live and warn up front (naming the dir and the shortfall)
-    // instead of silently degrading to network re-fetch mid-convert.
+    // row-group selection (summed per part for a multi source) — so compare
+    // it against the free space where the spill will live and warn up front
+    // (naming the dir and the shortfall) instead of silently degrading to
+    // network re-fetch mid-convert.
     super::convert::warn_spill_space(
         source,
-        crate::input::selected_compressed_bytes(builder.metadata(), selected_row_groups.as_deref()),
+        source.selected_input_bytes(selected_row_groups.as_ref())?,
         options.spill_dir.as_deref(),
     );
-    drop(builder);
 
     if input_schema
         .fields()
@@ -222,7 +223,7 @@ pub(crate) fn convert_streaming_strategy(
         geom_idx,
         options,
         &acc_cols,
-        selected_row_groups.as_deref(),
+        selected_row_groups.as_ref(),
         bbox_units.as_ref(),
     )?;
     if skipped_rows > 0 {
@@ -571,7 +572,7 @@ pub(crate) fn convert_streaming_strategy(
                     source,
                     options.read_batch_size,
                     options.in_flight_batches,
-                    selected_row_groups.as_deref(),
+                    selected_row_groups.as_ref(),
                     ctx,
                 )
             })
@@ -592,7 +593,7 @@ pub(crate) fn convert_streaming_strategy(
                     &hints[..n - 1],
                     source,
                     options.read_batch_size,
-                    selected_row_groups.as_deref(),
+                    selected_row_groups.as_ref(),
                     options.in_flight_batches,
                     backing,
                     &out_schema,
@@ -607,7 +608,7 @@ pub(crate) fn convert_streaming_strategy(
                 source,
                 options.read_batch_size,
                 options.in_flight_batches,
-                selected_row_groups.as_deref(),
+                selected_row_groups.as_ref(),
                 &ctxs[n - 1],
             )?);
             stats
@@ -874,12 +875,12 @@ struct Pass1Output {
 /// the per-spec source values (parallel to `acc_cols`). Memory: `O(read
 /// batch)` transient + `O(N)` small per-feature records.
 fn run_pass1(
-    source: &InputSource,
+    source: &ConvertSource,
     input_schema: &Schema,
     geom_idx: usize,
     options: &ConvertOptions,
     acc_cols: &[usize],
-    row_groups: Option<&[usize]>,
+    row_groups: Option<&RowGroupSelection>,
     bbox_units: Option<&[f64; 4]>,
 ) -> Result<Pass1Output, ConvertError> {
     let mut plan = build_rank_plan(input_schema, options)?;
@@ -903,17 +904,13 @@ fn run_pass1(
     // Original schema index → projected batch column index.
     let proj = |orig: usize| cols.binary_search(&orig).expect("projected column");
 
-    let mut builder = source.open()?;
-    let mask = ProjectionMask::roots(builder.parquet_schema(), cols.iter().copied());
     // Regional extract (#102): read only the bbox-selected row groups
-    // (identical selection in pass 2, keeping row indices aligned).
-    if let Some(rgs) = row_groups {
-        builder = builder.with_row_groups(rgs.to_vec());
-    }
-    let reader = builder
-        .with_projection(mask)
-        .with_batch_size(options.read_batch_size.max(1))
-        .build()?;
+    // (identical per-part selection in pass 2, keeping row indices aligned).
+    let reader = source.open_stream(&ReadPlan {
+        batch_size: options.read_batch_size.max(1),
+        projection: Some(&cols),
+        row_groups,
+    })?;
 
     let mut features: Vec<AssignFeature> = Vec::new();
     let mut num_rows = 0usize;
@@ -1245,10 +1242,10 @@ fn write_level_streaming(
     writer: &mut OverviewWriter<File>,
     level_idx: usize,
     hint: usize,
-    source: &InputSource,
+    source: &ConvertSource,
     read_batch_size: usize,
     in_flight: usize,
-    row_groups: Option<&[usize]>,
+    row_groups: Option<&RowGroupSelection>,
     ctx: &LevelStreamCtx<'_>,
 ) -> Result<(LevelWriteOutcome, usize, usize), ConvertError> {
     let rows = Cell::new(0usize);
@@ -1287,14 +1284,14 @@ fn write_level_streaming(
         // `&timers`, `row_groups`, the `usize`s) is `Copy`, so the outer
         // bindings — notably `timers`, read back after the scope — stay valid.
         let producer = scope.spawn(move || -> Result<(), ConvertError> {
-            let mut builder = source.open()?.with_batch_size(read_batch_size.max(1));
-            // Regional extract (#102): read the same bbox-selected row
-            // groups as pass 1, so the winner tables' global row indices
+            // Regional extract (#102): read the same per-part bbox-selected
+            // row groups as pass 1, so the winner tables' global row indices
             // line up.
-            if let Some(rgs) = row_groups {
-                builder = builder.with_row_groups(rgs.to_vec());
-            }
-            let mut reader = builder.build()?;
+            let mut reader = source.open_stream(&ReadPlan {
+                batch_size: read_batch_size.max(1),
+                projection: None,
+                row_groups,
+            })?;
             let mut row_offset = 0usize;
             // Heartbeat (#242): the finest level re-streams the whole
             // input; keep the operator informed on planet-scale files


### PR DESCRIPTION
Part of the **v0.7 multi-partition input** feature (PR-A of 3). Converts a *set* of GeoParquet files — a directory or a glob pattern — as one logical dataset:

```
gpq-tiles tiles data/buildings/ out.pmtiles
gpq-tiles overview 'data/part-*.parquet' out.parquet
```

## Design

The pipeline consumed its input at exactly four sites (header/footer read, pass-1 scan, pass-2 buffered read, canonical streamed level), all shaped *open → optional projection → optional row-group selection → iterate batches with a global row offset*. This PR abstracts that shape behind a new `crate::input_set` module:

- **`ConvertSource { Single(InputSource), Multi(MultiSource) }`** — `resolve()` maps an existing `.parquet` file or remote object URL to `Single` (byte-identical behavior to before), a directory to a recursive sorted `.parquet` collection (skipping `_SUCCESS` and `.`/`_`-hidden basenames), and a glob (`*?[`) to an expanded/sorted/deduped set. A single match collapses to `Single`; an empty result errors naming the input. Remote *prefixes* — **only** URLs whose path ends with `/` — return a clear "not yet supported, coming later in this release" error when the `remote` feature is on (PR-B wires them); extension-less non-slash URLs (presigned/API downloads that serve parquet) remain single objects, and with the feature off every remote URL keeps the standard `RemoteDisabled` error, both exactly as on main.
- **`MultiSource`** — footers loaded up front; every partition validated against partition 0: identical field names/types/order and field (extension) metadata; per-part CRS (via `detect_crs_from_kv`) must agree; nullability is unioned (any-nullable ⇒ nullable). Violations raise `InputError::IncompatiblePartition` naming the offending file.
- **`RowGroupSelection`** — per-part local row-group indices, the multi-file analogue of the single-file `selected_row_groups` bbox pruning (#102). Empty per-part selections skip the part without opening it.
- **`open_stream(ReadPlan { batch_size, projection, row_groups })`** — a `Send`, part-ordered batch iterator. Part *i + 1* opens lazily when part *i* is exhausted; on each transition the finished part's L1 read cache is released (`InputSource::release_read_cache` — remote spill + footer are kept), bounding resident memory to one part's working set.
- Accessors: union `schema()`, part-0 `key_value_metadata()`, summed `num_row_groups_total()`, per-part `select_row_groups(bbox)`, summed `fetch_stats()`, `display_name()` (`"<root> (N partitions)"`), and `selected_input_bytes()` (Σ compressed sizes — the hook for the #272 full-read guard).

## The invariant

**All passes must see the same rows in the same order** — winner tables are keyed by global row offset. `ConvertSource` guarantees it by construction: partitions are sorted once at resolve time and never reordered, every pass streams them in the same part order, and the per-part row-group selection is computed once and applied identically on every open. The anchor test converts identical rows as one file and as three partitions and asserts the exported PMTiles are **byte-identical** (export is byte-deterministic in this repo); 0-row mid-set partitions and per-part bbox pruning are covered the same way.

## Plumbing notes

- `convert_to_overviews` resolves through `ConvertSource`; the public `convert_to_overviews_source(&InputSource, …)` survives as a compat wrapper (`InputSource` is now `Clone` — cheap Arc handles for remote).
- The pass-2 reader thread moved from `std::thread::spawn` to `std::thread::scope` because the stream borrows the source (lazy part opens).
- The in-memory reference path (`--no-streaming`) rejects multi input with a dedicated `ConvertError::MultiPartitionRequiresStreaming`.
- `batch_processor::resolve_parquet_files` now delegates to the shared collection logic (callers unchanged); directory collection additionally skips `_SUCCESS`/hidden basenames.
- CLI: `tiles`/`overview` inputs pass through unchanged and gain dir/glob support via core; `validate`/`decode`/`export-pmtiles` keep single-file behavior (PR-C adds friendly rejections + glob-aware layer-name polish).

## Testing

TDD (red verified before each implementation step): 14 `input_set` unit tests (resolution, skip rules, glob, compat validation, nullability union, stream order, 0-row parts, per-part selection, projection, `Send`/`Sync` assertions) + 5 convert-level integration tests (byte-identical anchor, 0-row partition, per-part bbox, `--no-streaming` rejection, CRS-mismatch naming the offender). Regression: `overview::convert` (59), remote-feature (15), `input` (6), `batch_processor` (4) all green; `cargo check` clean for cli/python; `cargo clippy --workspace --all-targets --all-features` clean.

End-to-end with the real CLI: a duckdb-split 3-partition directory (with a `_SUCCESS` marker) and a quoted glob both convert; the directory's PMTiles is byte-identical (`cmp`) to the single-file conversion; `s3://bucket/prefix/` fails with the clear not-yet-supported error.

## Coming next

- **PR-B**: remote prefix listing (`s3://…/dataset/` → object listing → `MultiSource` over remote parts).
- **PR-C**: CLI polish — friendly rejections for `validate`/`decode`/`export-pmtiles`, glob layer-name derivation, docs.

(Not closing #16 — that is multi-*layer*, a different feature.)

## Review fixes (adversarial review round)

- **Remote URL classification** (major): a remote URL is a *prefix* only when its path ends with `/`; extension-less single-object URLs resolve as before, and the prefix check sits behind the `remote` feature gate so `RemoteDisabled` semantics are unchanged.
- **Set-level CRS validation**: two partitions with *different unsupported* CRSs are now rejected at construction with `IncompatiblePartition` naming both raw declared values (previously they "agreed on undetectable" and errored later naming only part 0's CRS).
- **Actionable metadata-mismatch errors**: `IncompatiblePartition` for field-metadata differences now names the mismatching key and shows a truncated value diff (the byte-exact comparison itself is unchanged in this PR).
- **Single-source footer caching**: `ConvertSource::Single` now wraps a `SingleSource` with a lazily cached footer, so the header phase parses a local footer once (was up to 4x).
- **#276 unification** (branch rebased onto main): `ConvertSource::selected_input_bytes` delegates per part to `input::selected_compressed_bytes` — one helper, not two — and the #272 spill-space preflight consumes the per-part sum; `set_spill_dir` applies to every part.

### Behavior note: `resolve_parquet_files` (second consumer)

`batch_processor::resolve_parquet_files` — also used by `quality.rs` (`check`) — now skips `_`/`.`-prefixed files **and** directories during directory collection (`_SUCCESS`, `.crc`, `_temporary/`, ...). Intentional Spark/Hive-marker semantics, shared with `ConvertSource` directory resolution; flagged here as a behavior change for that second consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
