### PR TITLE
docs: v0.7.0 changelog, README refresh, known limitations, launch post draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,136 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.7.0 (Unreleased)
+
+The converter was rebuilt around **GeoParquet overviews**: instead of
+tiling features tile-by-tile, `gpq-tiles` now embeds COG-style
+multi-resolution levels in a GeoParquet file (`gpq-tiles overview`) and
+exports PMTiles from that file (`gpq-tiles export-pmtiles`). The one-shot
+GeoParquet → PMTiles path still exists (`gpq-tiles tiles`, or the bare
+form) and is a thin facade over the same two-step chain. The overview
+format is specified in
+[`context/OVERVIEWS_SPEC.md`](https://github.com/geoparquet-io/gpq-tiles/blob/main/context/OVERVIEWS_SPEC.md)
+(draft v0.2.0).
+
+### Breaking Changes
+
+- The legacy per-tile pipeline was removed (#177). `tiles` (and the bare
+  form) now runs overview convert into a temporary file, then export.
+  Flags tied to the old pipeline — `--streaming-mode`, property filtering
+  (`--include`/`--exclude`/`--exclude-all`), output-compression selection,
+  `--deterministic` — are gone. The tuning surface is the
+  `overview`/`export-pmtiles` flag set, all of which is also accepted by
+  the one-shot `tiles` command (#249).
+- Python `convert()` is deprecated: it no longer runs the removed legacy
+  pipeline and is now a facade chaining `overview()` + `export_pmtiles()`.
+  Use the two-step API for the full option surface.
+
+### Features
+
+- **GeoParquet overviews** (`gpq-tiles overview`): embed multi-resolution
+  levels alongside your exact source data. The output stays valid
+  GeoParquet 1.1 — SQL-queryable, readable over HTTP range requests, the
+  finest level is the source data verbatim. `duplicating` (default) and
+  `partitioning` layout modes; `gpq-tiles validate` checks a file against
+  the spec.
+- **Quality ladder** calibrated on rendered corpus sweeps: class-aware
+  cell-winner ranking with Overture schema auto-detection, per-level
+  density budget (`--drop-rate`, `--drop-gamma`), visibility gates,
+  world-space GSD-driven simplification, and a drop-to-fit per-tile byte
+  cap on export (`--max-tile-size`).
+- **Point clustering** (`--cluster`): cluster winners carry a
+  `point_count` column, with numeric aggregation via
+  `--accumulate-attribute col:sum` (spec §12).
+- **Line coalescing** (on by default): thinned road/river networks are
+  merged into continuous strokes at coarse levels instead of fragmenting
+  (`--no-coalesce-lines` to opt out; spec §13).
+- **Multi-partition input** (#277, #281, #282): `overview`, `tiles`, and
+  Python `overview()` accept a local directory, a glob, an `s3://`/`gs://`
+  prefix (trailing slash), a `--files-from` manifest (ordered, mixed
+  local/remote), or a Python `list[str]` — read as one logical dataset,
+  with cross-partition schema/CRS validation, Hive sidecar filtering, and
+  a deterministic row-order guarantee. See
+  [Multi-Partition Input](https://geoparquet-io.github.io/gpq-tiles/multi-partition/).
+- **Remote input** (#210): convert directly from `s3://`, `https://`, and
+  `gs://` URLs via HTTP byte-range requests — the input is never
+  downloaded whole up front. Uses the standard AWS credential chain with
+  unsigned fallback for public buckets; honors `AWS_ENDPOINT_URL` /
+  `AWS_SKIP_SIGNATURE` for S3-compatible stores, with targeted hints on
+  signature failures.
+- **Regional extracts** (`--bbox`, #102): row groups whose bbox statistics
+  miss the region are skipped entirely — and, on remote inputs, never
+  downloaded.
+- **Configurable spill directory** (`--spill-dir`, Python `spill_dir=`,
+  #272): place the remote-input spill file on a volume of your choosing;
+  the converter projects the spill footprint before pass 1 and warns if
+  the volume's free space may not fit it.
+- A full-file remote conversion that would stage roughly the whole object
+  warns up front, with the equivalent download-then-convert commands, when
+  that route is likely faster (#267).
+- **PMTiles decoding** (`gpq-tiles decode`, #112): PMTiles → GeoParquet
+  with tippecanoe-decode semantics, for any PMTiles v3 MVT archive (not
+  just gpq-tiles output).
+- **Prebuilt CLI binaries** (#275): GitHub Releases now attach binaries
+  for Linux x86_64 (gnu and musl), macOS (Intel and Apple Silicon), and
+  Windows x86_64, plus generated release notes.
+
+### Performance
+
+- Remote-input network traffic is bounded to ≈1× the object's bytes,
+  regardless of zoom range or pass count: fetched column chunks are held
+  in an in-memory cache sized to the largest row group's working set
+  (#261) and staged in an on-disk spill file so later passes re-read from
+  local disk instead of the network (#219). The spill is best-effort — if
+  the volume fills, conversion continues with network re-fetch.
+- The convert stage's dominant serial sections were parallelized —
+  level assignment across levels, and finest-level write overlapped with
+  production (#264).
+- **Simple-clip fast path, now on by default** (#239, #255, #256): tile
+  clips whose result is a simple ring skip the expensive robust-boolean
+  fallback. Opt out with `--no-simple-clip-fastpath` (Python:
+  `simple_clip_fastpath=False`).
+- Three O(V²) hot spots on large geometries removed: export clip stall on
+  large-extent polygons (#237), uncapped validity checking of oversized
+  simplification candidates (#242), and the self-intersection scan, now a
+  sweepline (#241).
+- Export parallelized with Rayon: pass-2 simplification, and per-tile
+  clip + MVT encode; bbox-containment clips skip clipping entirely;
+  finished tile partitions stream to the PMTiles writer instead of
+  buffering.
+
+### Changed Defaults
+
+- `--polygon-visibility` retuned **4.0 → 2.0** (#259): the rendered sweep
+  on the #250 fixtures showed gates above 2.0 starve coarse zooms without
+  making files smaller, and gates below ~2.0 mostly admit candidates the
+  write-time collapse drops anyway (see `corpus/SWEEPS.md`, Decision 6).
+- `--line-thinning` retuned 2.0 → 1.0 from the same sweep methodology.
+
+### Fixes
+
+- MultiPolygon parts straddling a tile boundary are no longer silently
+  dropped during export clipping (#244).
+- Coarse-level export used geographic latitude instead of Web Mercator Y
+  in the tile-local transform, distorting high-latitude tiles.
+- Inputs with a case-insensitive `level` column collision are rejected up
+  front instead of producing an ambiguous overview file.
+- Remote URL classification, cross-partition CRS/metadata diagnostics, and
+  footer caching hardened during multi-partition review (#277).
+
+### Docs
+
+- Live **Germany buildings demo** (59M features) on the docs site, with a
+  hosted PMTiles viewer and a measured head-to-head against the
+  gpio → tippecanoe pipeline (#250).
+- New [Multi-Partition Input](https://geoparquet-io.github.io/gpq-tiles/multi-partition/)
+  and [Remote Reads](https://geoparquet-io.github.io/gpq-tiles/remote-reads/)
+  pages — the latter includes the evidence-based DuckDB recipe for
+  querying overview files in place (#203).
+- [Overview Tuning](https://geoparquet-io.github.io/gpq-tiles/OVERVIEW_TUNING/)
+  documents every generalization knob, default, and interaction; docs
+  consolidated to one source of truth per topic (#180).
+
 ## v0.6.0 (2026-03-11)
 
 ### Feat

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Fast GeoParquet → PMTiles converter in Rust.
 - One-shot GeoParquet → PMTiles (`gpq-tiles tiles`, or the bare form)
 - Quality ladder tuned against tippecanoe: class ranking (Overture auto-detect), visibility gates, density budget, point clustering, line coalescing
 - Memory-bounded streaming conversion — a 632k-polygon / 38M-vertex file converts to a full z0–14 overview pyramid in ~45 s at ~1.4 GB peak RSS, or a default z0–6 pyramid in ~7 s at ~0.4 GB (16-core machine)
-- Remote inputs (`s3://`, `https://`, `gs://`) read via byte-range requests — with `--bbox`, extract a city from a remote country-scale file while downloading only the matching row groups ([Remote Reads](docs/remote-reads.md))
+- Multi-partition input — a directory, glob, `s3://`/`gs://` prefix, or `--files-from` manifest is read as one dataset ([Multi-Partition Input](docs/multi-partition.md))
+- Remote inputs (`s3://`, `https://`, `gs://`) read via byte-range requests, bounded to ≈1× the object's bytes — with `--bbox`, extract a city from a remote country-scale file while downloading only the matching row groups ([Remote Reads](docs/remote-reads.md))
 - Spec validation (`gpq-tiles validate`)
 - PMTiles → GeoParquet decoding (`gpq-tiles decode`) — tippecanoe-decode
   semantics, any PMTiles v3 MVT archive
@@ -29,11 +30,23 @@ cargo install gpq-tiles    # CLI
 pip install gpq-tiles      # Python
 ```
 
-## Usage
+Prebuilt CLI binaries (Linux x86_64 gnu/musl, macOS Intel/Apple
+Silicon, Windows x86_64) are attached to each
+[GitHub Release](https://github.com/geoparquet-io/gpq-tiles/releases).
+
+## Quickstart
 
 ```bash
-# One-shot: GeoParquet in, PMTiles out
+# GeoParquet in, PMTiles out
 gpq-tiles input.parquet output.pmtiles --min-zoom 0 --max-zoom 14
+```
+
+Drop `output.pmtiles` onto [pmtiles.io](https://pmtiles.io/) to view it.
+The input can also be a directory of partitions, a glob, an
+`s3://`/`gs://` file or prefix, or an `https://` URL:
+
+```bash
+gpq-tiles overview s3://bucket/dataset/ overviews.parquet
 ```
 
 ### The Two-Step Workflow
@@ -86,11 +99,11 @@ from gpq_tiles import overview, export_pmtiles, validate
 overview("input.parquet", "overviews.parquet", min_zoom=0, max_zoom=14)
 validate("overviews.parquet")
 export_pmtiles("overviews.parquet", "output.pmtiles")
-
-# One-shot facade (deprecated in favor of the two-step API)
-from gpq_tiles import convert
-convert("input.parquet", "output.pmtiles", min_zoom=0, max_zoom=14)
 ```
+
+`overview()` also accepts a `list[str]` of parts, and exposes the full
+tuning surface as keyword arguments — see the
+[API Reference](docs/api-reference.md).
 
 ## Documentation
 
@@ -100,6 +113,8 @@ convert("input.parquet", "output.pmtiles", min_zoom=0, max_zoom=14)
 - **[API Reference](docs/api-reference.md)** — CLI flags, Python API, Rust API
 - **[Advanced Usage](docs/advanced-usage.md)** — Input optimization, memory, remote reads, CI/CD
 - **[Remote Reads](docs/remote-reads.md)** — Converting directly from s3://, https://, gs:// inputs, and querying overview files in place with DuckDB
+- **[Multi-Partition Input](docs/multi-partition.md)** — Directories, globs, remote prefixes, and --files-from manifests as one dataset
+- **[Known Limitations](docs/limitations.md)** — What gpq-tiles does not do yet, honestly
 - **[Format Spec (draft)](context/OVERVIEWS_SPEC.md)** — The `geo:overviews` format contract
 
 ## Development

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -13,7 +13,8 @@ Fast GeoParquet → PMTiles converter in Rust.
 - One-shot GeoParquet → PMTiles (`gpq-tiles tiles`, or the bare form)
 - Quality ladder tuned against tippecanoe: class ranking (Overture auto-detect), visibility gates, density budget, point clustering, line coalescing
 - Memory-bounded streaming conversion — a 632k-polygon / 38M-vertex file converts to a full z0–14 overview pyramid in ~45 s at ~1.4 GB peak RSS, or a default z0–6 pyramid in ~7 s at ~0.4 GB (16-core machine)
-- Remote inputs (`s3://`, `https://`, `gs://`) read via byte-range requests — with `--bbox`, extract a city from a remote country-scale file while downloading only the matching row groups ([Remote Reads](docs/remote-reads.md))
+- Multi-partition input — a directory, glob, `s3://`/`gs://` prefix, or `--files-from` manifest is read as one dataset ([Multi-Partition Input](docs/multi-partition.md))
+- Remote inputs (`s3://`, `https://`, `gs://`) read via byte-range requests, bounded to ≈1× the object's bytes — with `--bbox`, extract a city from a remote country-scale file while downloading only the matching row groups ([Remote Reads](docs/remote-reads.md))
 - Spec validation (`gpq-tiles validate`)
 - PMTiles → GeoParquet decoding (`gpq-tiles decode`) — tippecanoe-decode
   semantics, any PMTiles v3 MVT archive
@@ -29,11 +30,23 @@ cargo install gpq-tiles    # CLI
 pip install gpq-tiles      # Python
 ```
 
-## Usage
+Prebuilt CLI binaries (Linux x86_64 gnu/musl, macOS Intel/Apple
+Silicon, Windows x86_64) are attached to each
+[GitHub Release](https://github.com/geoparquet-io/gpq-tiles/releases).
+
+## Quickstart
 
 ```bash
-# One-shot: GeoParquet in, PMTiles out
+# GeoParquet in, PMTiles out
 gpq-tiles input.parquet output.pmtiles --min-zoom 0 --max-zoom 14
+```
+
+Drop `output.pmtiles` onto [pmtiles.io](https://pmtiles.io/) to view it.
+The input can also be a directory of partitions, a glob, an
+`s3://`/`gs://` file or prefix, or an `https://` URL:
+
+```bash
+gpq-tiles overview s3://bucket/dataset/ overviews.parquet
 ```
 
 ### The Two-Step Workflow
@@ -86,11 +99,11 @@ from gpq_tiles import overview, export_pmtiles, validate
 overview("input.parquet", "overviews.parquet", min_zoom=0, max_zoom=14)
 validate("overviews.parquet")
 export_pmtiles("overviews.parquet", "output.pmtiles")
-
-# One-shot facade (deprecated in favor of the two-step API)
-from gpq_tiles import convert
-convert("input.parquet", "output.pmtiles", min_zoom=0, max_zoom=14)
 ```
+
+`overview()` also accepts a `list[str]` of parts, and exposes the full
+tuning surface as keyword arguments — see the
+[API Reference](docs/api-reference.md).
 
 ## Documentation
 
@@ -100,6 +113,8 @@ convert("input.parquet", "output.pmtiles", min_zoom=0, max_zoom=14)
 - **[API Reference](docs/api-reference.md)** — CLI flags, Python API, Rust API
 - **[Advanced Usage](docs/advanced-usage.md)** — Input optimization, memory, remote reads, CI/CD
 - **[Remote Reads](docs/remote-reads.md)** — Converting directly from s3://, https://, gs:// inputs, and querying overview files in place with DuckDB
+- **[Multi-Partition Input](docs/multi-partition.md)** — Directories, globs, remote prefixes, and --files-from manifests as one dataset
+- **[Known Limitations](docs/limitations.md)** — What gpq-tiles does not do yet, honestly
 - **[Format Spec (draft)](context/OVERVIEWS_SPEC.md)** — The `geo:overviews` format contract
 
 ## Development

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -13,7 +13,8 @@ Fast GeoParquet → PMTiles converter in Rust.
 - One-shot GeoParquet → PMTiles (`gpq-tiles tiles`, or the bare form)
 - Quality ladder tuned against tippecanoe: class ranking (Overture auto-detect), visibility gates, density budget, point clustering, line coalescing
 - Memory-bounded streaming conversion — a 632k-polygon / 38M-vertex file converts to a full z0–14 overview pyramid in ~45 s at ~1.4 GB peak RSS, or a default z0–6 pyramid in ~7 s at ~0.4 GB (16-core machine)
-- Remote inputs (`s3://`, `https://`, `gs://`) read via byte-range requests — with `--bbox`, extract a city from a remote country-scale file while downloading only the matching row groups ([Remote Reads](docs/remote-reads.md))
+- Multi-partition input — a directory, glob, `s3://`/`gs://` prefix, or `--files-from` manifest is read as one dataset ([Multi-Partition Input](docs/multi-partition.md))
+- Remote inputs (`s3://`, `https://`, `gs://`) read via byte-range requests, bounded to ≈1× the object's bytes — with `--bbox`, extract a city from a remote country-scale file while downloading only the matching row groups ([Remote Reads](docs/remote-reads.md))
 - Spec validation (`gpq-tiles validate`)
 - PMTiles → GeoParquet decoding (`gpq-tiles decode`) — tippecanoe-decode
   semantics, any PMTiles v3 MVT archive
@@ -29,11 +30,23 @@ cargo install gpq-tiles    # CLI
 pip install gpq-tiles      # Python
 ```
 
-## Usage
+Prebuilt CLI binaries (Linux x86_64 gnu/musl, macOS Intel/Apple
+Silicon, Windows x86_64) are attached to each
+[GitHub Release](https://github.com/geoparquet-io/gpq-tiles/releases).
+
+## Quickstart
 
 ```bash
-# One-shot: GeoParquet in, PMTiles out
+# GeoParquet in, PMTiles out
 gpq-tiles input.parquet output.pmtiles --min-zoom 0 --max-zoom 14
+```
+
+Drop `output.pmtiles` onto [pmtiles.io](https://pmtiles.io/) to view it.
+The input can also be a directory of partitions, a glob, an
+`s3://`/`gs://` file or prefix, or an `https://` URL:
+
+```bash
+gpq-tiles overview s3://bucket/dataset/ overviews.parquet
 ```
 
 ### The Two-Step Workflow
@@ -86,11 +99,11 @@ from gpq_tiles import overview, export_pmtiles, validate
 overview("input.parquet", "overviews.parquet", min_zoom=0, max_zoom=14)
 validate("overviews.parquet")
 export_pmtiles("overviews.parquet", "output.pmtiles")
-
-# One-shot facade (deprecated in favor of the two-step API)
-from gpq_tiles import convert
-convert("input.parquet", "output.pmtiles", min_zoom=0, max_zoom=14)
 ```
+
+`overview()` also accepts a `list[str]` of parts, and exposes the full
+tuning surface as keyword arguments — see the
+[API Reference](docs/api-reference.md).
 
 ## Documentation
 
@@ -100,6 +113,8 @@ convert("input.parquet", "output.pmtiles", min_zoom=0, max_zoom=14)
 - **[API Reference](docs/api-reference.md)** — CLI flags, Python API, Rust API
 - **[Advanced Usage](docs/advanced-usage.md)** — Input optimization, memory, remote reads, CI/CD
 - **[Remote Reads](docs/remote-reads.md)** — Converting directly from s3://, https://, gs:// inputs, and querying overview files in place with DuckDB
+- **[Multi-Partition Input](docs/multi-partition.md)** — Directories, globs, remote prefixes, and --files-from manifests as one dataset
+- **[Known Limitations](docs/limitations.md)** — What gpq-tiles does not do yet, honestly
 - **[Format Spec (draft)](context/OVERVIEWS_SPEC.md)** — The `geo:overviews` format contract
 
 ## Development

--- a/crates/python/README.md
+++ b/crates/python/README.md
@@ -13,7 +13,8 @@ Fast GeoParquet → PMTiles converter in Rust.
 - One-shot GeoParquet → PMTiles (`gpq-tiles tiles`, or the bare form)
 - Quality ladder tuned against tippecanoe: class ranking (Overture auto-detect), visibility gates, density budget, point clustering, line coalescing
 - Memory-bounded streaming conversion — a 632k-polygon / 38M-vertex file converts to a full z0–14 overview pyramid in ~45 s at ~1.4 GB peak RSS, or a default z0–6 pyramid in ~7 s at ~0.4 GB (16-core machine)
-- Remote inputs (`s3://`, `https://`, `gs://`) read via byte-range requests — with `--bbox`, extract a city from a remote country-scale file while downloading only the matching row groups ([Remote Reads](docs/remote-reads.md))
+- Multi-partition input — a directory, glob, `s3://`/`gs://` prefix, or `--files-from` manifest is read as one dataset ([Multi-Partition Input](docs/multi-partition.md))
+- Remote inputs (`s3://`, `https://`, `gs://`) read via byte-range requests, bounded to ≈1× the object's bytes — with `--bbox`, extract a city from a remote country-scale file while downloading only the matching row groups ([Remote Reads](docs/remote-reads.md))
 - Spec validation (`gpq-tiles validate`)
 - PMTiles → GeoParquet decoding (`gpq-tiles decode`) — tippecanoe-decode
   semantics, any PMTiles v3 MVT archive
@@ -29,11 +30,23 @@ cargo install gpq-tiles    # CLI
 pip install gpq-tiles      # Python
 ```
 
-## Usage
+Prebuilt CLI binaries (Linux x86_64 gnu/musl, macOS Intel/Apple
+Silicon, Windows x86_64) are attached to each
+[GitHub Release](https://github.com/geoparquet-io/gpq-tiles/releases).
+
+## Quickstart
 
 ```bash
-# One-shot: GeoParquet in, PMTiles out
+# GeoParquet in, PMTiles out
 gpq-tiles input.parquet output.pmtiles --min-zoom 0 --max-zoom 14
+```
+
+Drop `output.pmtiles` onto [pmtiles.io](https://pmtiles.io/) to view it.
+The input can also be a directory of partitions, a glob, an
+`s3://`/`gs://` file or prefix, or an `https://` URL:
+
+```bash
+gpq-tiles overview s3://bucket/dataset/ overviews.parquet
 ```
 
 ### The Two-Step Workflow
@@ -86,11 +99,11 @@ from gpq_tiles import overview, export_pmtiles, validate
 overview("input.parquet", "overviews.parquet", min_zoom=0, max_zoom=14)
 validate("overviews.parquet")
 export_pmtiles("overviews.parquet", "output.pmtiles")
-
-# One-shot facade (deprecated in favor of the two-step API)
-from gpq_tiles import convert
-convert("input.parquet", "output.pmtiles", min_zoom=0, max_zoom=14)
 ```
+
+`overview()` also accepts a `list[str]` of parts, and exposes the full
+tuning surface as keyword arguments — see the
+[API Reference](docs/api-reference.md).
 
 ## Documentation
 
@@ -100,6 +113,8 @@ convert("input.parquet", "output.pmtiles", min_zoom=0, max_zoom=14)
 - **[API Reference](docs/api-reference.md)** — CLI flags, Python API, Rust API
 - **[Advanced Usage](docs/advanced-usage.md)** — Input optimization, memory, remote reads, CI/CD
 - **[Remote Reads](docs/remote-reads.md)** — Converting directly from s3://, https://, gs:// inputs, and querying overview files in place with DuckDB
+- **[Multi-Partition Input](docs/multi-partition.md)** — Directories, globs, remote prefixes, and --files-from manifests as one dataset
+- **[Known Limitations](docs/limitations.md)** — What gpq-tiles does not do yet, honestly
 - **[Format Spec (draft)](context/OVERVIEWS_SPEC.md)** — The `geo:overviews` format contract
 
 ## Development

--- a/docs/blog/v0.7-launch.md
+++ b/docs/blog/v0.7-launch.md
@@ -1,0 +1,140 @@
+# gpq-tiles v0.7: GeoParquet → PMTiles, straight from object storage
+
+!!! warning "Draft"
+    This post is a draft. Numbers marked `{{LIKE_THIS}}` are
+    placeholders awaiting the measured demo run. Do not publish.
+
+## What gpq-tiles is
+
+[gpq-tiles](https://github.com/geoparquet-io/gpq-tiles) converts
+GeoParquet to PMTiles vector tiles. It is written in Rust, reads
+GeoParquet natively through Arrow — there is no GeoJSON intermediate,
+which for large inputs is the single biggest cost in the usual
+`ogr2ogr`/`gpio convert geojson` → tippecanoe route — and it is
+library-first: the CLI and the Python package
+(`pip install gpq-tiles`) are thin wrappers over the same Rust core.
+
+Under the hood it does something slightly unusual: the conversion runs
+through **GeoParquet overviews** — COG-style multi-resolution levels
+embedded in a GeoParquet file, per a
+[draft spec](https://github.com/geoparquet-io/gpq-tiles/blob/main/context/OVERVIEWS_SPEC.md).
+You can keep that intermediate file: it stays valid GeoParquet 1.1,
+your exact source data is the finest level, and DuckDB can query one
+resolution band of it over HTTP range requests. PMTiles is an export
+of it. If you only want tiles, the one-shot form hides all of this:
+
+```bash
+gpq-tiles input.parquet output.pmtiles --max-zoom 14
+```
+
+## What's new in v0.7
+
+The headline: **a partitioned dataset in object storage converts to
+PMTiles in one command**, without downloading it first.
+
+```bash
+gpq-tiles overview s3://bucket/dataset/ overviews.parquet
+gpq-tiles export-pmtiles overviews.parquet output.pmtiles
+```
+
+Real datasets rarely arrive as one tidy file — they arrive as a
+directory of `part-*.parquet`, an Overture-style partition tree, or a
+prefix in a bucket. v0.7 accepts a local directory, a glob, an
+`s3://`/`gs://` prefix (listed natively), or a `--files-from` manifest
+of mixed local and remote files, and reads the set as one logical
+dataset: schemas and CRS validated across parts before any data is
+read, `_SUCCESS`/`.crc`-style sidecars filtered out, row order
+deterministic. Details in
+[Multi-Partition Input](../multi-partition.md).
+
+The remote read path got the matching guarantees:
+
+- Network traffic is bounded to **≈1× the object's bytes** no matter
+  how many passes the converter makes: fetched chunks are staged in a
+  local spill file and re-read from disk, never re-fetched.
+- `--spill-dir` picks the volume for that staging file, and a
+  free-space guard warns up front if it won't fit.
+- `--bbox` extracts compose with all of this: row groups outside the
+  region are never downloaded at all.
+- Public buckets need zero configuration (unsigned fallback);
+  S3-compatible endpoints work via the standard `AWS_*` variables.
+
+Beyond the headline: coarse-zoom rendering defaults were retuned from
+rendered corpus sweeps (`--polygon-visibility` 4.0 → 2.0, so dense
+polygon layers no longer go empty at country zooms), the simple-clip
+fast path is on by default, the convert stage parallelizes its
+formerly serial sections, and releases now ship prebuilt binaries.
+The [changelog](../changelog.md) has the complete list.
+
+## Demo: Fields of the World, from source.coop to a map
+
+To exercise exactly this path we converted a slice of **Fields of the
+World (FTW)** — a global agricultural field-boundary dataset published
+as partitioned GeoParquet on
+[Source Cooperative](https://source.coop/ftw/global-data) — directly
+from the bucket, no local copy of the input.
+
+```bash
+gpq-tiles overview {{S3_PREFIX}} ftw-overviews.parquet
+gpq-tiles export-pmtiles ftw-overviews.parquet ftw.pmtiles
+```
+
+| | |
+|---|---|
+| Region | {{REGION}} |
+| Input | {{INPUT_GB}} GB across {{N_FILES}} parquet files |
+| Wall clock | {{WALL_CLOCK}} |
+| Peak RSS | {{PEAK_RSS}} |
+| Output PMTiles | {{OUTPUT_MB}} MB |
+| Throughput | {{THROUGHPUT}} |
+
+*(Machine and zoom range to be stated with the numbers.)*
+
+{{VIEWER_LINK_OR_SCREENSHOT}}
+
+For a previously measured head-to-head against the incumbent
+GeoJSON → tippecanoe pipeline (59M Overture Germany buildings, live
+viewer included), see the [Germany buildings demo](../demo.md).
+
+## What it doesn't do yet
+
+Honesty section. gpq-tiles does not yet split geometries at the
+antimeridian, so features crossing ±180° smear at coarse zooms
+([#240](https://github.com/geoparquet-io/gpq-tiles/issues/240));
+each output archive holds a single MVT layer — no tippecanoe `-L`
+equivalent yet
+([#16](https://github.com/geoparquet-io/gpq-tiles/issues/16)); and
+small polygons are dropped or collapsed to points at coarse zooms
+rather than coalesced into larger ones, so full-coverage layers render
+as dot fill when zoomed out
+([#246](https://github.com/geoparquet-io/gpq-tiles/issues/246)).
+The full list, with workarounds where they exist, is in
+[Known Limitations](../limitations.md).
+
+## Install
+
+```bash
+cargo install gpq-tiles    # CLI, from source
+pip install gpq-tiles      # Python package (wheels)
+```
+
+Or grab a prebuilt CLI binary — Linux x86_64 (gnu/musl), macOS
+(Intel/Apple Silicon), Windows x86_64 — from the
+[releases page](https://github.com/geoparquet-io/gpq-tiles/releases).
+
+If your input needs preprocessing (reprojection to EPSG:4326, Hilbert
+sorting, row-group sizing), use
+[geoparquet-io](https://github.com/geoparquet-io/geoparquet-io):
+
+```bash
+gpio convert reproject input.parquet prepared.parquet \
+  -d EPSG:4326 --hilbert --row-group-size 100000
+```
+
+---
+
+*Fields of the World: Kerner et al., "Fields of The World: A Machine
+Learning Benchmark Dataset for Global Agricultural Field Boundary
+Segmentation" (AAAI 2025). Data from
+[source.coop/ftw/global-data](https://source.coop/ftw/global-data),
+licensed CC-BY.*

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,0 +1,41 @@
+# Known Limitations
+
+Things gpq-tiles does not do yet. Each is tracked in an open issue;
+none has a workaround that gpq-tiles silently applies for you.
+
+## Antimeridian / ±180° not handled
+
+Geometries that cross the antimeridian (or that are stored with a bbox
+spanning nearly the whole world, as unsplit crossing features are) are
+not split at ±180°. At coarse zooms such a feature can be assigned to
+tiles across the entire longitude range and render as a horizontal
+smear; datasets touching Fiji, Chukotka, the Aleutians, or global
+extents are the ones that hit this. The planned fix is an in-engine
+split-first pass with a span-budget backstop, since GeoParquet — unlike
+GeoJSON's RFC 7946 — does not require producers to split these
+geometries themselves. Until it lands, split crossing features upstream.
+Tracked in
+[#240](https://github.com/geoparquet-io/gpq-tiles/issues/240).
+
+## One layer per output
+
+A PMTiles archive produced by gpq-tiles contains exactly one MVT layer
+(`--layer-name`, default derived from the input name). There is no way
+to feed several GeoParquet inputs into one archive as separate layers,
+the way tippecanoe's `-L` does — today you would produce one archive
+per layer and combine them client-side in the map style. Multi-layer
+support (multiple inputs, one archive) is tracked in
+[#16](https://github.com/geoparquet-io/gpq-tiles/issues/16).
+
+## No polygon coalescing at coarse zooms
+
+When polygons get too small to see at a given zoom, gpq-tiles drops
+them (or, with `--collapse`, replaces them with representative points)
+— it does not merge neighbors into larger polygons the way
+tippecanoe's `--coalesce-smallest-as-needed` can. For full-coverage
+layers (land cover, parcels, dense building fabric) this means coarse
+zooms show a thinned sample or dot fill rather than a merged surface;
+the [tuning guide](OVERVIEW_TUNING.md#country-scale-dot-fill-for-dense-polygon-layers)
+documents the dot-fill recipe that works today. Coverage-preserving
+polygon coalescing is tracked in
+[#246](https://github.com/geoparquet-io/gpq-tiles/issues/246).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,8 +60,10 @@ nav:
   - Advanced Usage: advanced-usage.md
   - Remote Reads: remote-reads.md
   - Multi-Partition Input: multi-partition.md
+  - Known Limitations: limitations.md
   - Architecture: architecture.md
   - Overview Tuning: OVERVIEW_TUNING.md
   - Development: development.md
   - Contributing: contributing.md
   - Changelog: changelog.md
+  - "v0.7 Launch Post (draft)": blog/v0.7-launch.md


### PR DESCRIPTION
> [!IMPORTANT]
> **USER-GATED — DO NOT MERGE.** This PR is public-facing content
> (changelog, README, launch post). It ships only with Nissim's
> explicit sign-off. Do not enable auto-merge.

## Deliverables

1. **CHANGELOG.md — v0.7.0 (Unreleased)**: human-written section covering everything since v0.6.0 (2026-03-11), grouped Breaking Changes / Features / Performance / Changed Defaults / Fixes / Docs. Headlines: the overview-architecture rebuild, multi-partition input (#277/#281/#282), remote-input ≈1× network bound via disk spill (#219/#261), `--spill-dir` + free-space guard (#272), coarse-zoom retune `--polygon-visibility` 4.0→2.0 (#259), simple-clip fast path **now default-on** (#239/#255/#256 — the briefing said "opt-in"; #256 flipped it), convert parallelization (#264), full-file remote warning (#267), prebuilt binaries (#275). Every issue number and flag verified against `gh` and the clap definitions. `docs/changelog.md` is a symlink to this file, so the docs site picks it up automatically; doc links use absolute URLs so they resolve from both locations.
2. **README refresh**: multi-partition one-liner in the pitch, ≈1× remote-bytes note, prebuilt-binaries install line, `Usage` → `Quickstart` with a view step (pmtiles.io), deprecated Python `convert()` example removed (two-step API + `list[str]` note instead), Multi-Partition + Known Limitations added to the doc index. Untouched sections left alone.
3. **docs/limitations.md**: antimeridian (#240), single layer per output (#16), no polygon coalescing (#246) — one honest paragraph each, with the workaround that exists today.
4. **docs/blog/v0.7-launch.md**: launch post **draft** with a top-of-page draft warning. FTW demo numbers are `{{PLACEHOLDER}}` tokens: `{{REGION}}`, `{{S3_PREFIX}}`, `{{INPUT_GB}}`, `{{N_FILES}}`, `{{WALL_CLOCK}}`, `{{PEAK_RSS}}`, `{{OUTPUT_MB}}`, `{{THROUGHPUT}}`, `{{VIEWER_LINK_OR_SCREENSHOT}}`. CC-BY attribution for FTW (Kerner et al., AAAI 2025; source.coop/ftw/global-data) included. No performance numbers stated anywhere in the post.
5. **mkdocs.yml**: nav entries for Known Limitations and the launch post (labeled "(draft)").

## Verification

- `uvx --with mkdocs-material mkdocs build` (the CI invocation) passes; the new pages produce **zero** warnings.
- `mkdocs build --strict` fails on **8 pre-existing** warnings in `architecture.md`/`contributing.md` (links to files outside `docs/`) — untouched by this PR, noted for a follow-up.
- Flags checked against `crates/cli/src/main.rs` and `crates/python/gpq_tiles.pyi`; issue titles via `gh issue view`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)