### PR TITLE
docs: fix broken links, add PROFILING to nav, enable strict builds (closes #284)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Build documentation
-        run: uvx --with mkdocs-material mkdocs build
+        run: uvx --with mkdocs-material mkdocs build --strict
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ git config core.hooksPath .githooks
 cargo build && cargo check
 ```
 
-See [DEVELOPMENT.md](DEVELOPMENT.md) for the day-to-day workflow,
+See [DEVELOPMENT.md](https://github.com/geoparquet-io/gpq-tiles/blob/main/DEVELOPMENT.md) for the day-to-day workflow,
 Python setup, and how to run every CI gate locally.
 
 ## Commit Convention
@@ -34,7 +34,7 @@ Python setup, and how to run every CI gate locally.
    --all-features -- -D warnings`, `cargo machete`, targeted tests,
    and (for Python changes) the ruff/mypy/stubtest/vulture/xenon/pytest
    suite via `uv run`. The full list with commands:
-   [DEVELOPMENT.md → CI Gates](DEVELOPMENT.md#ci-gates--and-how-to-run-them-locally).
+   [DEVELOPMENT.md → CI Gates](https://github.com/geoparquet-io/gpq-tiles/blob/main/DEVELOPMENT.md#ci-gates--and-how-to-run-them-locally).
 3. Submit the PR; never bypass the pre-commit hooks (`--no-verify` is
    forbidden).
 

--- a/context/ARCHITECTURE.md
+++ b/context/ARCHITECTURE.md
@@ -2,17 +2,17 @@
 
 Design decisions and tippecanoe divergences for the **current** system.
 Historical material (the removed per-tile pipeline, execution plans,
-session triage) lives in [`context/archive/`](./archive/README.md).
+session triage) lives in [`context/archive/`](https://github.com/geoparquet-io/gpq-tiles/blob/main/context/archive/README.md).
 
 Related canonical documents:
 
-- **Format**: [`context/OVERVIEWS_SPEC.md`](./OVERVIEWS_SPEC.md) — the
+- **Format**: [`context/OVERVIEWS_SPEC.md`](https://github.com/geoparquet-io/gpq-tiles/blob/main/context/OVERVIEWS_SPEC.md) — the
   `geo:overviews` draft spec (single source of truth for the file format).
-- **Tuning**: [`docs/OVERVIEW_TUNING.md`](../docs/OVERVIEW_TUNING.md) — every
+- **Tuning**: [`docs/OVERVIEW_TUNING.md`](https://github.com/geoparquet-io/gpq-tiles/blob/main/docs/OVERVIEW_TUNING.md) — every
   generalization knob, its default, and its direction.
-- **Benchmarks**: [`benchmarks/overview/RESULTS.md`](../benchmarks/overview/RESULTS.md)
+- **Benchmarks**: [`benchmarks/overview/RESULTS.md`](https://github.com/geoparquet-io/gpq-tiles/blob/main/benchmarks/overview/RESULTS.md)
   (storage/access numbers) and
-  [`benchmarks/overview/PROFILE.md`](../benchmarks/overview/PROFILE.md)
+  [`benchmarks/overview/PROFILE.md`](https://github.com/geoparquet-io/gpq-tiles/blob/main/benchmarks/overview/PROFILE.md)
   (performance methodology + history).
 
 ## Decision Record: Legacy Tiles Pipeline Removed (#177, 2026-07-03)
@@ -40,7 +40,7 @@ What survives:
 
 Consequences: #102 (row-group bbox filtering for the tiles pipeline) lost
 its remaining scope; the legacy pipeline's architecture notes were moved to
-[`context/archive/LEGACY_TILES_ARCHITECTURE.md`](./archive/LEGACY_TILES_ARCHITECTURE.md).
+[`context/archive/LEGACY_TILES_ARCHITECTURE.md`](https://github.com/geoparquet-io/gpq-tiles/blob/main/context/archive/LEGACY_TILES_ARCHITECTURE.md).
 
 ## Design Principles
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
   - Getting Started: getting-started.md
   - Demo (Germany buildings): demo.md
   - Performance: performance.md
+  - Profiling: PROFILING.md
   - Decoding PMTiles: decode.md
   - API Reference: api-reference.md
   - Advanced Usage: advanced-usage.md


### PR DESCRIPTION
Closes #284.

## What

1. **Fix the 8 links that break `mkdocs build --strict`** — all pointed at repo files outside `docs/` (the docs pages are symlinks: `docs/architecture.md` → `context/ARCHITECTURE.md`, `docs/contributing.md` → `CONTRIBUTING.md`, so the edits land in the real files). All 8 now use absolute GitHub URLs on `main`, which resolve both on the built site and when reading the source files on GitHub:
   - `architecture.md`: `./archive/README.md`, `./OVERVIEWS_SPEC.md`, `../docs/OVERVIEW_TUNING.md`, `../benchmarks/overview/RESULTS.md`, `../benchmarks/overview/PROFILE.md`, `./archive/LEGACY_TILES_ARCHITECTURE.md`
   - `contributing.md`: `DEVELOPMENT.md`, `DEVELOPMENT.md#ci-gates--and-how-to-run-them-locally`

   Note: `OVERVIEW_TUNING.md` *is* in `docs/`, but a docs-relative link would break the GitHub view of `context/ARCHITECTURE.md`, so it gets a GitHub URL like the rest.

2. **Add `docs/PROFILING.md` to the mkdocs nav** as "Profiling", right after "Performance".

3. **Enable `--strict` in the CI docs build** (`.github/workflows/docs.yml`) so future broken links fail the PR instead of shipping silently.

## Verification

```
uvx --with mkdocs-material mkdocs build --strict
```
passes with **zero warnings** (exit 0). No code changes; no cargo tests needed.

## Coordination note

PR #283 (`docs/v0.7-launch-refresh`) also touches `mkdocs.yml` (nav) and adds docs pages. This PR is based on `main` only and deliberately does not include #283's changes — a trivial nav merge conflict between the two is expected; whichever merges second just re-adds its nav line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)