### PR TITLE
feat(cli): multi-partition UX polish — layer names, friendly rejections, docs (3/3)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -147,6 +147,11 @@ struct DecodeArgs {
     /// Write the JSON decode report to this path.
     #[arg(long, value_name = "PATH")]
     report: Option<PathBuf>,
+
+    /// Not supported here (single-file subcommand); accepted so the error
+    /// can point at `overview`/`tiles` instead of clap's generic message.
+    #[arg(long, value_name = "PATH", hide = true)]
+    files_from: Option<PathBuf>,
 }
 
 /// Arguments for `gpq-tiles export-pmtiles`.
@@ -186,6 +191,11 @@ struct ExportPmtilesArgs {
     /// different start vertex.
     #[arg(long)]
     no_simple_clip_fastpath: bool,
+
+    /// Not supported here (single-file subcommand); accepted so the error
+    /// can point at `overview`/`tiles` instead of clap's generic message.
+    #[arg(long, value_name = "PATH", hide = true)]
+    files_from: Option<PathBuf>,
 }
 
 /// Arguments for `gpq-tiles overview`.
@@ -786,6 +796,11 @@ struct ValidateArgs {
     /// GeoParquet overview file to validate.
     #[arg(value_name = "FILE")]
     file: PathBuf,
+
+    /// Not supported here (single-file subcommand); accepted so the error
+    /// can point at `overview`/`tiles` instead of clap's generic message.
+    #[arg(long, value_name = "PATH", hide = true)]
+    files_from: Option<PathBuf>,
 }
 
 /// Arguments for `gpq-tiles tiles` — the one-shot GeoParquet → PMTiles facade.
@@ -1282,6 +1297,9 @@ fn parse_accumulate(spec: &str) -> Result<gpq_tiles_core::overview::cluster::Acc
 fn run_validate(args: ValidateArgs) -> Result<()> {
     use gpq_tiles_core::overview::check::validate_file;
 
+    reject_files_from(args.files_from.as_ref(), "validate")?;
+    require_single_local_file(&args.file, "validate")?;
+
     let report = validate_file(&args.file)
         .map_err(|e| anyhow::anyhow!("could not open '{}': {e}", args.file.display()))?;
 
@@ -1303,16 +1321,55 @@ fn run_validate(args: ValidateArgs) -> Result<()> {
     }
 }
 
