### PR TITLE
feat(core): multi-partition input — remote prefix listing + --files-from (2/3)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -191,16 +191,27 @@ struct ExportPmtilesArgs {
 /// Arguments for `gpq-tiles overview`.
 #[derive(Parser, Debug)]
 struct OverviewArgs {
-    /// Input GeoParquet file (EPSG:4326 or EPSG:3857): a local path or a
-    /// remote URL (s3://, https://, gs://). Remote inputs are read with
-    /// byte-range requests; with --bbox, only the matching row groups are
-    /// ever downloaded.
-    #[arg(value_name = "INPUT")]
-    input: PathBuf,
+    /// Input GeoParquet (EPSG:4326 or EPSG:3857): a local file, a directory
+    /// or glob of partitions, or a remote URL (s3://, https://, gs://).
+    /// s3://.../ and gs://.../ prefixes (trailing slash) are listed to their
+    /// .parquet objects. Remote inputs are read with byte-range requests;
+    /// with --bbox, only the matching row groups are ever downloaded.
+    /// Omit when --files-from is given (then the one positional is OUTPUT).
+    #[arg(value_name = "INPUT", required_unless_present = "files_from")]
+    input: Option<PathBuf>,
 
     /// Output overview GeoParquet file.
-    #[arg(value_name = "OUTPUT")]
-    output: PathBuf,
+    #[arg(value_name = "OUTPUT", required_unless_present = "files_from")]
+    output: Option<PathBuf>,
+
+    /// Convert the inputs listed in this manifest instead of a positional
+    /// INPUT: one local path or remote URL per line; `#` comment lines and
+    /// blank lines are skipped; line order is preserved VERBATIM (it defines
+    /// the dataset row order). Each line must be a single .parquet
+    /// file/object — no directories, globs, or prefixes. Local and remote
+    /// entries may be mixed. Usage: --files-from <PATH> OUTPUT.
+    #[arg(long, value_name = "PATH")]
+    files_from: Option<PathBuf>,
 
     /// Level materialization mode.
     #[arg(long, default_value = "duplicating", value_parser = ["duplicating", "partitioning"])]
@@ -788,15 +799,26 @@ struct ValidateArgs {
 /// pipeline this command used to run was removed (see issue #177).
 #[derive(Parser, Debug)]
 struct TilesArgs {
-    /// Input GeoParquet file (EPSG:4326 or EPSG:3857): a local path or a
-    /// remote URL (s3://, https://, gs://); remote inputs are read with
-    /// byte-range requests.
-    #[arg(value_name = "INPUT")]
-    input: PathBuf,
+    /// Input GeoParquet (EPSG:4326 or EPSG:3857): a local file, a directory
+    /// or glob of partitions, or a remote URL (s3://, https://, gs://).
+    /// s3://.../ and gs://.../ prefixes (trailing slash) are listed to their
+    /// .parquet objects; remote inputs are read with byte-range requests.
+    /// Omit when --files-from is given (then the one positional is OUTPUT).
+    #[arg(value_name = "INPUT", required_unless_present = "files_from")]
+    input: Option<PathBuf>,
 
     /// Output PMTiles file.
-    #[arg(value_name = "OUTPUT")]
-    output: PathBuf,
+    #[arg(value_name = "OUTPUT", required_unless_present = "files_from")]
+    output: Option<PathBuf>,
+
+    /// Convert the inputs listed in this manifest instead of a positional
+    /// INPUT: one local path or remote URL per line; `#` comment lines and
+    /// blank lines are skipped; line order is preserved VERBATIM (it defines
+    /// the dataset row order). Each line must be a single .parquet
+    /// file/object — no directories, globs, or prefixes. Local and remote
+    /// entries may be mixed. Usage: --files-from <PATH> OUTPUT.
+    #[arg(long, value_name = "PATH")]
+    files_from: Option<PathBuf>,
 
     /// Minimum (coarsest) Web Mercator zoom level.
     #[arg(long, default_value = "0")]
@@ -914,6 +936,79 @@ where
     rewritten
 }
 
+/// The resolved input shape of `tiles`/`overview`.
+#[derive(Debug)]
+enum InputSpec {
+    /// Positional INPUT: file, directory, glob, or URL/prefix.
+    Path(PathBuf),
+    /// `--files-from` manifest of explicit files/URLs.
+    Manifest(PathBuf),
+}
+
+impl InputSpec {
+    /// Label for summary lines (input file name or manifest file name).
+    fn label(&self) -> String {
+        let p = match self {
+            InputSpec::Path(p) | InputSpec::Manifest(p) => p,
+        };
+        p.file_name().unwrap_or_default().to_string_lossy().into()
+    }
+}
+
+/// Sort out positional INPUT/OUTPUT vs `--files-from`, shared by `tiles`
+/// and `overview`. Without `--files-from`, clap enforces both positionals.
+/// With it, exactly ONE positional is expected — the OUTPUT, which clap
+/// slots into the INPUT position; a second positional means INPUT was also
+/// given, which conflicts with the manifest.
+fn resolve_io(
+    input: Option<PathBuf>,
+    output: Option<PathBuf>,
+    files_from: Option<PathBuf>,
+) -> Result<(InputSpec, PathBuf)> {
+    match files_from {
+        None => match (input, output) {
+            (Some(i), Some(o)) => Ok((InputSpec::Path(i), o)),
+            // Unreachable via clap (`required_unless_present`), kept for
+            // direct callers/tests.
+            _ => anyhow::bail!("INPUT and OUTPUT are required"),
+        },
+        Some(manifest) => match (input, output) {
+            (Some(out), None) => Ok((InputSpec::Manifest(manifest), out)),
+            (Some(input), Some(output)) => anyhow::bail!(
+                "--files-from conflicts with the positional INPUT: got both the \
+                 manifest and {:?}; pass only the OUTPUT ({:?})",
+                input,
+                output
+            ),
+            (None, _) => {
+                anyhow::bail!("missing OUTPUT (usage: --files-from <PATH> OUTPUT)")
+            }
+        },
+    }
+}
+
+/// Convert via the core pipeline, dispatching on the input shape: a path
+/// (file/dir/glob/URL/prefix, resolved by core) or a `--files-from`
+/// manifest (explicit ordered file list, order preserved verbatim).
+fn run_convert(
+    spec: &InputSpec,
+    output: &std::path::Path,
+    options: &gpq_tiles_core::overview::convert::ConvertOptions,
+) -> Result<gpq_tiles_core::overview::convert::ConvertReport> {
+    use gpq_tiles_core::input_set::ConvertSource;
+    use gpq_tiles_core::overview::convert::{
+        convert_to_overviews, convert_to_overviews_sources, ConvertError,
+    };
+
+    match spec {
+        InputSpec::Path(p) => convert_to_overviews(p, output, options),
+        InputSpec::Manifest(m) => ConvertSource::from_manifest(m)
+            .map_err(ConvertError::from)
+            .and_then(|source| convert_to_overviews_sources(&source, output, options)),
+    }
+    .map_err(|e| anyhow::anyhow!("overview conversion failed: {e}"))
+}
+
 /// Run `gpq-tiles tiles`: the one-shot GeoParquet → PMTiles facade.
 ///
 /// Chains the two product pipelines through a temporary overview file:
@@ -921,16 +1016,20 @@ where
 /// file lives next to the output (same filesystem) and is removed on both
 /// success and failure via [`tempfile::NamedTempFile`]'s drop guard.
 fn run_tiles(args: TilesArgs) -> Result<()> {
-    use gpq_tiles_core::overview::convert::{convert_to_overviews, LevelPlan};
+    use gpq_tiles_core::overview::convert::LevelPlan;
     use gpq_tiles_core::overview::export::{export_pmtiles, ExportOptions};
     use gpq_tiles_core::overview::level::Mode;
 
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
-    // Derive layer name from input filename if not specified.
+    let (spec, output) = resolve_io(args.input, args.output, args.files_from)?;
+
+    // Derive layer name from the input (or manifest) filename if not given.
     let layer_name = args.layer_name.clone().unwrap_or_else(|| {
-        args.input
-            .file_stem()
+        let p = match &spec {
+            InputSpec::Path(p) | InputSpec::Manifest(p) => p,
+        };
+        p.file_stem()
             .and_then(|s| s.to_str())
             .unwrap_or("layer")
             .to_string()
@@ -951,8 +1050,7 @@ fn run_tiles(args: TilesArgs) -> Result<()> {
 
     // Intermediate overview file next to the output (same filesystem);
     // NamedTempFile removes it on drop — success or failure alike.
-    let tmp_dir = args
-        .output
+    let tmp_dir = output
         .parent()
         .filter(|p| !p.as_os_str().is_empty())
         .map(std::path::Path::to_path_buf)
@@ -963,8 +1061,7 @@ fn run_tiles(args: TilesArgs) -> Result<()> {
         .tempfile_in(&tmp_dir)
         .context("failed to create temporary overview file")?;
 
-    let convert_report = convert_to_overviews(&args.input, overview_tmp.path(), &options)
-        .map_err(|e| anyhow::anyhow!("overview conversion failed: {e}"))?;
+    let convert_report = run_convert(&spec, overview_tmp.path(), &options)?;
 
     if args.verbose {
         println!(
@@ -983,7 +1080,7 @@ fn run_tiles(args: TilesArgs) -> Result<()> {
         tile_size_limit: args.max_tile_size,
         simple_clip_fastpath: !args.no_simple_clip_fastpath,
     };
-    let export_report = export_pmtiles(overview_tmp.path(), &args.output, &export_opts)
+    let export_report = export_pmtiles(overview_tmp.path(), &output, &export_opts)
         .map_err(|e| anyhow::anyhow!("export failed: {e}"))?;
 
     if args.verbose {
@@ -997,11 +1094,8 @@ fn run_tiles(args: TilesArgs) -> Result<()> {
 
     println!(
         "✓ Converted {} → {}",
-        args.input.file_name().unwrap_or_default().to_string_lossy(),
-        args.output
-            .file_name()
-            .unwrap_or_default()
-            .to_string_lossy()
+        spec.label(),
+        output.file_name().unwrap_or_default().to_string_lossy()
     );
     println!(
         "  {} tiles across z{}..z{} in {:.2}s",
@@ -1016,10 +1110,12 @@ fn run_tiles(args: TilesArgs) -> Result<()> {
 
 /// Run `gpq-tiles overview`: build a multi-resolution overview GeoParquet file.
 fn run_overview(args: OverviewArgs) -> Result<()> {
-    use gpq_tiles_core::overview::convert::{convert_to_overviews, LevelPlan};
+    use gpq_tiles_core::overview::convert::LevelPlan;
     use gpq_tiles_core::overview::level::Mode;
 
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    let (spec, output) = resolve_io(args.input, args.output, args.files_from)?;
 
     let mode = match args.mode.as_str() {
         "duplicating" => Mode::Duplicating,
@@ -1048,18 +1144,14 @@ fn run_overview(args: OverviewArgs) -> Result<()> {
         .tuning
         .build_convert_options(mode, levels, bbox, args.cogp_compat)?;
 
-    let report = convert_to_overviews(&args.input, &args.output, &options)
-        .map_err(|e| anyhow::anyhow!("overview conversion failed: {e}"))?;
+    let report = run_convert(&spec, &output, &options)?;
 
     // Human-readable summary.
     println!();
     println!(
         "✓ Overview {} → {}  ({:?} mode)",
-        args.input.file_name().unwrap_or_default().to_string_lossy(),
-        args.output
-            .file_name()
-            .unwrap_or_default()
-            .to_string_lossy(),
+        spec.label(),
+        output.file_name().unwrap_or_default().to_string_lossy(),
         report.mode
     );
     println!(
@@ -1386,6 +1478,74 @@ mod tests {
         assert!(parse_accumulate(":sum").is_err(), "empty column");
         assert!(parse_accumulate("pop:median").is_err(), "unknown op");
         assert!(parse_accumulate("pop:").is_err(), "empty op");
+    }
+
+    // --- --files-from (v0.7 multi-partition) ---------------------------------
+
+    /// `--files-from` parses on BOTH subcommands; the single positional is
+    /// the OUTPUT (clap slots it into the INPUT position; resolve_io swaps).
+    #[test]
+    fn files_from_parses_on_both_subcommands() {
+        let cli =
+            Cli::try_parse_from(["gpq-tiles", "tiles", "--files-from", "m.txt", "out.pmtiles"])
+                .expect("tiles --files-from should parse");
+        let Command::Tiles(a) = cli.command else {
+            panic!("expected tiles");
+        };
+        let (spec, out) = resolve_io(a.input, a.output, a.files_from).unwrap();
+        assert!(matches!(spec, InputSpec::Manifest(ref m) if m == &PathBuf::from("m.txt")));
+        assert_eq!(out, PathBuf::from("out.pmtiles"));
+
+        let cli = Cli::try_parse_from([
+            "gpq-tiles",
+            "overview",
+            "--files-from",
+            "m.txt",
+            "out.parquet",
+        ])
+        .expect("overview --files-from should parse");
+        let Command::Overview(a) = cli.command else {
+            panic!("expected overview");
+        };
+        let (spec, out) = resolve_io(a.input, a.output, a.files_from).unwrap();
+        assert!(matches!(spec, InputSpec::Manifest(_)));
+        assert_eq!(out, PathBuf::from("out.parquet"));
+    }
+
+    /// `--files-from` conflicts with a positional INPUT; INPUT stays
+    /// required without it; OUTPUT is still required with it.
+    #[test]
+    fn files_from_conflicts_with_positional_input() {
+        let cli = Cli::try_parse_from([
+            "gpq-tiles",
+            "overview",
+            "--files-from",
+            "m.txt",
+            "in.parquet",
+            "out.parquet",
+        ])
+        .expect("clap accepts; resolve_io rejects");
+        let Command::Overview(a) = cli.command else {
+            panic!("expected overview");
+        };
+        let err = resolve_io(a.input, a.output, a.files_from).unwrap_err();
+        assert!(
+            err.to_string().contains("conflicts"),
+            "conflict named: {err}"
+        );
+
+        // Without --files-from, INPUT/OUTPUT stay clap-required.
+        assert!(Cli::try_parse_from(["gpq-tiles", "overview"]).is_err());
+        assert!(Cli::try_parse_from(["gpq-tiles", "tiles", "only-one"]).is_err());
+
+        // With --files-from but no positional at all: OUTPUT is missing.
+        let cli = Cli::try_parse_from(["gpq-tiles", "tiles", "--files-from", "m.txt"])
+            .expect("parses; resolve_io names the missing OUTPUT");
+        let Command::Tiles(a) = cli.command else {
+            panic!("expected tiles");
+        };
+        let err = resolve_io(a.input, a.output, a.files_from).unwrap_err();
+        assert!(err.to_string().contains("OUTPUT"), "names OUTPUT: {err}");
     }
 
     /// Parse a `tiles` invocation and return its args (INPUT/OUTPUT are dummies).

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -24,6 +24,7 @@ remote = [
     "dep:aws-config",
     "dep:aws-credential-types",
     "dep:async-trait",
+    "dep:futures-util",
     "dep:url",
     "dep:fs4",
 ]
@@ -60,6 +61,7 @@ tokio = { version = "1", default-features = false, features = ["rt-multi-thread"
 aws-config = { version = "1", optional = true }
 aws-credential-types = { version = "1", optional = true }
 async-trait = { version = "0.1", optional = true }
+futures-util = { version = "0.3", default-features = false, features = ["std"], optional = true }
 url = { version = "2", optional = true }
 bytes = "1"
 fs4 = { version = "0.13", optional = true }

--- a/crates/core/src/input.rs
+++ b/crates/core/src/input.rs
@@ -118,15 +118,38 @@ pub enum InputError {
         /// The original input string (directory path or glob pattern).
         input: String,
     },
-    /// A remote URL that is not a single `.parquet` object (a bucket prefix /
-    /// "directory"). Listing remote prefixes lands later in this release.
+    /// An `http(s)://` URL naming a prefix ("directory"). Generic HTTP has
+    /// no listing API, so the objects must be named explicitly; `s3://` and
+    /// `gs://` prefixes are listed natively.
     #[error(
-        "remote prefix input {url:?} is not yet supported (single .parquet object \
-         URLs are; remote prefix listing is coming later in this release)"
+        "cannot list objects under {url:?}: http(s) prefixes have no generic \
+         listing API. Pass the object URLs explicitly with --files-from \
+         <manifest> (one per line); s3:// and gs:// prefixes are listed \
+         natively"
     )]
     RemotePrefixUnsupported {
         /// The rejected URL.
         url: String,
+    },
+    /// The `--files-from` manifest itself could not be read.
+    #[error("cannot read --files-from manifest {path:?}: {source}")]
+    ManifestRead {
+        /// The manifest path as supplied.
+        path: String,
+        /// The underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// An explicitly listed input (a `--files-from` manifest line or a
+    /// Python input-list entry) does not exist as a local file. Listed
+    /// entries are single files/objects only — no directory, glob, or
+    /// prefix expansion.
+    #[error("{context}: input {input:?} does not exist or is not a file")]
+    MissingListedInput {
+        /// Where the entry came from (manifest line / list position).
+        context: String,
+        /// The offending entry.
+        input: String,
     },
     /// A glob input string is not a valid glob pattern.
     #[error("invalid glob pattern {pattern:?}: {message}")]
@@ -487,40 +510,139 @@ pub(crate) mod remote {
         cap_base: u64,
     }
 
-    impl RemoteSource {
-        /// Connect to `url`, resolving the backing store from the scheme
-        /// and HEAD-ing the object for its size.
-        pub(crate) fn connect(url_str: &str) -> Result<Self, InputError> {
-            let url = Url::parse(url_str)
-                .map_err(|e| InputError::RemoteConfig(format!("invalid URL {url_str:?}: {e}")))?;
-            let (scheme, location) = ObjectStoreScheme::parse(&url).map_err(|e| {
-                InputError::RemoteConfig(format!("cannot interpret URL {url_str:?}: {e}"))
-            })?;
-            let store: Arc<dyn ObjectStore> = match scheme {
-                ObjectStoreScheme::AmazonS3 => build_s3(&url)?,
-                ObjectStoreScheme::GoogleCloudStorage => Arc::new(
-                    GoogleCloudStorageBuilder::from_env()
-                        .with_url(url_str)
+    /// Resolve the object store + object path for `url_str`.
+    ///
+    /// Stores are cached per `scheme://authority` for the life of the
+    /// process, so one convert resolves credentials ONCE per bucket: a
+    /// prefix listing and its N per-part sources, or N `--files-from`
+    /// manifest entries in the same bucket, all share one store instance
+    /// (the AWS credential chain probe in [`build_s3`] is otherwise paid
+    /// per part).
+    pub(crate) fn store_and_location(
+        url_str: &str,
+    ) -> Result<(Arc<dyn ObjectStore>, ObjectPath), InputError> {
+        static STORES: OnceLock<Mutex<std::collections::HashMap<String, Arc<dyn ObjectStore>>>> =
+            OnceLock::new();
+
+        let url = Url::parse(url_str)
+            .map_err(|e| InputError::RemoteConfig(format!("invalid URL {url_str:?}: {e}")))?;
+        let (scheme, location) = ObjectStoreScheme::parse(&url).map_err(|e| {
+            InputError::RemoteConfig(format!("cannot interpret URL {url_str:?}: {e}"))
+        })?;
+        let key = url[..url::Position::BeforePath].to_ascii_lowercase();
+        let stores = STORES.get_or_init(Default::default);
+        if let Some(store) = stores.lock().expect("store cache lock").get(&key) {
+            return Ok((Arc::clone(store), location));
+        }
+        let store: Arc<dyn ObjectStore> = match scheme {
+            ObjectStoreScheme::AmazonS3 => build_s3(&url)?,
+            ObjectStoreScheme::GoogleCloudStorage => Arc::new(
+                GoogleCloudStorageBuilder::from_env()
+                    .with_url(url_str)
+                    .build()
+                    .map_err(|e| store_error(url_str, e))?,
+            ),
+            ObjectStoreScheme::Http => {
+                let origin = &url[..url::Position::BeforePath];
+                Arc::new(
+                    HttpBuilder::new()
+                        .with_url(origin)
+                        .with_client_options(ClientOptions::new().with_allow_http(true))
                         .build()
                         .map_err(|e| store_error(url_str, e))?,
-                ),
-                ObjectStoreScheme::Http => {
-                    let origin = &url[..url::Position::BeforePath];
-                    Arc::new(
-                        HttpBuilder::new()
-                            .with_url(origin)
-                            .with_client_options(ClientOptions::new().with_allow_http(true))
-                            .build()
-                            .map_err(|e| store_error(url_str, e))?,
-                    )
-                }
-                _ => {
-                    return Err(InputError::UnsupportedScheme {
-                        scheme: url.scheme().to_string(),
-                        url: url_str.to_string(),
-                    })
-                }
-            };
+                )
+            }
+            _ => {
+                return Err(InputError::UnsupportedScheme {
+                    scheme: url.scheme().to_string(),
+                    url: url_str.to_string(),
+                })
+            }
+        };
+        // A concurrent resolve may have raced us; either instance works,
+        // last insert wins.
+        stores
+            .lock()
+            .expect("store cache lock")
+            .insert(key, Arc::clone(&store));
+        Ok((store, location))
+    }
+
+    /// One `.parquet` object found under a remote prefix.
+    pub(crate) struct ListedPart {
+        /// Full object key (from the bucket root).
+        pub location: ObjectPath,
+        /// Object size in bytes, straight from the listing (no HEAD).
+        pub size: u64,
+    }
+
+    /// List the `.parquet` objects under remote prefix `prefix`, applying
+    /// the same hygiene as the local directory walk
+    /// ([`crate::input_set::list_parquet_files`]): keys must end
+    /// `.parquet`; zero-byte objects and any path component below the
+    /// prefix starting with `.` or `_` (`_SUCCESS`, `_delta_log/…`,
+    /// `.crc`) are skipped; results are sorted by key — the ordering the
+    /// converter's row-order invariant keys on.
+    pub(crate) fn list_parquet_under_prefix(
+        store: &Arc<dyn ObjectStore>,
+        prefix: &ObjectPath,
+        url_str: &str,
+    ) -> Result<Vec<ListedPart>, InputError> {
+        use futures_util::TryStreamExt;
+        let metas: Vec<object_store::ObjectMeta> = runtime()
+            .block_on(store.list(Some(prefix)).try_collect())
+            .map_err(|e| store_error(url_str, e))?;
+        let prefix_depth = prefix.parts().count();
+        let mut parts: Vec<ListedPart> = metas
+            .into_iter()
+            .filter(|m| {
+                m.size > 0
+                    && m.location.as_ref().ends_with(".parquet")
+                    && m.location
+                        .parts()
+                        .skip(prefix_depth)
+                        .all(|c| !c.as_ref().starts_with(['.', '_']))
+            })
+            .map(|m| ListedPart {
+                location: m.location,
+                size: m.size,
+            })
+            .collect();
+        parts.sort_by(|a, b| a.location.as_ref().cmp(b.location.as_ref()));
+        Ok(parts)
+    }
+
+    /// Connect every listed `.parquet` object under remote prefix
+    /// `url_str`, in key order. ONE store instance serves the listing and
+    /// all returned sources (one credential resolution), and the object
+    /// sizes come from the listing itself — no per-part HEAD requests.
+    pub(crate) fn sources_under_prefix(url_str: &str) -> Result<Vec<RemoteSource>, InputError> {
+        let (store, prefix) = store_and_location(url_str)?;
+        let parts = list_parquet_under_prefix(&store, &prefix, url_str)?;
+        Ok(parts
+            .into_iter()
+            .map(|p| {
+                let url = part_url(url_str, &p.location);
+                RemoteSource::from_store_sized(Arc::clone(&store), p.location, url, p.size)
+            })
+            .collect())
+    }
+
+    /// URL of one listed object: the prefix URL's `scheme://authority`
+    /// plus the object's full key.
+    fn part_url(prefix_url: &str, location: &ObjectPath) -> String {
+        match Url::parse(prefix_url) {
+            Ok(u) => format!("{}/{}", &u[..url::Position::BeforePath], location),
+            Err(_) => format!("{prefix_url}{location}"),
+        }
+    }
+
+    impl RemoteSource {
+        /// Connect to `url`, resolving the backing store from the scheme
+        /// (cached per bucket, see [`store_and_location`]) and HEAD-ing the
+        /// object for its size.
+        pub(crate) fn connect(url_str: &str) -> Result<Self, InputError> {
+            let (store, location) = store_and_location(url_str)?;
             Self::from_store(store, location, url_str.to_string())
         }
 
@@ -547,17 +669,41 @@ pub(crate) mod remote {
             let head = runtime()
                 .block_on(store.head(&location))
                 .map_err(|e| store_error(&url, e))?;
-            Ok(Self {
+            Ok(Self::from_store_sized_with_cap_base(
+                store, location, url, head.size, cap_base,
+            ))
+        }
+
+        /// [`Self::from_store`] with the object size already known (from a
+        /// prefix listing) — skips the HEAD request, so connecting N listed
+        /// parts costs no network round-trips at all.
+        pub(crate) fn from_store_sized(
+            store: Arc<dyn ObjectStore>,
+            location: ObjectPath,
+            url: String,
+            size: u64,
+        ) -> Self {
+            Self::from_store_sized_with_cap_base(store, location, url, size, CHUNK_CACHE_MAX_BYTES)
+        }
+
+        fn from_store_sized_with_cap_base(
+            store: Arc<dyn ObjectStore>,
+            location: ObjectPath,
+            url: String,
+            size: u64,
+            cap_base: u64,
+        ) -> Self {
+            Self {
                 url,
                 store,
                 location,
-                size: head.size,
+                size,
                 shared: Arc::new(SharedState::default()),
                 metadata: OnceLock::new(),
                 cache: Arc::new(Mutex::new(ChunkCache::new(cap_base))),
                 spill: Arc::new(Mutex::new(DiskSpill::default())),
                 cap_base,
-            })
+            }
         }
 
         /// The input URL.
@@ -1166,6 +1312,56 @@ pub(crate) fn test_memory_source(bytes: Vec<u8>, name: &str) -> InputSource {
     InputSource::Remote(
         remote::RemoteSource::from_store(store, location, format!("memory://{name}")).unwrap(),
     )
+}
+
+/// Test-only: a multi-partition [`crate::input_set::ConvertSource`] over ONE
+/// in-memory object store — `objects` are `(basename, bytes)` pairs placed
+/// under a `set/` prefix and resolved through the REAL prefix-listing path
+/// (filtering, key sort, shared store instance, sizes from the listing).
+/// Also returns the per-part [`InputSource`] handles: clones share the fetch
+/// counters, so tests can assert per-part fetched ranges after a convert.
+#[cfg(all(test, feature = "remote"))]
+pub(crate) fn test_memory_multi_source(
+    objects: Vec<(&str, Vec<u8>)>,
+) -> (crate::input_set::ConvertSource, Vec<InputSource>) {
+    use crate::input_set::{ConvertSource, MultiSource};
+    use object_store::memory::InMemory;
+    use object_store::path::Path as ObjectPath;
+    use object_store::ObjectStore;
+    use std::sync::Arc;
+
+    let store = Arc::new(InMemory::new());
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    for (name, bytes) in objects {
+        rt.block_on(store.put(&ObjectPath::from(format!("set/{name}")), bytes.into()))
+            .unwrap();
+    }
+    let store: Arc<dyn ObjectStore> = store;
+    let listed =
+        remote::list_parquet_under_prefix(&store, &ObjectPath::from("set"), "memory://set/")
+            .unwrap();
+    let parts: Vec<InputSource> = listed
+        .into_iter()
+        .map(|p| {
+            InputSource::Remote(remote::RemoteSource::from_store_sized(
+                Arc::clone(&store),
+                p.location.clone(),
+                format!("memory://{}", p.location),
+                p.size,
+            ))
+        })
+        .collect();
+    let source = if parts.len() == 1 {
+        ConvertSource::single(parts[0].clone())
+    } else {
+        ConvertSource::Multi(
+            MultiSource::from_sources("memory://set/".to_string(), parts.clone()).unwrap(),
+        )
+    };
+    (source, parts)
 }
 
 /// Test-only: [`test_memory_source`] with an explicit chunk-cache floor, so a

--- a/crates/core/src/input_set.rs
+++ b/crates/core/src/input_set.rs
@@ -30,8 +30,11 @@
 //! match; and an identical detected CRS. Nullability is the one permitted
 //! difference: the exposed schema unions it (any-nullable ⇒ nullable).
 //!
-//! Remote *prefixes* (e.g. `s3://bucket/dataset/`) are rejected with a
-//! clear error for now; remote prefix listing lands later in this release.
+//! `s3://` / `gs://` *prefixes* (e.g. `s3://bucket/dataset/`) are listed
+//! natively (sorted `.parquet` keys, one shared store instance);
+//! `http(s)://` prefixes have no generic listing API and error with a
+//! pointer at `--files-from`, which accepts an explicit ordered manifest
+//! of files/URLs instead.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -100,8 +103,9 @@ struct PartMeta {
     parquet: Arc<ParquetMetaData>,
 }
 
-/// An ordered set of local parquet partitions with footers loaded and
-/// validated up front (see the module docs for the compatibility rules).
+/// An ordered set of parquet partitions (local files and/or remote
+/// objects) with footers loaded and validated up front (see the module
+/// docs for the compatibility rules).
 #[derive(Debug)]
 pub struct MultiSource {
     /// The original input string (directory path or glob pattern).
@@ -183,10 +187,13 @@ impl ConvertSource {
     ///   filtered to `.parquet` files, sorted, deduplicated;
     /// - remote single-object URL (no trailing slash — including
     ///   extension-less presigned/API URLs) → `Single` (unchanged);
-    /// - remote prefix (path ending `/`) →
-    ///   [`InputError::RemotePrefixUnsupported`] when the `remote` feature
-    ///   is on (for now); without the feature, the standard
-    ///   [`InputError::RemoteDisabled`] as before;
+    /// - `s3://` / `gs://` prefix (path ending `/`) → native object
+    ///   listing: `.parquet` keys sorted by key, `_SUCCESS`/zero-byte/
+    ///   hidden (`.`/`_`) names skipped, one store instance shared by all
+    ///   parts; requires the `remote` feature (without it, the standard
+    ///   [`InputError::RemoteDisabled`] as before);
+    /// - `http(s)://` prefix → [`InputError::RemotePrefixUnsupported`]
+    ///   (no generic listing API; the error points at `--files-from`);
     /// - a single resolved partition collapses to `Single`;
     /// - an empty directory/glob result → [`InputError::NoParquetInputs`].
     pub fn resolve(input: &str) -> Result<Self, InputError> {
@@ -202,9 +209,12 @@ impl ConvertSource {
                 && is_remote_scheme(_scheme)
                 && remote_url_is_prefix(input)
             {
-                return Err(InputError::RemotePrefixUnsupported {
-                    url: input.to_string(),
-                });
+                if _scheme.eq_ignore_ascii_case("http") || _scheme.eq_ignore_ascii_case("https") {
+                    return Err(InputError::RemotePrefixUnsupported {
+                        url: input.to_string(),
+                    });
+                }
+                return Self::from_remote_prefix(input);
             }
             // `file://` maps to a local path, remote objects stay single,
             // unsupported schemes get the standard error — all exactly as
@@ -234,17 +244,102 @@ impl ConvertSource {
     }
 
     /// `Single` for one file, `Multi` for several, a clear error for none.
-    fn from_local_files(input: &str, mut files: Vec<PathBuf>) -> Result<Self, InputError> {
-        match files.len() {
+    fn from_local_files(input: &str, files: Vec<PathBuf>) -> Result<Self, InputError> {
+        Self::from_parts(input, files.into_iter().map(InputSource::Local).collect())
+    }
+
+    /// `Single` for one part, `Multi` for several,
+    /// [`InputError::NoParquetInputs`] for none. `parts` must already be in
+    /// read order (the row-order invariant).
+    fn from_parts(input: &str, mut parts: Vec<InputSource>) -> Result<Self, InputError> {
+        match parts.len() {
             0 => Err(InputError::NoParquetInputs {
                 input: input.to_string(),
             }),
-            1 => Ok(ConvertSource::single(InputSource::Local(files.remove(0)))),
-            _ => Ok(ConvertSource::Multi(MultiSource::from_local_files(
+            1 => Ok(ConvertSource::single(parts.remove(0))),
+            _ => Ok(ConvertSource::Multi(MultiSource::from_sources(
                 input.to_string(),
-                files,
+                parts,
             )?)),
         }
+    }
+
+    /// Resolve an `s3://`/`gs://` prefix by listing the store: every
+    /// visible `.parquet` object under the prefix, sorted by key, all
+    /// sharing ONE store instance (one credential resolution) with sizes
+    /// taken from the listing (no per-part HEADs).
+    #[cfg(feature = "remote")]
+    fn from_remote_prefix(input: &str) -> Result<Self, InputError> {
+        let sources = crate::input::remote::sources_under_prefix(input)?;
+        Self::from_parts(
+            input,
+            sources.into_iter().map(InputSource::Remote).collect(),
+        )
+    }
+
+    /// Build a source from a `--files-from` manifest: one local path or
+    /// remote URL per line, `#`-prefixed comment lines and blank lines
+    /// skipped, entries trimmed. Line order is preserved VERBATIM — never
+    /// sorted — because the converter's row-order invariant keys winner
+    /// tables by global row offset; reordering the manifest reorders the
+    /// dataset. Each line is resolved as a SINGLE file/object (no
+    /// directory, glob, or prefix expansion); mixing local and remote
+    /// entries is allowed (compatibility is validated as usual).
+    pub fn from_manifest(manifest: &Path) -> Result<Self, InputError> {
+        let text = std::fs::read_to_string(manifest).map_err(|e| InputError::ManifestRead {
+            path: manifest.display().to_string(),
+            source: e,
+        })?;
+        let entries: Vec<(String, String)> = manifest_entries(&text)
+            .into_iter()
+            .map(|(line, entry)| {
+                (
+                    format!("line {line} of manifest {}", manifest.display()),
+                    entry.to_string(),
+                )
+            })
+            .collect();
+        Self::from_explicit_list(&manifest.display().to_string(), &entries)
+    }
+
+    /// Build a source from an explicit ordered list of inputs (local paths
+    /// or URLs) — the Python `list[str]` input shape. Order is preserved
+    /// verbatim; each entry is a single file/object (no expansion).
+    pub fn from_input_list<S: AsRef<str>>(inputs: &[S]) -> Result<Self, InputError> {
+        let entries: Vec<(String, String)> = inputs
+            .iter()
+            .enumerate()
+            .map(|(i, entry)| {
+                (
+                    format!("input list entry {}", i + 1),
+                    entry.as_ref().to_string(),
+                )
+            })
+            .collect();
+        Self::from_explicit_list("input list", &entries)
+    }
+
+    /// Shared by [`Self::from_manifest`] and [`Self::from_input_list`]:
+    /// resolve each `(context, entry)` as a single source, requiring local
+    /// entries to exist up front so the error can name the entry instead
+    /// of surfacing as a bare I/O error at footer-load time.
+    fn from_explicit_list(root: &str, entries: &[(String, String)]) -> Result<Self, InputError> {
+        let mut parts = Vec::with_capacity(entries.len());
+        for (context, entry) in entries {
+            let src = InputSource::from_str_input(entry)?;
+            // Without the `remote` feature `Local` is the only variant.
+            #[cfg_attr(not(feature = "remote"), allow(irrefutable_let_patterns))]
+            if let InputSource::Local(p) = &src {
+                if !p.is_file() {
+                    return Err(InputError::MissingListedInput {
+                        context: context.clone(),
+                        input: entry.clone(),
+                    });
+                }
+            }
+            parts.push(src);
+        }
+        Self::from_parts(root, parts)
     }
 
     /// [`ConvertSource::resolve`] for `Path` inputs (non-UTF-8 paths fall
@@ -422,21 +517,61 @@ fn load_part_meta(source: &InputSource) -> Result<PartMeta, InputError> {
     })
 }
 
-impl MultiSource {
-    /// Build and validate a multi source over local partition files.
-    fn from_local_files(root: String, files: Vec<PathBuf>) -> Result<Self, InputError> {
-        Self::from_sources(root, files.into_iter().map(InputSource::Local).collect())
-    }
+/// Ceiling on concurrent footer loads in [`load_part_metas`]. A remote
+/// footer costs two range requests; loading hundreds of parts serially
+/// pays hundreds of sequential round-trips, while unbounded parallelism
+/// would open one connection per part. Eight in flight keeps a
+/// hundreds-of-parts prefix listing responsive without a connection storm.
+const FOOTER_LOAD_CONCURRENCY: usize = 8;
 
+/// Load every part's footer, in order, with bounded concurrency. Results
+/// are written into per-index slots so the returned order always matches
+/// `parts` regardless of completion order; the first error (by part index)
+/// wins.
+fn load_part_metas(parts: &[InputSource]) -> Result<Vec<PartMeta>, InputError> {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    let workers = FOOTER_LOAD_CONCURRENCY.min(parts.len());
+    if workers <= 1 {
+        return parts.iter().map(load_part_meta).collect();
+    }
+    let next = AtomicUsize::new(0);
+    let slots: Vec<std::sync::Mutex<Option<Result<PartMeta, InputError>>>> = (0..parts.len())
+        .map(|_| std::sync::Mutex::new(None))
+        .collect();
+    std::thread::scope(|scope| {
+        for _ in 0..workers {
+            scope.spawn(|| loop {
+                let i = next.fetch_add(1, Ordering::Relaxed);
+                if i >= parts.len() {
+                    break;
+                }
+                let meta = load_part_meta(&parts[i]);
+                *slots[i].lock().expect("footer slot lock") = Some(meta);
+            });
+        }
+    });
+    slots
+        .into_iter()
+        .map(|slot| {
+            slot.into_inner()
+                .expect("footer slot lock")
+                .expect("every slot filled by a worker")
+        })
+        .collect()
+}
+
+impl MultiSource {
     /// Build a multi source over already-constructed parts: load every
     /// part's footer and validate compatibility against part 0 (see the
     /// module docs). `parts` must be non-empty and already ordered.
+    /// Footer loads run with bounded concurrency
+    /// ([`FOOTER_LOAD_CONCURRENCY`]): a remote footer is two range
+    /// requests, so hundreds of parts would otherwise serialize hundreds
+    /// of round-trips — but must not open hundreds of connections at once
+    /// either.
     pub fn from_sources(root: String, parts: Vec<InputSource>) -> Result<Self, InputError> {
         assert!(!parts.is_empty(), "MultiSource requires at least one part");
-        let metas = parts
-            .iter()
-            .map(load_part_meta)
-            .collect::<Result<Vec<_>, _>>()?;
+        let metas = load_part_metas(&parts)?;
 
         let first_name = parts[0].display_name();
         // The reference CRS: `Ok(crs)` per detect_crs_from_kv, `None` for an
@@ -679,6 +814,20 @@ fn has_glob_meta(input: &str) -> bool {
     input.contains(['*', '?', '['])
 }
 
+/// Parse `--files-from` manifest text into `(1-based line number, entry)`
+/// pairs: entries are trimmed; blank lines and lines whose first non-space
+/// character is `#` are skipped. Order is preserved verbatim (see
+/// [`ConvertSource::from_manifest`]).
+fn manifest_entries(text: &str) -> Vec<(usize, &str)> {
+    text.lines()
+        .enumerate()
+        .filter_map(|(i, line)| {
+            let entry = line.trim();
+            (!entry.is_empty() && !entry.starts_with('#')).then_some((i + 1, entry))
+        })
+        .collect()
+}
+
 /// Whether a remote URL names a *prefix* ("directory"): its path component
 /// — query string and fragment stripped — ends with `/`. Everything else,
 /// including extension-less presigned/API URLs that serve parquet, is a
@@ -905,21 +1054,23 @@ mod tests {
         assert!(!remote_url_is_prefix("s3://bucket/dataset"));
     }
 
-    /// With the `remote` feature compiled in, only trailing-slash URLs are
-    /// rejected as prefixes (before any network touch); everything else
-    /// proceeds to the single-object path.
+    /// http(s) prefixes stay hard errors (generic HTTP has no listing API)
+    /// and the error points at `--files-from`. s3/gs prefixes are listed
+    /// for real now (covered by the InMemory tests below), so they are NOT
+    /// rejected here.
     #[cfg(feature = "remote")]
     #[test]
-    fn resolve_remote_prefix_rejected() {
-        for url in [
-            "s3://bucket/dataset/",
-            "https://example.com/data/",
-            "gs://bucket/prefix/",
-        ] {
+    fn resolve_https_prefix_points_at_files_from() {
+        for url in ["https://example.com/data/", "http://example.com/data/"] {
             let err = ConvertSource::resolve(url).unwrap_err();
             assert!(
                 matches!(err, InputError::RemotePrefixUnsupported { .. }),
                 "{url} → {err:?}"
+            );
+            let msg = err.to_string();
+            assert!(
+                msg.contains("--files-from"),
+                "error must point at --files-from: {msg}"
             );
         }
     }
@@ -1209,5 +1360,253 @@ mod tests {
         // Scoped reader threads capture &ConvertSource.
         fn assert_sync<T: Sync>() {}
         assert_sync::<ConvertSource>();
+    }
+
+    // --- --files-from manifest (v0.7 PR-B) ------------------------------------
+
+    /// Comments, blank lines, and surrounding whitespace are skipped;
+    /// entry order is preserved VERBATIM (never sorted) — the row-order
+    /// invariant keys winner tables by global row offset.
+    #[test]
+    fn manifest_entries_skip_comments_and_preserve_order() {
+        let text = "\
+# heading comment
+b.parquet
+
+  # indented comment
+  a.parquet  \n\nz/c.parquet\n";
+        let entries = manifest_entries(text);
+        assert_eq!(
+            entries,
+            vec![(2, "b.parquet"), (5, "a.parquet"), (7, "z/c.parquet")],
+            "order verbatim (b before a), 1-based line numbers"
+        );
+    }
+
+    #[test]
+    fn manifest_multi_source_preserves_line_order() {
+        let dir = tmpdir();
+        // Deliberately list b before a: order must be kept, not sorted.
+        write_standard(&dir.path().join("b.parquet"), vec![0, 1], false);
+        write_standard(&dir.path().join("a.parquet"), vec![2, 3], false);
+        let manifest = dir.path().join("parts.txt");
+        std::fs::write(
+            &manifest,
+            format!(
+                "# two partitions, b first\n{}\n\n{}\n",
+                dir.path().join("b.parquet").display(),
+                dir.path().join("a.parquet").display()
+            ),
+        )
+        .unwrap();
+        let src = ConvertSource::from_manifest(&manifest).unwrap();
+        assert!(matches!(src, ConvertSource::Multi(_)));
+        let plan = ReadPlan {
+            batch_size: 1024,
+            projection: None,
+            row_groups: None,
+        };
+        assert_eq!(stream_ids(&src, &plan), vec![0, 1, 2, 3]);
+    }
+
+    /// A single-entry manifest collapses to `Single`; a `file://` URL line
+    /// proves the URL classification path runs per line (no network).
+    #[test]
+    fn manifest_single_entry_and_file_url() {
+        let dir = tmpdir();
+        let f = dir.path().join("only.parquet");
+        write_standard(&f, vec![7], false);
+        let manifest = dir.path().join("one.txt");
+        std::fs::write(&manifest, format!("file://{}\n", f.display())).unwrap();
+        let src = ConvertSource::from_manifest(&manifest).unwrap();
+        assert!(matches!(src, ConvertSource::Single(_)));
+        let plan = ReadPlan {
+            batch_size: 8,
+            projection: None,
+            row_groups: None,
+        };
+        assert_eq!(stream_ids(&src, &plan), vec![7]);
+    }
+
+    /// A manifest line naming a missing local file errors, naming BOTH the
+    /// line number and the offending path. Lines are single files only —
+    /// a directory line is rejected too (no recursion).
+    #[test]
+    fn manifest_missing_file_names_line_and_path() {
+        let dir = tmpdir();
+        write_standard(&dir.path().join("ok.parquet"), vec![1], false);
+        let manifest = dir.path().join("bad.txt");
+        std::fs::write(
+            &manifest,
+            format!(
+                "{}\n# comment\n{}\n",
+                dir.path().join("ok.parquet").display(),
+                dir.path().join("nope.parquet").display()
+            ),
+        )
+        .unwrap();
+        let err = ConvertSource::from_manifest(&manifest).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("line 3"), "names the manifest line: {msg}");
+        assert!(msg.contains("nope.parquet"), "names the path: {msg}");
+
+        // A directory entry is not a file: same error (no recursion).
+        let manifest2 = dir.path().join("dir.txt");
+        std::fs::write(&manifest2, format!("{}\n", dir.path().display())).unwrap();
+        let err = ConvertSource::from_manifest(&manifest2).unwrap_err();
+        assert!(
+            matches!(err, InputError::MissingListedInput { .. }),
+            "directory lines are rejected: {err:?}"
+        );
+    }
+
+    #[test]
+    fn manifest_empty_or_unreadable_is_a_clear_error() {
+        let dir = tmpdir();
+        let empty = dir.path().join("empty.txt");
+        std::fs::write(&empty, "# only comments\n\n").unwrap();
+        let err = ConvertSource::from_manifest(&empty).unwrap_err();
+        assert!(matches!(err, InputError::NoParquetInputs { .. }), "{err:?}");
+
+        let err = ConvertSource::from_manifest(&dir.path().join("missing.txt")).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("missing.txt"), "names the manifest: {msg}");
+    }
+
+    /// The Python list-input path: explicit entries, order verbatim, each a
+    /// single file (no recursion), missing entries named by position.
+    #[test]
+    fn input_list_preserves_order_and_validates() {
+        let dir = tmpdir();
+        write_standard(&dir.path().join("b.parquet"), vec![0], false);
+        write_standard(&dir.path().join("a.parquet"), vec![1], false);
+        let list = [
+            dir.path().join("b.parquet").display().to_string(),
+            dir.path().join("a.parquet").display().to_string(),
+        ];
+        let src = ConvertSource::from_input_list(&list).unwrap();
+        let plan = ReadPlan {
+            batch_size: 8,
+            projection: None,
+            row_groups: None,
+        };
+        assert_eq!(stream_ids(&src, &plan), vec![0, 1]);
+
+        let bad = [dir.path().join("nope.parquet").display().to_string()];
+        let err = ConvertSource::from_input_list(&bad).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("entry 1"), "names the entry: {msg}");
+        assert!(msg.contains("nope.parquet"), "names the path: {msg}");
+
+        let none: [String; 0] = [];
+        let err = ConvertSource::from_input_list(&none).unwrap_err();
+        assert!(matches!(err, InputError::NoParquetInputs { .. }), "{err:?}");
+    }
+
+    // --- remote prefix listing (v0.7 PR-B) ------------------------------------
+
+    #[cfg(feature = "remote")]
+    mod remote_listing {
+        use super::*;
+        use crate::input::remote::{list_parquet_under_prefix, RemoteSource};
+        use object_store::memory::InMemory;
+        use object_store::path::Path as ObjectPath;
+        use object_store::ObjectStore;
+
+        /// Seed one InMemory store with `objects` (key → bytes).
+        fn seeded_store(objects: &[(&str, Vec<u8>)]) -> Arc<InMemory> {
+            let store = Arc::new(InMemory::new());
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            for (key, bytes) in objects {
+                rt.block_on(store.put(&ObjectPath::from(*key), bytes.clone().into()))
+                    .unwrap();
+            }
+            store
+        }
+
+        fn parquet_bytes(ids: Vec<i64>) -> Vec<u8> {
+            let batch = RecordBatch::try_new(
+                Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)])),
+                vec![Arc::new(Int64Array::from(ids))],
+            )
+            .unwrap();
+            let mut buf = Vec::new();
+            let mut w = ArrowWriter::try_new(&mut buf, batch.schema(), None).unwrap();
+            w.write(&batch).unwrap();
+            w.close().unwrap();
+            buf
+        }
+
+        /// The listing finds exactly the `.parquet` keys, sorted by key,
+        /// skipping `_SUCCESS`, zero-byte objects, hidden (`.`/`_`) names —
+        /// including hidden "directory" components below the prefix — and
+        /// keys outside the prefix.
+        #[test]
+        fn listing_filters_and_sorts() {
+            let store = seeded_store(&[
+                ("set/b.parquet", parquet_bytes(vec![1])),
+                ("set/a.parquet", parquet_bytes(vec![2])),
+                ("set/nested/c.parquet", parquet_bytes(vec![3])),
+                ("set/_SUCCESS", vec![]),
+                ("set/_delta_log/d.parquet", parquet_bytes(vec![4])),
+                ("set/.hidden.parquet", parquet_bytes(vec![5])),
+                ("set/zero.parquet", vec![]),
+                ("set/readme.txt", b"hi".to_vec()),
+                ("other/x.parquet", parquet_bytes(vec![6])),
+            ]);
+            let store: Arc<dyn ObjectStore> = store;
+            let listed =
+                list_parquet_under_prefix(&store, &ObjectPath::from("set"), "memory://set/")
+                    .unwrap();
+            let keys: Vec<String> = listed
+                .iter()
+                .map(|p| p.location.as_ref().to_string())
+                .collect();
+            assert_eq!(
+                keys,
+                vec!["set/a.parquet", "set/b.parquet", "set/nested/c.parquet"],
+                "exactly the visible .parquet keys, sorted"
+            );
+            assert!(listed.iter().all(|p| p.size > 0), "sizes from the listing");
+        }
+
+        /// Listed parts stream in key order through a ConvertSource, all
+        /// sharing ONE store instance.
+        #[test]
+        fn listed_parts_stream_in_order() {
+            let store = seeded_store(&[
+                ("set/p1.parquet", parquet_bytes(vec![10, 11])),
+                ("set/p0.parquet", parquet_bytes(vec![0, 1])),
+            ]);
+            let store: Arc<dyn ObjectStore> = store;
+            let listed =
+                list_parquet_under_prefix(&store, &ObjectPath::from("set"), "memory://set/")
+                    .unwrap();
+            let parts: Vec<InputSource> = listed
+                .into_iter()
+                .map(|p| {
+                    InputSource::Remote(RemoteSource::from_store_sized(
+                        Arc::clone(&store),
+                        p.location.clone(),
+                        format!("memory://{}", p.location),
+                        p.size,
+                    ))
+                })
+                .collect();
+            let src = ConvertSource::Multi(
+                MultiSource::from_sources("memory://set/".to_string(), parts).unwrap(),
+            );
+            let plan = ReadPlan {
+                batch_size: 1024,
+                projection: None,
+                row_groups: None,
+            };
+            assert_eq!(stream_ids(&src, &plan), vec![0, 1, 10, 11]);
+            let stats = src.fetch_stats().expect("remote parts have stats");
+            assert!(stats.object_size > 0, "object_size sums the parts");
+        }
     }
 }

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -822,6 +822,24 @@ pub fn convert_to_overviews(
     )
 }
 
+/// [`convert_to_overviews`] over an already-resolved [`ConvertSource`] —
+/// the entry point for callers that build the (possibly multi-partition)
+/// source themselves: a `--files-from` manifest
+/// ([`ConvertSource::from_manifest`]), an explicit input list
+/// ([`ConvertSource::from_input_list`]), or custom object stores.
+pub fn convert_to_overviews_sources(
+    source: &ConvertSource,
+    output_path: &Path,
+    options: &ConvertOptions,
+) -> Result<ConvertReport, ConvertError> {
+    convert_to_overviews_source_strategy(
+        source,
+        output_path,
+        options,
+        super::stream::Pass2Strategy::Pipelined,
+    )
+}
+
 /// [`convert_to_overviews`] over an already-resolved [`InputSource`] — the
 /// entry point for callers that construct the source themselves (custom
 /// object stores, tests over in-memory stores).
@@ -1552,42 +1570,51 @@ pub(super) const FULL_FILE_REMOTE_WARN_BYTES: u64 = 1 << 30;
 /// for local inputs (OS page cache), for effective bbox extracts (fewer row
 /// groups read than the file holds), and for objects below the threshold.
 pub(super) fn full_file_remote_warning(
-    is_remote: bool,
+    remote_parts: usize,
     row_groups_read: usize,
     row_groups_total: usize,
     object_size: u64,
 ) -> Option<String> {
-    if !is_remote || row_groups_read < row_groups_total || object_size < FULL_FILE_REMOTE_WARN_BYTES
+    if remote_parts == 0
+        || row_groups_read < row_groups_total
+        || object_size < FULL_FILE_REMOTE_WARN_BYTES
     {
         return None;
     }
+    let gib = object_size as f64 / (1024.0 * 1024.0 * 1024.0);
+    // Multi-partition sources (v0.7) sum object_size over their remote
+    // parts, so name the part count: 20 × 600 MB partitions trip the same
+    // ≥1 GiB total-transfer threshold as one 12 GiB object.
+    let what = if remote_parts > 1 {
+        format!("{remote_parts} remote partitions totalling {gib:.1} GiB")
+    } else {
+        format!("a {gib:.1} GiB object")
+    };
     Some(format!(
-        "full-file remote convert of a {:.1} GiB object: it is fetched once over \
+        "full-file remote convert of {what}: the input is fetched once over \
          the network (≈1× — the local spill keeps later passes off the network, \
          #219) and staged under $TMPDIR. For a region of interest pass --bbox to \
          fetch only the covering row groups (and skip the spill); otherwise \
          downloading first (e.g. `aws s3 cp`) and converting locally avoids the \
          second-pass disk read. Point --spill-dir (or $TMPDIR) at fast local disk \
          with room for it, not a small tmpfs.",
-        object_size as f64 / (1024.0 * 1024.0 * 1024.0),
     ))
 }
 
 /// Emit the #267 nudge for a full-file remote convert, if warranted. Thin
 /// logging wrapper over [`full_file_remote_warning`] (for a multi source,
-/// `object_size` is summed over the remote parts).
+/// `object_size` is summed over the remote parts and the part count is
+/// named in the message).
 pub(super) fn warn_full_file_remote(
     source: &ConvertSource,
     row_groups_read: usize,
     row_groups_total: usize,
 ) {
     let object_size = source.fetch_stats().map_or(0, |s| s.object_size);
-    if let Some(msg) = full_file_remote_warning(
-        source.is_remote(),
-        row_groups_read,
-        row_groups_total,
-        object_size,
-    ) {
+    let remote_parts = source.parts().iter().filter(|p| p.is_remote()).count();
+    if let Some(msg) =
+        full_file_remote_warning(remote_parts, row_groups_read, row_groups_total, object_size)
+    {
         log::warn!("{msg}");
     }
 }
@@ -2589,24 +2616,50 @@ mod tests {
     #[test]
     fn full_file_remote_warning_gated_on_large_unpruned_remote() {
         const BIG: u64 = 4 << 30; // 4 GiB, above the 1 GiB threshold
-                                  // Local input: re-reads hit the OS page cache — never warn.
-        assert!(full_file_remote_warning(false, 8, 8, BIG).is_none());
+                                  // Local input (0 remote parts): re-reads hit
+                                  // the OS page cache — never warn.
+        assert!(full_file_remote_warning(0, 8, 8, BIG).is_none());
         // Effective bbox extract (fewer row groups read): never warn.
-        assert!(full_file_remote_warning(true, 2, 8, BIG).is_none());
+        assert!(full_file_remote_warning(1, 2, 8, BIG).is_none());
         // Small remote object: below threshold — never warn.
-        assert!(full_file_remote_warning(true, 8, 8, 100 << 20).is_none());
+        assert!(full_file_remote_warning(1, 8, 8, 100 << 20).is_none());
         // Just below the threshold: still quiet.
-        assert!(full_file_remote_warning(true, 8, 8, FULL_FILE_REMOTE_WARN_BYTES - 1).is_none());
+        assert!(full_file_remote_warning(1, 8, 8, FULL_FILE_REMOTE_WARN_BYTES - 1).is_none());
         // At the threshold: warns (guard is a strict `<`).
-        assert!(full_file_remote_warning(true, 8, 8, FULL_FILE_REMOTE_WARN_BYTES).is_some());
+        assert!(full_file_remote_warning(1, 8, 8, FULL_FILE_REMOTE_WARN_BYTES).is_some());
         // Large full-file remote: warns, and the nudge names the cheaper paths.
-        let msg = full_file_remote_warning(true, 8, 8, BIG)
+        let msg = full_file_remote_warning(1, 8, 8, BIG)
             .expect("large full-file remote convert should warn");
         assert!(msg.contains("--bbox"), "nudge should mention --bbox: {msg}");
         assert!(
             msg.contains("4.0 GiB"),
             "nudge should state the object size: {msg}"
         );
+        assert!(
+            !msg.contains("partitions"),
+            "single object: no part count in the message: {msg}"
+        );
+    }
+
+    /// v0.7 multi-partition: the summed object size trips the same
+    /// threshold (20 × 600 MB with no bbox IS a ≥1 GiB full-file remote
+    /// convert), and the message names the part count so the total is not
+    /// mistaken for one object.
+    #[test]
+    fn full_file_remote_warning_names_partition_count() {
+        const PART: u64 = 600 << 20; // 600 MB per partition
+        let msg = full_file_remote_warning(20, 40, 40, 20 * PART)
+            .expect("20 x 600 MB unpruned remote parts should warn");
+        assert!(
+            msg.contains("20 remote partitions"),
+            "message names the part count: {msg}"
+        );
+        assert!(
+            msg.contains("11.7 GiB"),
+            "message states the summed size: {msg}"
+        );
+        // Summed size below the threshold stays quiet regardless of count.
+        assert!(full_file_remote_warning(20, 40, 40, 500 << 20).is_none());
     }
 
     /// #272: the spill free-space preflight warns when the projected spill
@@ -5450,6 +5503,162 @@ mod tests {
                 read_all_ids(&OverviewReader::open(tout_local.path()).unwrap()),
             );
             assert!(report_remote.remote_fetch.is_some());
+        }
+
+        // --- multi-partition remote input (v0.7 PR-B) ------------------------
+
+        /// Partition bytes for `geoms[range]`, via the shared local writer.
+        fn partition_bytes(
+            geoms: &[Geometry<f64>],
+            range: std::ops::Range<usize>,
+            row_group_rows: Option<usize>,
+        ) -> Vec<u8> {
+            let tmp = tempfile::NamedTempFile::new().unwrap();
+            write_input_partition(tmp.path(), geoms, range, row_group_rows);
+            std::fs::read(tmp.path()).unwrap()
+        }
+
+        /// Convert a remote ConvertSource and export to PMTiles; returns
+        /// the archive bytes (PMTiles export is byte-deterministic).
+        fn convert_sources_and_export(
+            source: &crate::input_set::ConvertSource,
+            workdir: &Path,
+            tag: &str,
+            opts: &ConvertOptions,
+        ) -> Vec<u8> {
+            use crate::overview::export::{export_pmtiles, ExportOptions};
+            let overview = workdir.join(format!("{tag}-overview.parquet"));
+            let pmtiles = workdir.join(format!("{tag}.pmtiles"));
+            convert_to_overviews_sources(source, &overview, opts).unwrap();
+            export_pmtiles(&overview, &pmtiles, &ExportOptions::default()).unwrap();
+            std::fs::read(&pmtiles).unwrap()
+        }
+
+        /// #219's ≈1× guarantee must hold PER PART across the streaming
+        /// pipeline's three passes (assign, coarse levels, finest last):
+        /// each part's fetched ranges sum to at most ~1.5× its object size
+        /// (footer overhead), and no byte range crosses the network twice.
+        #[test]
+        fn multi_part_three_pass_moves_each_part_once() {
+            let geoms = synthetic_geometries();
+            let n = geoms.len();
+            let (source, parts) = crate::input::test_memory_multi_source(vec![
+                ("p0.parquet", partition_bytes(&geoms, 0..5, None)),
+                ("p1.parquet", partition_bytes(&geoms, 5..9, None)),
+                ("p2.parquet", partition_bytes(&geoms, 9..n, None)),
+            ]);
+            assert_eq!(parts.len(), 3);
+
+            let tout = tempfile::NamedTempFile::new().unwrap();
+            let report =
+                convert_to_overviews_sources(&source, tout.path(), &multi_test_options()).unwrap();
+            assert_eq!(report.input_features, n);
+
+            let summed = report.remote_fetch.expect("multi remote reports stats");
+            let mut object_total = 0;
+            for part in &parts {
+                let stats = part.fetch_stats().expect("remote part has stats");
+                object_total += stats.object_size;
+                assert!(
+                    stats.bytes_fetched <= stats.object_size + stats.object_size / 2,
+                    "part {} moved {} bytes for a {}-byte object (>1.5x, #219 \
+                     must hold per part)",
+                    part.display_name(),
+                    stats.bytes_fetched,
+                    stats.object_size,
+                );
+                // No byte range crosses the network twice for any part.
+                let mut seen = std::collections::HashSet::new();
+                for r in part.fetched_ranges().expect("remote part logs ranges") {
+                    assert!(
+                        seen.insert((r.start, r.end)),
+                        "part {}: range {r:?} fetched more than once (#219)",
+                        part.display_name(),
+                    );
+                }
+            }
+            assert_eq!(
+                summed.object_size, object_total,
+                "ConvertReport.remote_fetch.object_size sums the parts"
+            );
+        }
+
+        /// bbox pruning an ENTIRE part: its row groups are pruned at the
+        /// footer level, so the network never touches that part's data
+        /// pages — only its footer (fetched once at set construction).
+        #[test]
+        fn multi_part_bbox_prunes_part_to_footer_only() {
+            let geoms = synthetic_geometries();
+            let n = geoms.len();
+            // p1 holds ONLY the lines (x 40..96); the bbox below excludes them.
+            let p1_bytes = partition_bytes(&geoms, 6..10, None);
+            let p1_spans = row_group_spans(&p1_bytes);
+            let (source, parts) = crate::input::test_memory_multi_source(vec![
+                ("p0.parquet", partition_bytes(&geoms, 0..6, None)),
+                ("p1.parquet", p1_bytes),
+                ("p2.parquet", partition_bytes(&geoms, 10..n, None)),
+            ]);
+
+            let opts = ConvertOptions {
+                bbox: Some([-100.0, -70.0, 30.0, 20.0]),
+                ..multi_test_options()
+            };
+            let tout = tempfile::NamedTempFile::new().unwrap();
+            let report = convert_to_overviews_sources(&source, tout.path(), &opts).unwrap();
+            assert!(
+                report.row_groups_read < report.row_groups_total,
+                "bbox must prune the lines part: {}/{}",
+                report.row_groups_read,
+                report.row_groups_total
+            );
+
+            let pruned = &parts[1];
+            let fetched = pruned.fetched_ranges().expect("remote part logs ranges");
+            assert!(
+                !fetched.is_empty(),
+                "the footer itself is fetched at set construction"
+            );
+            for r in &fetched {
+                for span in &p1_spans {
+                    assert!(
+                        r.end <= span.start || r.start >= span.end,
+                        "pruned part fetched data-page range {r:?} \
+                         (row-group span {span:?}) — must be footer-only"
+                    );
+                }
+            }
+        }
+
+        /// The PR-A anchor, over the wire: the same rows as one remote
+        /// object and as three remote partitions under one prefix must
+        /// produce byte-identical PMTiles.
+        #[test]
+        fn multi_part_remote_output_matches_single_remote() {
+            let geoms = synthetic_geometries();
+            let n = geoms.len();
+            let dir = tempfile::tempdir().unwrap();
+            let opts = multi_test_options();
+
+            let (single, _) = crate::input::test_memory_multi_source(vec![(
+                "single.parquet",
+                partition_bytes(&geoms, 0..n, None),
+            )]);
+            let (multi, parts) = crate::input::test_memory_multi_source(vec![
+                ("part-000.parquet", partition_bytes(&geoms, 0..5, None)),
+                ("part-001.parquet", partition_bytes(&geoms, 5..9, None)),
+                ("part-002.parquet", partition_bytes(&geoms, 9..n, None)),
+            ]);
+            assert_eq!(parts.len(), 3);
+
+            let pm_single = convert_sources_and_export(&single, dir.path(), "single", &opts);
+            let pm_multi = convert_sources_and_export(&multi, dir.path(), "multi", &opts);
+            assert!(
+                pm_single == pm_multi,
+                "remote multi-partition output must be byte-identical to the \
+                 single remote object ({} vs {} bytes)",
+                pm_single.len(),
+                pm_multi.len()
+            );
         }
 
         /// A throwaway localhost HTTP/1.1 server that serves one byte blob with

--- a/crates/python/gpq_tiles.pyi
+++ b/crates/python/gpq_tiles.pyi
@@ -18,7 +18,7 @@ def convert(
     simple_clip_fastpath: bool = True,
 ) -> None: ...
 def overview(
-    input: str,
+    input: str | list[str],
     output: str,
     *,
     mode: str = "duplicating",

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -2,18 +2,20 @@
 //!
 //! This module exposes the gpq-tiles-core functionality to Python via pyo3.
 
+use gpq_tiles_core::input_set::ConvertSource;
 use gpq_tiles_core::overview::assign::{
     AssignConfig, DensityBudgetConfig, SortDirection, CLUSTER_POINT_THINNING_DEFAULT,
 };
 use gpq_tiles_core::overview::check::validate_file;
 use gpq_tiles_core::overview::cluster::{AccumulateOp, AccumulateSpec};
 use gpq_tiles_core::overview::convert::{
-    convert_to_overviews, ClassRanking, ConvertError, ConvertOptions, ConvertReport, LevelPlan,
+    convert_to_overviews, convert_to_overviews_sources, ClassRanking, ConvertError, ConvertOptions,
+    ConvertReport, LevelPlan,
 };
 use gpq_tiles_core::overview::export::{export_pmtiles as export_pmtiles_core, ExportOptions};
 use gpq_tiles_core::overview::level::{MemoryProfile, Mode};
 use gpq_tiles_core::overview::simplify::SimplifyOptions;
-use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::exceptions::{PyRuntimeError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 use std::collections::BTreeMap;
@@ -213,10 +215,15 @@ fn convert_report_to_dict(py: Python<'_>, report: &ConvertReport) -> PyResult<Py
 /// exportable to PMTiles by ``export_pmtiles()``.
 ///
 /// Args:
-///     input (str): Input GeoParquet file (EPSG:4326 or EPSG:3857): a local
-///         path or a remote URL (``s3://``, ``https://``, ``gs://``) read via
-///         byte-range requests. With ``bbox``, only the matching row groups
-///         of a remote input are ever downloaded.
+///     input (str or list[str]): Input GeoParquet (EPSG:4326 or EPSG:3857):
+///         a local file, a directory or glob of partitions, a remote URL
+///         (``s3://``, ``https://``, ``gs://``), an ``s3://…/`` or
+///         ``gs://…/`` prefix (listed to its ``.parquet`` objects, sorted by
+///         key), or an explicit ordered ``list[str]`` of files/URLs (each a
+///         single file/object — no expansion; list order defines the dataset
+///         row order). Remote inputs are read via byte-range requests. With
+///         ``bbox``, only the matching row groups of a remote input are ever
+///         downloaded.
 ///     output (str): Output overview GeoParquet file.
 ///     mode (str, optional): Level materialization mode, "duplicating" (each
 ///         level is a self-contained rendering) or "partitioning" (each
@@ -406,7 +413,7 @@ fn convert_report_to_dict(py: Python<'_>, report: &ConvertReport) -> PyResult<Py
 #[allow(clippy::too_many_arguments)] // Python API mirrors CLI flags; grouping into struct would hurt usability
 fn overview(
     py: Python<'_>,
-    input: &str,
+    input: &Bound<'_, PyAny>,
     output: &str,
     mode: &str,
     min_zoom: u8,
@@ -594,12 +601,37 @@ fn overview(
         spill_dir,
     };
 
-    let input_path = Path::new(input).to_path_buf();
+    // `str` stays the single-input path (files, directories, globs, remote
+    // URLs/prefixes — resolved by core); `list[str]` is an explicit ordered
+    // part list (v0.7 multi-partition). The str check runs FIRST: a str is
+    // itself a sequence, so Vec extraction would happily split it into
+    // characters.
+    enum OverviewInput {
+        Path(PathBuf),
+        List(Vec<String>),
+    }
+    let parsed = if let Ok(s) = input.extract::<String>() {
+        OverviewInput::Path(PathBuf::from(s))
+    } else if let Ok(list) = input.extract::<Vec<String>>() {
+        OverviewInput::List(list)
+    } else {
+        return Err(PyTypeError::new_err(
+            "input must be a str path/URL or a list[str] of paths/URLs",
+        ));
+    };
     let output_path = Path::new(output).to_path_buf();
 
     // Release the GIL while the Rust pipeline runs.
     let report = py
-        .detach(|| convert_to_overviews(&input_path, &output_path, &options))
+        .detach(|| match &parsed {
+            OverviewInput::Path(input_path) => {
+                convert_to_overviews(input_path, &output_path, &options)
+            }
+            OverviewInput::List(inputs) => {
+                let source = ConvertSource::from_input_list(inputs).map_err(ConvertError::from)?;
+                convert_to_overviews_sources(&source, &output_path, &options)
+            }
+        })
         .map_err(convert_error_to_py)?;
 
     convert_report_to_dict(py, &report)

--- a/crates/python/tests/test_overview.py
+++ b/crates/python/tests/test_overview.py
@@ -41,6 +41,49 @@ class TestRemoteInput:
         assert "s3://" in doc
 
 
+STREAMING_SMALL = FIXTURES_DIR / "streaming" / "multi-rowgroup-small.parquet"
+
+needs_streaming_small = pytest.mark.skipif(
+    not STREAMING_SMALL.exists(),
+    reason="multi-rowgroup-small.parquet fixture not available",
+)
+
+
+class TestMultiPartitionInput:
+    """list[str] input (v0.7 multi-partition): explicit ordered part list."""
+
+    @needs_streaming_small
+    def test_list_input_concatenates_parts(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            single = Path(tmpdir) / "single.parquet"
+            double = Path(tmpdir) / "double.parquet"
+            r1 = gpq_tiles.overview(str(STREAMING_SMALL), str(single), max_zoom=4)
+            r2 = gpq_tiles.overview(
+                [str(STREAMING_SMALL), str(STREAMING_SMALL)],
+                str(double),
+                max_zoom=4,
+            )
+            assert r2["input_features"] == 2 * r1["input_features"]
+
+    @needs_streaming_small
+    def test_list_input_missing_entry_names_it(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir) / "o.parquet"
+            missing = Path(tmpdir) / "nope.parquet"
+            with pytest.raises((RuntimeError, ValueError), match="nope.parquet"):
+                gpq_tiles.overview(
+                    [str(STREAMING_SMALL), str(missing)], str(out), max_zoom=4
+                )
+
+    def test_input_wrong_type_is_type_error(self):
+        with pytest.raises(TypeError, match=r"list\[str\]"):
+            gpq_tiles.overview(123, "/tmp/o.parquet")  # type: ignore[arg-type]
+
+    def test_empty_list_is_an_error(self):
+        with pytest.raises((RuntimeError, ValueError)):
+            gpq_tiles.overview([], "/tmp/o.parquet")
+
+
 class TestOverviewApi:
     """API-surface tests for overview() (no fixture needed)."""
 

--- a/crates/python/tests/test_overview.py
+++ b/crates/python/tests/test_overview.py
@@ -70,7 +70,7 @@ class TestMultiPartitionInput:
         with tempfile.TemporaryDirectory() as tmpdir:
             out = Path(tmpdir) / "o.parquet"
             missing = Path(tmpdir) / "nope.parquet"
-            with pytest.raises((RuntimeError, ValueError), match="nope.parquet"):
+            with pytest.raises((RuntimeError, ValueError), match=r"nope\.parquet"):
                 gpq_tiles.overview(
                     [str(STREAMING_SMALL), str(missing)], str(out), max_zoom=4
                 )


### PR DESCRIPTION
Part **2/3** of the v0.7 multi-partition input feature (follows #277, PR-A).

## What

### Remote prefix listing (`s3://…/`, `gs://…/`)
`ConvertSource::resolve` now lists trailing-slash s3/gs prefixes natively instead of returning `RemotePrefixUnsupported`:

- `.parquet` keys only, **sorted by key** (the row-order invariant keys on it); zero-byte objects, `_SUCCESS`, and `.`/`_`-prefixed components below the prefix are skipped (mirrors the local directory walk).
- Non-slash extension-less URLs stay `Single` (the deliberate PR-A behavior — not regressed; covered by the existing classification tests).
- `http(s)://` prefixes stay a hard error: no generic listing API — the message points at `--files-from`.
- Empty listing → the standard `NoParquetInputs` error.

### Store sharing (one credential resolution)
Object-store construction is factored out of `RemoteSource::connect` into `store_and_location`, cached per `scheme://authority` for the process lifetime. One store instance serves the listing **and** all N per-part sources; part sizes come from the listing itself, so connecting N listed parts costs **zero** extra round-trips (no HEADs). Per-part footer loads in `MultiSource::from_sources` run with bounded concurrency (8 in flight) — hundreds of parts neither serialize hundreds of round-trips nor open hundreds of connections.

### `--files-from <PATH>` manifest (both `tiles` and `overview`)
- One local path or remote URL per line; `#` comment lines and blank lines skipped; **order preserved verbatim** (never sorted — it defines the dataset row order).
- Each line is a single file/object: no directory/glob/prefix recursion; a missing local entry errors naming the **line and path**. Mixed local+remote allowed.
- INPUT/OUTPUT are conditionally required: with `--files-from` the one positional is the OUTPUT; passing INPUT too is a named conflict. (Pure clap `conflicts_with` would mis-slot the OUTPUT positional into INPUT and produce a baffling error, so the conflict is enforced in `resolve_io`, unit-tested.)

### Python
`overview()` input is a plain string passthrough (core resolves dirs/globs/URLs/prefixes from the string, so all of the above already works from Python). For explicit part lists it now also accepts **`list[str]`** → `ConvertSource::from_input_list` (order verbatim, each entry a single file/object). Chosen over a `files_from=` kwarg as the least invasive shape that works: Python callers hold lists, not manifest files, and the manifest is a CLI affordance. `gpq_tiles.pyi` updated (`str | list[str]`); stubtest passes.

### Aggregated reporting
`ConvertReport.remote_fetch` sums over remote parts (asserted in tests). The #267 full-file warning is multi-part aware: 20 × 600 MB unpruned remote parts trip the same ≥1 GiB total-transfer threshold, and the message now names the part count ("20 remote partitions totalling 11.7 GiB") instead of implying one object.

## Custom endpoints — the Source Coop / FTW demo case

No new flags were needed: `AmazonS3Builder::from_env()` already honors `AWS_ENDPOINT_URL` (and `AWS_ENDPOINT`), `AWS_SKIP_SIGNATURE`, and `AWS_VIRTUAL_HOSTED_STYLE_REQUEST` (verified against object_store 0.12.5 source). The Source Coop proxy speaks S3 list-type=2 with the **account as the bucket** (path-style, unsigned); anonymous ListObjects on the raw `us-west-2.opendata.source.coop` bucket returns 0 keys, so the proxy form is the supported invocation:

```bash
AWS_ENDPOINT_URL=https://data.source.coop \
AWS_REGION=us-west-2 \
AWS_SKIP_SIGNATURE=true \
gpq-tiles overview \
  "s3://ftw/global-data/predictions/vectors/alpha/results-by-admin-conf/admin:country_code=AD/" \
  ftw-ad-overview.parquet
```

Verified live against source.coop: prefix listing filtered the sidecar `.json`/`.pmtiles`/`.md` down to the `.parquet` object and converted (85 features, 15 range requests); a two-object remote `--files-from` manifest (Andorra + AU_ACT, one shared store) converted end-to-end as well.

## Tests (TDD, targeted)

- **input_set**: manifest parsing (comments/blanks/1-based line numbers/order verbatim), missing-entry errors naming line+path, empty/unreadable manifest, single-entry collapse, `file://` lines, input-list validation; InMemory listing filter+sort (`_SUCCESS`, zero-byte, hidden components, out-of-prefix keys); listed parts stream in key order over one shared store.
- **overview::convert::remote_input**: 3 in-memory parts under one prefix — per-part Σ fetched ranges ≤ 1.5× object size and **no byte range fetched twice** (#219's ≈1× holds per part); bbox pruning an entire part fetches **footer only** (no fetched range intersects any row-group span); 3-part remote PMTiles **byte-identical** to the single concatenated remote object; summed `remote_fetch.object_size` equals Σ parts.
- **CLI**: `--files-from` parses on both subcommands; conflict/missing-OUTPUT shapes.
- **Python**: list input concatenates parts (2× features), missing entry named, wrong type → `TypeError`, empty list errors; stubtest clean.

`cargo clippy --workspace --all-targets` and `-p gpq-tiles-core --features remote` exit 0; `cargo fmt --all` clean; rebased on `main` after #278.

## For PR-C

- Manifest **remote** entries still connect serially with one HEAD each (`InputSource::from_str_input`); the store cache makes this one credential resolution per bucket, but a hundreds-of-URLs manifest would benefit from the same bounded-parallel connect used for footer loads.
- User-facing docs (README / docs/) don't cover multi-partition input yet — worth a section once the feature is complete.
- If credentialed users hit S3-compatible endpoints that reject foreign signatures, `AWS_SKIP_SIGNATURE=true` is the documented escape hatch; consider surfacing it in the remote-input error text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