-/// Remote (URL) inputs are supported only where the converter reads them
-/// (`overview`, `tiles`); give the other subcommands a helpful error
-/// instead of a confusing `No such file or directory`.
-fn reject_remote_input(input: &std::path::Path, subcommand: &str) -> Result<()> {
-    if input.to_str().is_some_and(|s| s.contains("://")) {
+/// `validate`, `decode`, and `export-pmtiles` read exactly ONE local file.
+/// Multi-partition inputs (directories, globs, `s3://`/`gs://` prefixes,
+/// `--files-from` manifests) and remote URLs are converter features
+/// (`overview`, `tiles`); reject them here with a one-line pointer instead
+/// of an obscure I/O or parquet error.
+fn require_single_local_file(input: &std::path::Path, subcommand: &str) -> Result<()> {
+    let s = input.to_string_lossy();
+    if s.contains("://") {
+        // Query string / fragment stripped: `s3://b/set/?x` is a prefix.
+        let no_meta = s.split(['?', '#']).next().unwrap_or(&s);
+        if no_meta.ends_with('/') {
+            anyhow::bail!(
+                "`gpq-tiles {subcommand}` reads a single local file, but {} is a \
+                 remote prefix; multi-partition input (directories, globs, \
+                 s3://gs:// prefixes, --files-from) is supported by the `overview` \
+                 and `tiles` subcommands",
+                input.display()
+            );
+        }
         anyhow::bail!(
             "`gpq-tiles {subcommand}` does not support remote inputs (got {}); \
              remote URLs (s3://, https://, gs://) are supported by the `overview` \
              and `tiles` subcommands — download the file first (e.g. `aws s3 cp`)",
             input.display()
+        );
+    }
+    let kind = if input.is_dir() {
+        "a directory"
+    } else if s.contains(['*', '?', '[']) {
+        "a glob pattern"
+    } else {
+        return Ok(());
+    };
+    anyhow::bail!(
+        "`gpq-tiles {subcommand}` reads a single local file, but {} is {kind}; \
+         multi-partition input (directories, globs, s3://gs:// prefixes, \
+         --files-from) is supported by the `overview` and `tiles` subcommands",
+        input.display()
+    );
+}
+
+/// Reject `--files-from` on single-file subcommands with the same pointer
+/// (clap alone would say only "unexpected argument '--files-from'").
+fn reject_files_from(files_from: Option<&PathBuf>, subcommand: &str) -> Result<()> {
+    if files_from.is_some() {
+        anyhow::bail!(
+            "`gpq-tiles {subcommand}` reads a single local file and does not \
+             support --files-from; multi-partition input is supported by the \
+             `overview` and `tiles` subcommands"
         );
     }
     Ok(())
@@ -1323,7 +1380,8 @@ fn run_export_pmtiles(args: ExportPmtilesArgs) -> Result<()> {
 
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
-    reject_remote_input(&args.input, "export-pmtiles")?;
+    reject_files_from(args.files_from.as_ref(), "export-pmtiles")?;
+    require_single_local_file(&args.input, "export-pmtiles")?;
 
     let opts = ExportOptions {
         layer_name: args.layer_name,
@@ -1384,7 +1442,8 @@ fn run_decode(args: DecodeArgs) -> Result<()> {
 
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
-    reject_remote_input(&args.input, "decode")?;
+    reject_files_from(args.files_from.as_ref(), "decode")?;
+    require_single_local_file(&args.input, "decode")?;
 
     // `--zoom N` is shorthand for `--min-zoom N --max-zoom N` (clap already
     // rejects combining them).
@@ -1454,6 +1513,62 @@ fn format_number(n: u64) -> String {
 mod tests {
     use super::*;
     use gpq_tiles_core::overview::cluster::AccumulateOp;
+
+    // --- single-file-only rejections (v0.7 PR-C) -----------------------------
+
+    /// `validate`/`decode`/`export-pmtiles` are single-file only: a
+    /// directory, glob, or remote-prefix input must fail with a one-line
+    /// error naming the subcommand and pointing at `overview`/`tiles`,
+    /// not an obscure I/O or parquet error.
+    #[test]
+    fn single_file_subcommands_reject_multi_inputs() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Directory input.
+        let err = require_single_local_file(dir.path(), "validate")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("validate"), "names the subcommand: {err}");
+        assert!(err.contains("single"), "says single-file only: {err}");
+        assert!(
+            err.contains("overview") && err.contains("tiles"),
+            "points at the multi-partition subcommands: {err}"
+        );
+
+        // Remote prefix (trailing slash).
+        let err =
+            require_single_local_file(std::path::Path::new("s3://bucket/set/"), "export-pmtiles")
+                .unwrap_err()
+                .to_string();
+        assert!(err.contains("export-pmtiles"), "{err}");
+        assert!(err.contains("overview") && err.contains("tiles"), "{err}");
+
+        // Glob pattern.
+        let err = require_single_local_file(std::path::Path::new("/data/*.parquet"), "decode")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("decode"), "{err}");
+        assert!(err.contains("overview") && err.contains("tiles"), "{err}");
+
+        // A plain (single) local file passes.
+        let f = dir.path().join("x.parquet");
+        std::fs::write(&f, b"x").unwrap();
+        assert!(require_single_local_file(&f, "validate").is_ok());
+        // Nonexistent single file also passes (open reports the io error).
+        assert!(require_single_local_file(
+            std::path::Path::new("/no/such/file.parquet"),
+            "validate"
+        )
+        .is_ok());
+
+        // A single remote object keeps the historical download-first pointer.
+        let err =
+            require_single_local_file(std::path::Path::new("s3://bucket/file.parquet"), "validate")
+                .unwrap_err()
+                .to_string();
+        assert!(err.contains("remote"), "{err}");
+        assert!(err.contains("aws s3 cp"), "{err}");
+    }
 
     #[test]
     fn parse_accumulate_valid_specs() {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1024,15 +1024,15 @@ fn run_tiles(args: TilesArgs) -> Result<()> {
 
     let (spec, output) = resolve_io(args.input, args.output, args.files_from)?;
 
-    // Derive layer name from the input (or manifest) filename if not given.
+    // Derive the layer name from the input if not given: file stem for a
+    // single file, last path segment for a directory or s3://gs:// prefix,
+    // last literal segment for a glob, manifest stem for --files-from
+    // (core owns the rules — see input_set::derive_layer_name).
     let layer_name = args.layer_name.clone().unwrap_or_else(|| {
         let p = match &spec {
             InputSpec::Path(p) | InputSpec::Manifest(p) => p,
         };
-        p.file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("layer")
-            .to_string()
+        gpq_tiles_core::input_set::derive_layer_name(&p.to_string_lossy())
     });
 
     let bbox = args.bbox.as_ref().map(|s| parse_bbox(s)).transpose()?;

--- a/crates/core/src/input.rs
+++ b/crates/core/src/input.rs
@@ -824,6 +824,52 @@ pub(crate) mod remote {
 
     /// Map an object-store error, attaching the input URL.
     fn store_error(url: &str, source: object_store::Error) -> InputError {
+        store_error_with_hint(url, source, custom_endpoint_configured())
+    }
+
+    /// Whether a custom (non-AWS) S3 endpoint is configured via the env
+    /// vars `AmazonS3Builder::from_env` honors.
+    fn custom_endpoint_configured() -> bool {
+        std::env::var_os("AWS_ENDPOINT_URL").is_some() || std::env::var_os("AWS_ENDPOINT").is_some()
+    }
+
+    /// Whether `text` (an object-store error rendering) looks like an S3
+    /// signature/authorization failure — the shape an anonymous
+    /// S3-compatible endpoint produces when ambient AWS credentials sign
+    /// requests it cannot verify.
+    fn looks_like_signature_error(text: &str) -> bool {
+        const MARKERS: [&str; 5] = [
+            "403",
+            "forbidden",
+            "invalidaccesskeyid",
+            "signaturedoesnotmatch",
+            "accessdenied",
+        ];
+        let lower = text.to_ascii_lowercase();
+        MARKERS.iter().any(|m| lower.contains(m))
+    }
+
+    /// [`store_error`] with the endpoint check injected (test seam). With a
+    /// custom endpoint configured, a signature/authorization-style failure
+    /// appends the `AWS_SKIP_SIGNATURE=true` hint — string-level, in the
+    /// Display path only (the error types are unchanged): resolved AWS
+    /// credentials are signed into every request, and an anonymous
+    /// S3-compatible endpoint rejects them with exactly this error shape.
+    fn store_error_with_hint(
+        url: &str,
+        source: object_store::Error,
+        custom_endpoint: bool,
+    ) -> InputError {
+        if custom_endpoint {
+            let text = source.to_string();
+            if looks_like_signature_error(&text) {
+                return InputError::RemoteConfig(format!(
+                    "remote input error for {url}: {text} — if this S3-compatible \
+                     endpoint serves anonymous (unsigned) requests, retry with \
+                     AWS_SKIP_SIGNATURE=true"
+                ));
+            }
+        }
         InputError::Remote {
             url: url.to_string(),
             source,
@@ -1288,6 +1334,57 @@ pub(crate) mod remote {
                 spill.get(0).is_none(),
                 "create failure must disable the spill"
             );
+        }
+    }
+
+    #[cfg(test)]
+    mod hint_tests {
+        use super::*;
+
+        fn signature_shaped_error() -> object_store::Error {
+            object_store::Error::Generic {
+                store: "S3",
+                source: "Client error with status 403 Forbidden: \
+                         <Code>InvalidAccessKeyId</Code>"
+                    .into(),
+            }
+        }
+
+        /// PR-C: a signature/authorization-style failure against a custom
+        /// S3-compatible endpoint appends the AWS_SKIP_SIGNATURE hint in
+        /// the error text (string-level; the error types are unchanged).
+        #[test]
+        fn signature_error_on_custom_endpoint_appends_skip_signature_hint() {
+            let msg = store_error_with_hint("s3://b/k.parquet", signature_shaped_error(), true)
+                .to_string();
+            assert!(
+                msg.contains("AWS_SKIP_SIGNATURE=true"),
+                "hint appended: {msg}"
+            );
+            assert!(msg.contains("s3://b/k.parquet"), "keeps the URL: {msg}");
+            assert!(msg.contains("403"), "keeps the original error: {msg}");
+        }
+
+        /// Without a custom endpoint the error is untouched (the hint is
+        /// specific to S3-compatible endpoints like anonymous data hosts).
+        #[test]
+        fn signature_error_without_custom_endpoint_is_unchanged() {
+            let msg = store_error_with_hint("s3://b/k.parquet", signature_shaped_error(), false)
+                .to_string();
+            assert!(!msg.contains("AWS_SKIP_SIGNATURE"), "no hint: {msg}");
+            assert!(msg.contains("403"), "original error preserved: {msg}");
+        }
+
+        /// A non-signature failure (e.g. object not found) never grows the
+        /// hint, custom endpoint or not.
+        #[test]
+        fn non_signature_error_never_hints() {
+            let not_found = object_store::Error::NotFound {
+                path: "k.parquet".to_string(),
+                source: "no such key".into(),
+            };
+            let msg = store_error_with_hint("s3://b/k.parquet", not_found, true).to_string();
+            assert!(!msg.contains("AWS_SKIP_SIGNATURE"), "no hint: {msg}");
         }
     }
 }

--- a/crates/core/src/input_set.rs
+++ b/crates/core/src/input_set.rs
@@ -322,23 +322,25 @@ impl ConvertSource {
     /// Shared by [`Self::from_manifest`] and [`Self::from_input_list`]:
     /// resolve each `(context, entry)` as a single source, requiring local
     /// entries to exist up front so the error can name the entry instead
-    /// of surfacing as a bare I/O error at footer-load time.
+    /// of surfacing as a bare I/O error at footer-load time. Remote entries
+    /// connect (one HEAD each) under bounded concurrency
+    /// ([`LIST_CONNECT_CONCURRENCY`]); entry order is preserved verbatim
+    /// in the resulting parts (the row-order invariant).
     fn from_explicit_list(root: &str, entries: &[(String, String)]) -> Result<Self, InputError> {
-        let mut parts = Vec::with_capacity(entries.len());
-        for (context, entry) in entries {
+        let parts = resolve_list_entries(entries, |context, entry| {
             let src = InputSource::from_str_input(entry)?;
             // Without the `remote` feature `Local` is the only variant.
             #[cfg_attr(not(feature = "remote"), allow(irrefutable_let_patterns))]
             if let InputSource::Local(p) = &src {
                 if !p.is_file() {
                     return Err(InputError::MissingListedInput {
-                        context: context.clone(),
-                        input: entry.clone(),
+                        context: context.to_string(),
+                        input: entry.to_string(),
                     });
                 }
             }
-            parts.push(src);
-        }
+            Ok(src)
+        })?;
         Self::from_parts(root, parts)
     }
 
@@ -812,6 +814,58 @@ impl Iterator for SourceStream<'_> {
 /// Whether `input` contains glob metacharacters (`*`, `?`, `[`).
 fn has_glob_meta(input: &str) -> bool {
     input.contains(['*', '?', '['])
+}
+
+/// Entry-resolution concurrency for explicit lists (`--files-from`
+/// manifests, Python input lists). Remote entries cost one connect (HEAD)
+/// each, so hundreds of manifest lines would otherwise serialize hundreds
+/// of round-trips; matches [`FOOTER_LOAD_CONCURRENCY`].
+const LIST_CONNECT_CONCURRENCY: usize = 8;
+
+/// Resolve every `(context, entry)` pair with `resolve` under bounded
+/// concurrency ([`LIST_CONNECT_CONCURRENCY`]). Results are written into
+/// per-index slots, so the returned vector always matches `entries` order
+/// regardless of completion order — the row-order invariant — and the
+/// first error (by entry index) wins.
+fn resolve_list_entries<F>(
+    entries: &[(String, String)],
+    resolve: F,
+) -> Result<Vec<InputSource>, InputError>
+where
+    F: Fn(&str, &str) -> Result<InputSource, InputError> + Sync,
+{
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    let workers = LIST_CONNECT_CONCURRENCY.min(entries.len());
+    if workers <= 1 {
+        return entries
+            .iter()
+            .map(|(context, entry)| resolve(context, entry))
+            .collect();
+    }
+    let next = AtomicUsize::new(0);
+    let slots: Vec<std::sync::Mutex<Option<Result<InputSource, InputError>>>> = (0..entries.len())
+        .map(|_| std::sync::Mutex::new(None))
+        .collect();
+    std::thread::scope(|scope| {
+        for _ in 0..workers {
+            scope.spawn(|| loop {
+                let i = next.fetch_add(1, Ordering::Relaxed);
+                if i >= entries.len() {
+                    break;
+                }
+                let (context, entry) = &entries[i];
+                *slots[i].lock().expect("entry slot lock") = Some(resolve(context, entry));
+            });
+        }
+    });
+    slots
+        .into_iter()
+        .map(|slot| {
+            slot.into_inner()
+                .expect("entry slot lock")
+                .expect("every slot filled by a worker")
+        })
+        .collect()
 }
 
 /// Parse `--files-from` manifest text into `(1-based line number, entry)`
@@ -1671,6 +1725,102 @@ b.parquet
             assert_eq!(stream_ids(&src, &plan), vec![0, 1, 10, 11]);
             let stats = src.fetch_stats().expect("remote parts have stats");
             assert!(stats.object_size > 0, "object_size sums the parts");
+        }
+
+        /// PR-C: explicit-list (manifest / input-list) entries resolve under
+        /// bounded parallelism, but the resulting parts MUST preserve entry
+        /// order VERBATIM (the row-order invariant) — never completion or
+        /// lexicographic order.
+        #[test]
+        fn explicit_list_parallel_connect_preserves_order() {
+            use std::sync::atomic::{AtomicBool, Ordering};
+            use std::sync::{Condvar, Mutex as StdMutex};
+
+            let store = seeded_store(&[
+                ("m/a.parquet", parquet_bytes(vec![10])),
+                ("m/b.parquet", parquet_bytes(vec![0, 1])),
+                ("m/c.parquet", parquet_bytes(vec![20])),
+            ]);
+            let store: Arc<dyn ObjectStore> = store;
+
+            // Deliberately NOT lexicographic: c, a, b.
+            let entries: Vec<(String, String)> = ["m/c.parquet", "m/a.parquet", "m/b.parquet"]
+                .into_iter()
+                .enumerate()
+                .map(|(i, key)| (format!("entry {}", i + 1), key.to_string()))
+                .collect();
+
+            // Overlap detector: the first resolver call blocks until a
+            // second one is in flight (or a generous timeout passes), so a
+            // serial implementation fails the `overlapped` assertion while
+            // a parallel one passes deterministically.
+            let in_flight = StdMutex::new(0usize);
+            let cv = Condvar::new();
+            let overlapped = AtomicBool::new(false);
+
+            let resolved = resolve_list_entries(&entries, |_context, entry| {
+                {
+                    let mut n = in_flight.lock().unwrap();
+                    *n += 1;
+                    if *n >= 2 {
+                        overlapped.store(true, Ordering::SeqCst);
+                        cv.notify_all();
+                    } else {
+                        let (guard, _) = cv
+                            .wait_timeout_while(n, std::time::Duration::from_secs(10), |_| {
+                                !overlapped.load(Ordering::SeqCst)
+                            })
+                            .unwrap();
+                        drop(guard);
+                    }
+                }
+                Ok(InputSource::Remote(RemoteSource::from_store(
+                    Arc::clone(&store),
+                    ObjectPath::from(entry),
+                    format!("memory://{entry}"),
+                )?))
+            })
+            .unwrap();
+            assert!(
+                overlapped.load(Ordering::SeqCst),
+                "entry connects must overlap (bounded parallelism), not run serially"
+            );
+
+            let src = ConvertSource::from_parts("list", resolved).unwrap();
+            let plan = ReadPlan {
+                batch_size: 1024,
+                projection: None,
+                row_groups: None,
+            };
+            assert_eq!(
+                stream_ids(&src, &plan),
+                vec![20, 10, 0, 1],
+                "parts follow entry order verbatim"
+            );
+        }
+
+        /// Parallel completion order must not change WHICH error surfaces:
+        /// the first failing entry by INDEX wins.
+        #[test]
+        fn explicit_list_first_error_by_index_wins() {
+            let entries: Vec<(String, String)> = (1..=4)
+                .map(|i| (format!("entry {i}"), format!("e{i}")))
+                .collect();
+            let err = resolve_list_entries(&entries, |context, entry| {
+                if entry == "e2" || entry == "e4" {
+                    return Err(InputError::MissingListedInput {
+                        context: context.to_string(),
+                        input: entry.to_string(),
+                    });
+                }
+                Ok(InputSource::Local(PathBuf::from(entry)))
+            })
+            .unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains("entry 2"),
+                "first failing entry by index wins: {msg}"
+            );
         }
     }
 

--- a/crates/core/src/input_set.rs
+++ b/crates/core/src/input_set.rs
@@ -889,6 +889,70 @@ pub(crate) fn expand_glob(pattern: &str) -> Result<Vec<PathBuf>, InputError> {
     Ok(files)
 }
 
+/// Default PMTiles layer name derived from a CLI-style input string — the
+/// multi-partition generalization of "the input file's stem":
+///
+/// - single file (local path or nonexistent-yet path) → file stem
+///   (historical behavior; also what a `--files-from` manifest path gives:
+///   the manifest file's stem);
+/// - existing local directory → the directory's last path segment,
+///   verbatim (a dotted directory name is a name, not an extension);
+/// - glob pattern → the deepest literal (wildcard-free) path segment
+///   before the first wildcard segment;
+/// - remote URL (`scheme://…`, query string and fragment stripped):
+///   trailing-slash prefix → last non-empty path segment verbatim
+///   (bucket name for a bucket-root prefix); single object → the key's
+///   last segment's stem;
+/// - anything degenerate (empty, no usable segment) → `"layer"`, the
+///   same fallback the single-file path has always used.
+pub fn derive_layer_name(input: &str) -> String {
+    const FALLBACK: &str = "layer";
+    let stem_of = |p: &Path| p.file_stem().and_then(|s| s.to_str()).map(str::to_string);
+
+    let name = if url_scheme(input).is_some() {
+        let no_fragment = input.split('#').next().unwrap_or(input);
+        let no_query = no_fragment.split('?').next().unwrap_or(no_fragment);
+        let rest = no_query
+            .split_once("://")
+            .map(|(_, rest)| rest)
+            .unwrap_or(no_query);
+        rest.split('/')
+            .rev()
+            .find(|seg| !seg.is_empty())
+            .and_then(|seg| {
+                if remote_url_is_prefix(input) {
+                    Some(seg.to_string())
+                } else {
+                    stem_of(Path::new(seg))
+                }
+            })
+    } else {
+        let path = Path::new(input);
+        if path.is_dir() {
+            path.file_name()
+                .and_then(|n| n.to_str())
+                .map(str::to_string)
+        } else if !path.is_file() && has_glob_meta(input) {
+            // Deepest literal segment before the first wildcard one.
+            let mut last_literal = None;
+            for comp in path.components() {
+                if let std::path::Component::Normal(seg) = comp {
+                    match seg.to_str() {
+                        Some(s) if !has_glob_meta(s) => last_literal = Some(s.to_string()),
+                        // Wildcard (or non-UTF-8) segment: stop descending.
+                        _ => break,
+                    }
+                }
+            }
+            last_literal
+        } else {
+            stem_of(path)
+        }
+    };
+    name.filter(|n| !n.is_empty())
+        .unwrap_or_else(|| FALLBACK.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1608,5 +1672,81 @@ b.parquet
             let stats = src.fetch_stats().expect("remote parts have stats");
             assert!(stats.object_size > 0, "object_size sums the parts");
         }
+    }
+
+    // --- layer-name derivation (v0.7 PR-C) ------------------------------------
+
+    /// Single files (local or nonexistent-yet paths) keep the historical
+    /// behavior: the file stem, `"layer"` when there is none.
+    #[test]
+    fn layer_name_single_file_is_stem() {
+        assert_eq!(derive_layer_name("/data/buildings.parquet"), "buildings");
+        assert_eq!(derive_layer_name("buildings.parquet"), "buildings");
+        // A --files-from manifest path takes the manifest file's stem.
+        assert_eq!(
+            derive_layer_name("/tmp/portland-roads.txt"),
+            "portland-roads"
+        );
+    }
+
+    /// Directory inputs use the directory's last path segment VERBATIM
+    /// (no extension stripping — a dotted directory name is a name, not
+    /// a file extension), trailing slash tolerated.
+    #[test]
+    fn layer_name_directory_is_last_segment() {
+        let dir = tmpdir();
+        let parts = dir.path().join("nyc_buildings");
+        std::fs::create_dir(&parts).unwrap();
+        assert_eq!(derive_layer_name(parts.to_str().unwrap()), "nyc_buildings");
+
+        let dotted = dir.path().join("buildings.v2");
+        std::fs::create_dir(&dotted).unwrap();
+        assert_eq!(
+            derive_layer_name(&format!("{}/", dotted.display())),
+            "buildings.v2"
+        );
+    }
+
+    /// Glob inputs use the deepest literal (wildcard-free) path segment
+    /// before the first wildcard segment; an all-wildcard pattern falls
+    /// back to `"layer"`.
+    #[test]
+    fn layer_name_glob_uses_last_literal_segment() {
+        assert_eq!(derive_layer_name("/data/parts/*.parquet"), "parts");
+        assert_eq!(derive_layer_name("/data/part-*.parquet"), "data");
+        assert_eq!(derive_layer_name("/data/**/part-?.parquet"), "data");
+        assert_eq!(derive_layer_name("*.parquet"), "layer");
+    }
+
+    /// `s3://`/`gs://` prefixes use the last non-empty path segment of the
+    /// prefix (query string and fragment stripped); a bucket-root prefix
+    /// uses the bucket name.
+    #[test]
+    fn layer_name_remote_prefix_uses_last_segment() {
+        assert_eq!(derive_layer_name("s3://bucket/datasets/roads/"), "roads");
+        assert_eq!(derive_layer_name("gs://bucket/roads/"), "roads");
+        assert_eq!(derive_layer_name("s3://bucket/roads/?list-type=2"), "roads");
+        assert_eq!(derive_layer_name("s3://bucket/"), "bucket");
+    }
+
+    /// Remote single objects behave like local single files: the object
+    /// key's stem, with query string / fragment stripped first.
+    #[test]
+    fn layer_name_remote_object_is_stem() {
+        assert_eq!(derive_layer_name("s3://bucket/data/roads.parquet"), "roads");
+        assert_eq!(
+            derive_layer_name("https://host/dl/roads.parquet?sig=abc"),
+            "roads"
+        );
+        // Extension-less presigned/API URL: last segment verbatim.
+        assert_eq!(derive_layer_name("https://host/api/download/42"), "42");
+    }
+
+    /// Degenerate inputs sanitize to the historical `"layer"` fallback.
+    #[test]
+    fn layer_name_degenerate_falls_back() {
+        assert_eq!(derive_layer_name(""), "layer");
+        assert_eq!(derive_layer_name("s3://"), "layer");
+        assert_eq!(derive_layer_name("/"), "layer");
     }
 }

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -82,14 +82,11 @@ fn convert(
     let input_path = Path::new(input).to_path_buf();
     let output_path = Path::new(output).to_path_buf();
 
-    // Derive layer name from input filename if not provided.
-    let layer_name = layer_name.unwrap_or_else(|| {
-        input_path
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("layer")
-            .to_string()
-    });
+    // Derive the layer name from the input if not provided: file stem for a
+    // single file, last path segment for a directory or s3://gs:// prefix,
+    // last literal segment for a glob (core owns the rules).
+    let layer_name =
+        layer_name.unwrap_or_else(|| gpq_tiles_core::input_set::derive_layer_name(input));
 
     let options = ConvertOptions {
         levels: LevelPlan::ZoomRange { min_zoom, max_zoom },

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ export_pmtiles("overviews.parquet", "output.pmtiles")
 - [API Reference](api-reference.md) — CLI flags, Python API, Rust API
 - [Advanced Usage](advanced-usage.md) — Input optimization, memory, export
 - [Remote Reads](remote-reads.md) — Converting directly from s3://, https://, gs:// inputs, and querying overview files in place with DuckDB
+- [Multi-Partition Input](multi-partition.md) — Directories, globs, s3://gs:// prefixes, and --files-from manifests as one dataset
 - [Architecture](architecture.md) — Design decisions and internals
 
 ## License

--- a/docs/multi-partition.md
+++ b/docs/multi-partition.md
@@ -1,0 +1,161 @@
+# Multi-Partition Input
+
+Real-world GeoParquet datasets frequently arrive as a *set* of parquet
+files — Hive/Spark `part-*.parquet` directories, Overture-style
+partitions — rather than one file. The `overview` and `tiles`
+subcommands (and the Python `overview()` function) accept such sets
+directly and read them as one logical dataset:
+
+```bash
+# A directory of partitions (recursive)
+gpq-tiles overview parts/ overviews.parquet
+
+# A glob pattern (quote it so the shell doesn't expand it)
+gpq-tiles tiles "parts/**/*.parquet" tiles.pmtiles
+
+# An s3:// or gs:// prefix (note the trailing slash)
+gpq-tiles overview s3://bucket/dataset/ overviews.parquet
+
+# An explicit ordered manifest
+gpq-tiles overview --files-from manifest.txt overviews.parquet
+```
+
+`validate`, `decode`, and `export-pmtiles` are single-file
+subcommands: given a directory, glob, remote prefix, or
+`--files-from`, they fail with a one-line error pointing back at
+`overview`/`tiles`.
+
+## How an input string is resolved
+
+| input shape | resolution |
+|---|---|
+| existing local file | single file (the historical behavior) |
+| existing local directory | recursive collection of `.parquet` files |
+| string containing `*`, `?`, or `[` | glob expansion, filtered to `.parquet` files |
+| `s3://`/`gs://` URL ending in `/` | native object listing under the prefix |
+| `s3://`/`gs://` URL not ending in `/` | one remote object (extension-less presigned/API URLs included) |
+| `https://` URL ending in `/` | error — generic HTTP has no listing API; use `--files-from` |
+| `--files-from <PATH>` | explicit ordered manifest (see below) |
+
+The trailing slash is what makes a remote URL a prefix — query string
+and fragment are stripped before the check, so
+`s3://bucket/dataset/?list-type=2` is still a prefix. A resolution
+that finds exactly one file collapses to the single-file path; one
+that finds none fails with `no .parquet files found in input ...`.
+
+## Sidecar filtering
+
+Partitioned datasets carry non-data files; the resolvers skip them:
+
+- **Directories** (local): only `*.parquet` files are collected, and
+  any file or directory whose basename starts with `.` or `_` is
+  skipped at every level — `_SUCCESS`, `.crc` files, `_temporary/`
+  and `_delta_log/` trees never participate.
+- **Remote prefixes**: only keys ending `.parquet` are listed;
+  zero-byte objects are skipped; so is any key with a path component
+  below the prefix starting with `.` or `_`.
+- **Globs**: only files with a `.parquet` extension survive, but no
+  hidden-name filtering is applied — a glob names its matches
+  explicitly.
+
+## Ordering guarantee
+
+The converter reads its input several times (assignment scan, coarse
+levels, canonical finest level) and keys its winner tables by global
+row offset, so every pass must see the same rows in the same order.
+`ConvertSource` guarantees this at resolve time:
+
+- directory, glob, and prefix results are **sorted
+  lexicographically** (by path / object key) and never reordered;
+- `--files-from` manifests and Python `list[str]` inputs are
+  preserved **verbatim, in entry order** — reordering the manifest
+  reorders the dataset;
+- rows stream in part order: part *i + 1* opens only after part *i*
+  is exhausted.
+
+## Schema and CRS validation
+
+All partitions are validated against the first one before any data is
+read (footers only, loaded with bounded concurrency):
+
+- identical column names, types, and order;
+- identical field (extension) metadata — the geometry encoding must
+  match, and the error shows the first differing metadata key when it
+  doesn't;
+- identical detected CRS (the error names both raw CRS declarations);
+- **nullability is the one permitted difference**: the exposed schema
+  is the union (any part nullable ⇒ nullable).
+
+A failure names the offending partition, e.g.
+`incompatible input partition "parts/b.parquet": column "id" has type
+Utf8 but the first partition has Int64 (first partition:
+"parts/a.parquet")`.
+
+## `--files-from` manifests
+
+`tiles` and `overview` accept `--files-from <PATH> OUTPUT` in place of
+the positional INPUT. The manifest format:
+
+- one local path or remote URL per line (entries are trimmed);
+- blank lines are skipped, as are comment lines whose first non-space
+  character is `#`;
+- line order is preserved verbatim — it defines the dataset row order;
+- each line must name a single `.parquet` file or object; directories,
+  globs, and prefixes are not expanded;
+- local and remote entries may be mixed;
+- a local entry that is not an existing file fails up front, naming
+  the manifest line and path.
+
+```text
+# ordered parts (this order defines the row order)
+/data/local-part-0.parquet
+s3://bucket/dataset/part-1.parquet
+https://example.com/download/part-2.parquet
+```
+
+Remote manifest entries connect in parallel (bounded at 8 concurrent
+connects), with the manifest order preserved in the result.
+
+This is also the workaround for the `https://` limitation: generic
+HTTP servers expose no listing API, so an `https://.../` prefix is
+rejected — list the object URLs explicitly in a manifest instead.
+
+In Python, pass a `list[str]` to `overview()` for the same explicit
+ordered-parts shape:
+
+```python
+from gpq_tiles import overview
+
+overview(["part-0.parquet", "s3://bucket/part-1.parquet"], "out.parquet")
+```
+
+## Default layer names
+
+When `tiles` (or Python `convert()`) derives the PMTiles layer name
+from the input, multi-partition shapes generalize the single-file
+"file stem" rule:
+
+| input | default layer name |
+|---|---|
+| `data/buildings.parquet` | `buildings` |
+| `data/nyc_buildings/` (directory) | `nyc_buildings` |
+| `data/parts/*.parquet` (glob) | `parts` (last wildcard-free segment) |
+| `s3://bucket/datasets/roads/` (prefix) | `roads` |
+| `--files-from portland-roads.txt` | `portland-roads` (manifest stem) |
+
+Pass `--layer-name` (Python: `layer_name=`) to override.
+
+## Remote behavior notes
+
+- All parts of an `s3://`/`gs://` prefix share one object-store
+  instance, so credentials are resolved once per bucket; object sizes
+  come from the listing (no per-part HEAD requests).
+- `--bbox` row-group pruning applies per part; a part with no
+  intersecting row groups is never opened at all.
+- The standard `AWS_*` environment variables are honored for
+  S3-compatible endpoints (e.g. `AWS_ENDPOINT_URL`, `AWS_REGION`,
+  and `AWS_SKIP_SIGNATURE=true` for endpoints that serve anonymous,
+  unsigned requests); a signature/authorization failure against a
+  custom endpoint says so in the error text.
+- Fetch behavior, caching, and the disk spill are described in
+  [Remote Reads](remote-reads.md).

--- a/docs/remote-reads.md
+++ b/docs/remote-reads.md
@@ -15,7 +15,15 @@ The `overview` and `tiles` subcommands (and the Python `overview()` /
 `gs://` URLs as the *input* path. The converter reads the object with
 HTTP byte-range requests through the same synchronous parquet pipeline
 used for local files: footer first, then each column chunk of each row
-group it actually needs. Nothing is staged to disk.
+group it actually needs. Fetched chunks are staged in a temporary
+spill file (see the fetch-behavior note below) so re-reads never
+touch the network twice; the input itself is never downloaded whole
+up front.
+
+An `s3://` or `gs://` URL ending in `/` is treated as a *prefix* and
+listed to its `.parquet` objects — see
+[Multi-Partition Input](multi-partition.md) for prefix semantics,
+filtering, ordering, and `--files-from` manifests.
 
 ```bash
 # Full remote conversion

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ nav:
   - API Reference: api-reference.md
   - Advanced Usage: advanced-usage.md
   - Remote Reads: remote-reads.md
+  - Multi-Partition Input: multi-partition.md
   - Architecture: architecture.md
   - Overview Tuning: OVERVIEW_TUNING.md
   - Development: development.md


### PR DESCRIPTION
Part 3/3 of the multi-partition input feature (follows #277 and #281).

## 1. Layer-name derivation for multi inputs

New `input_set::derive_layer_name()` in core (library-first; CLI `tiles` and Python `convert()` delegate to it):

| input | default layer name |
|---|---|
| file | stem (unchanged) |
| directory | last path segment, verbatim |
| glob | deepest literal (wildcard-free) segment |
| `s3://gs://` prefix | last non-empty prefix segment (query/fragment stripped) |
| `--files-from` | manifest file's stem |
| degenerate | `"layer"` (historical fallback) |

Unit tests for every case (TDD red→green). Verified end-to-end: `tiles nyc_buildings/ out.pmtiles` produces layer `nyc_buildings`; `--files-from portland-roads.txt` produces `portland-roads`.

## 2. Friendly single-file-only rejections

`validate`, `decode`, and `export-pmtiles` given a directory, glob, remote prefix, or `--files-from` now fail with a one-line error naming the subcommand and pointing at `overview`/`tiles`, instead of an obscure I/O/parquet error. Remote single objects keep the download-first pointer (`validate` gains the remote rejection the other two already had); a hidden `--files-from` arg turns clap's generic "unexpected argument" into the same pointer. Unit tests cover dir, prefix, glob, remote object, and pass-through cases; all four rejections exercised against the built binary.

## 3. Parallel manifest/input-list connects

`from_explicit_list` (backing `--files-from` and Python `list[str]`) resolved entries serially — one HEAD round-trip per remote line. Entries now resolve under bounded concurrency (8, matching `FOOTER_LOAD_CONCURRENCY`) with per-index slots: result order matches entry order verbatim (row-order invariant) and the first error by entry index wins. Hermetic InMemory tests prove overlap (condvar-based, deterministic), order preservation through a full stream read, and error determinism.

## 4. AWS_SKIP_SIGNATURE hint

A 403 / InvalidAccessKeyId / SignatureDoesNotMatch / AccessDenied-style failure against a custom endpoint (`AWS_ENDPOINT_URL`/`AWS_ENDPOINT` set) appends "…retry with `AWS_SKIP_SIGNATURE=true`" to the error text. String-level in the Display path via the existing `RemoteConfig` variant — error types unchanged. Tests: hint appears with custom endpoint + signature error; absent without either.

## 5. Docs

New `docs/multi-partition.md` (mkdocs nav + index + remote-reads cross-links): input resolution table, prefix semantics (slash = prefix, no slash = single object), sidecar filtering (verified against `list_parquet_files` / `list_parquet_under_prefix` — including that zero-byte filtering is remote-listing-only and globs skip hidden-name filtering), lexicographic ordering guarantee, `--files-from` format (`#` comments, trim, verbatim order, single-file lines, mixed local+remote), schema/CRS validation behavior, default layer names, https:// prefix limitation → `--files-from`, and a one-line generic note that standard `AWS_*` env vars are honored for S3-compatible endpoints. Also fixes remote-reads.md's stale "nothing is staged to disk" claim (obsolete since #219).

## Test evidence

- `cargo test -p gpq-tiles-core input_set::` — 29 passed (no remote); 33 passed with `--features remote` (incl. new parallel-connect + layer-name tests)
- `cargo test -p gpq-tiles-core --features remote input::` — 29 passed, 1 ignored (bench)
- `cargo test -p gpq-tiles` — 13 passed (incl. new rejection test)
- `rtk proxy cargo clippy --workspace --all-targets` — exit 0
- Every feature TDD'd (red verified before implementation); functional verification of all three CLI-visible behaviors against the built binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)