### PR TITLE
perf(remote): stage row groups to coalesce+parallelize remote fetches — 86→9 requests, 4.3x faster on FTW Amazonas (#286, #287)

### DIFF
--- a/context/ARCHITECTURE.md
+++ b/context/ARCHITECTURE.md
@@ -68,6 +68,18 @@ verbatim (spec §2.4).
 
 **Streaming is the default** (`stream.rs`, two passes):
 
+0. **Pass 0 (remote input only)** stages the selected row groups to the local
+   disk spill up front (#286/#287). A row group's column chunks are a
+   *contiguous* byte span, so each selected row group is fetched as **one**
+   coalesced range request (several in flight per part, bounded by a
+   memory budget) and sliced back into the per-column-chunk spill entries the
+   reader already serves from. Both passes below then read entirely from local
+   disk. This removes the two latency-bound patterns high-TTFB hosts exposed:
+   the reader keeping ~1 range request in flight per column chunk per pass
+   (#287), and pass 2 re-fetching, cold, the property columns pass 1's
+   geometry+ranking projection skipped (#286). Only selected row groups are
+   staged, so pruned groups are still never touched and total network traffic
+   stays ≈1× the object (#219); local inputs skip pass 0 entirely.
 1. **Pass 1** streams the input once, keeping only a small per-feature record
    (bbox, kind, ranking key). Level assignment + density budget run over
    those records to produce per-level **winner tables** (~1 byte/feature).

--- a/crates/core/src/input.rs
+++ b/crates/core/src/input.rs
@@ -309,6 +309,21 @@ impl InputSource {
             InputSource::Remote(r) => r.release_read_cache(),
         }
     }
+
+    /// Stage the selected row groups to the local disk spill up front (pass
+    /// 0, #286/#287), coalescing each row group into one parallel range
+    /// request so the later passes read entirely from disk. No-op for local
+    /// inputs (the OS page cache already serves re-reads). `selected` (`None`
+    /// = all) must match the row groups the passes will read, so pruned groups
+    /// are never fetched and total traffic stays ≈1× (#219).
+    #[cfg_attr(not(feature = "remote"), allow(unused_variables))]
+    pub fn stage_row_groups(&self, selected: Option<&[usize]>) -> Result<(), InputError> {
+        match self {
+            InputSource::Local(_) => Ok(()),
+            #[cfg(feature = "remote")]
+            InputSource::Remote(r) => r.stage_row_groups(selected),
+        }
+    }
 }
 
 /// Sum of the compressed byte sizes of the selected input row groups — the
@@ -795,6 +810,142 @@ pub(crate) mod remote {
             self.spill.lock().expect("spill lock").dir = dir.map(Path::to_path_buf);
         }
 
+        /// Parse (and cache) the footer, returning the shared metadata.
+        /// Mirrors the load in [`Self::open_builder`] so staging (pass 0) does
+        /// not depend on a builder open; the header phase has usually loaded
+        /// it already, in which case this is a cheap clone with no fetch.
+        fn load_footer(&self) -> Result<ArrowReaderMetadata, InputError> {
+            if let Some(md) = self.metadata.get() {
+                return Ok(md.clone());
+            }
+            let reader = InputReader::Remote(self.reader());
+            let md = ArrowReaderMetadata::load(&reader, ArrowReaderOptions::new())?;
+            let _ = self.metadata.set(md.clone());
+            Ok(md)
+        }
+
+        /// Pass 0 (#286/#287): stage the selected row groups to the disk spill
+        /// up front — ONE coalesced range request per row group, several in
+        /// flight at once — so both later passes read entirely from local
+        /// disk.
+        ///
+        /// A row group's column chunks form a contiguous byte span, so each
+        /// row group is fetched as a single large GET and sliced back into the
+        /// per-column-chunk spill entries the reader's L2 path already serves
+        /// from ([`RemoteReader::chunk_data`]). This removes the two
+        /// latency-bound patterns the demo hit: the per-column-chunk, per-pass
+        /// serial re-fetch (#287, reader kept ~1 request in flight), and in
+        /// particular pass 2's cold re-fetch of the property columns that pass
+        /// 1's geometry+ranking projection skipped (#286, ~10 small serial
+        /// range requests per row group).
+        ///
+        /// `selected` (`None` = every row group) is the SAME per-part bbox
+        /// row-group selection the passes read, so pruned row groups are still
+        /// never touched and total network traffic stays ≈1× the object
+        /// (#219); no speculative over-fetch. Each span counts as one request
+        /// so callers observe the coalesced pattern. Best-effort by
+        /// construction: a chunk that fails to spill (spill disabled / out of
+        /// space, #272) simply falls back to the reader's network path on
+        /// first touch, so a spill write is never fatal — only an actual fetch
+        /// error, which the passes would hit anyway, is surfaced.
+        pub(crate) fn stage_row_groups(
+            &self,
+            selected: Option<&[usize]>,
+        ) -> Result<(), InputError> {
+            let metadata = self.load_footer()?;
+            let row_groups = metadata.metadata().row_groups();
+
+            let indices: Vec<usize> = match selected {
+                Some(sel) => sel.to_vec(),
+                None => (0..row_groups.len()).collect(),
+            };
+            let plan: Vec<StagedRowGroup> = indices
+                .into_iter()
+                .filter_map(|i| row_groups.get(i))
+                .filter_map(|rg| {
+                    let mut start = u64::MAX;
+                    let mut end = 0u64;
+                    let mut chunks = Vec::with_capacity(rg.columns().len());
+                    for col in rg.columns() {
+                        let (s, len) = col.byte_range();
+                        start = start.min(s);
+                        end = end.max(s + len);
+                        chunks.push((s, len as usize));
+                    }
+                    (end > start).then_some(StagedRowGroup {
+                        span: start..end,
+                        chunks,
+                    })
+                })
+                .collect();
+            if plan.is_empty() {
+                return Ok(());
+            }
+
+            // Bound in-flight (resident) spans by the memory budget: holding
+            // one row group transiently matches the L1 cache ceiling, so never
+            // hold more than the budget's worth at once.
+            let max_span = plan
+                .iter()
+                .map(|r| r.span.end - r.span.start)
+                .max()
+                .unwrap_or(0);
+            let concurrency = match max_span {
+                0 => 1,
+                s => ((STAGE_MEM_BUDGET / s).max(1) as usize).min(STAGE_MAX_CONCURRENCY),
+            };
+
+            let store = Arc::clone(&self.store);
+            let location = self.location.clone();
+            let spill = Arc::clone(&self.spill);
+            let shared = Arc::clone(&self.shared);
+
+            runtime().block_on(async move {
+                use futures_util::stream::StreamExt;
+                let mut inflight = futures_util::stream::iter(plan.into_iter().map(|rg| {
+                    let store = Arc::clone(&store);
+                    let location = location.clone();
+                    async move {
+                        let bytes = store
+                            .get_range(&location, rg.span.clone())
+                            .await
+                            .map_err(|e| ParquetError::External(Box::new(e)))?;
+                        Ok::<(StagedRowGroup, Bytes), ParquetError>((rg, bytes))
+                    }
+                }))
+                .buffer_unordered(concurrency);
+
+                while let Some(result) = inflight.next().await {
+                    let (rg, bytes) = result?;
+                    // Count the coalesced request (mirrors `fetch`).
+                    shared.requests.fetch_add(1, Ordering::Relaxed);
+                    shared
+                        .bytes
+                        .fetch_add(bytes.len() as u64, Ordering::Relaxed);
+                    shared
+                        .ranges
+                        .lock()
+                        .expect("ranges lock")
+                        .push(rg.span.clone());
+                    // Slice into per-column-chunk spill entries. Guard the
+                    // slice bounds: a well-behaved store returns exactly the
+                    // requested span, but a short read must fall back to the
+                    // reader's network path (skip spilling), never panic.
+                    let base = rg.span.start;
+                    let mut spill = spill.lock().expect("spill lock");
+                    for (chunk_start, len) in rg.chunks {
+                        let off = (chunk_start - base) as usize;
+                        if off + len <= bytes.len() {
+                            spill.put(chunk_start, &bytes.slice(off..off + len));
+                        }
+                    }
+                }
+                Ok::<(), ParquetError>(())
+            })?;
+
+            Ok(())
+        }
+
         /// Snapshot of the fetch counters.
         pub fn fetch_stats(&self) -> FetchStats {
             FetchStats {
@@ -971,6 +1122,28 @@ pub(crate) mod remote {
     /// bigger than the cache thrashes, re-fetching an evicted chunk on the next
     /// batch (issue #261). This constant is just the small-input floor.
     const CHUNK_CACHE_MAX_BYTES: u64 = 256 * 1024 * 1024;
+
+    /// Staging (pass 0, #286/#287) concurrency ceiling: at most this many
+    /// row-group spans are fetched — and thus resident — at once. The live
+    /// concurrency is the lesser of this and [`STAGE_MEM_BUDGET`] divided by
+    /// the largest span, so a file of huge row groups never holds more than
+    /// the budget's worth of in-flight spans in memory.
+    const STAGE_MAX_CONCURRENCY: usize = 8;
+
+    /// Transient-memory budget bounding staging concurrency. One row group's
+    /// working set is already the in-memory chunk-cache ceiling (#261 sizes
+    /// the cache to the largest row group), so reuse that figure: staging
+    /// never holds more than a budget's worth of in-flight spans at once.
+    const STAGE_MEM_BUDGET: u64 = CHUNK_CACHE_MAX_BYTES;
+
+    /// One selected row group's staging plan: its contiguous byte span and
+    /// the `(chunk_start, len)` of every column chunk inside it — keyed
+    /// exactly how the L2 spill and [`RemoteReader::chunk_data`] look chunks
+    /// up (`chunk.start`), so a staged slice is a drop-in L2 hit.
+    struct StagedRowGroup {
+        span: Range<u64>,
+        chunks: Vec<(u64, usize)>,
+    }
 
     /// On-disk overflow for fetched column chunks (issue #219).
     ///

--- a/crates/core/src/input_set.rs
+++ b/crates/core/src/input_set.rs
@@ -475,6 +475,33 @@ impl ConvertSource {
         total
     }
 
+    /// Stage every part's selected row groups to local disk up front (pass 0,
+    /// #286/#287) so the streaming passes read from disk, not the network.
+    ///
+    /// Each remote part coalesces its selected row groups into one parallel
+    /// range request per row group (a row group is a contiguous byte span);
+    /// local parts are no-ops. Parts are staged in order so resident memory
+    /// stays bounded by one part's in-flight spans. `selection` (`None` = all
+    /// row groups) is the per-part bbox pruning the passes will honor, so
+    /// pruned groups are never fetched and total network traffic stays ≈1×
+    /// the input (#219). Errors are the caller's to handle; the streaming
+    /// pipeline treats staging as best-effort (a network error here is one the
+    /// passes would hit anyway).
+    pub fn stage_selected(&self, selection: Option<&RowGroupSelection>) -> Result<(), InputError> {
+        let parts = self.parts();
+        if let Some(sel) = selection {
+            debug_assert_eq!(
+                sel.0.len(),
+                parts.len(),
+                "row-group selection must cover every part"
+            );
+        }
+        for (i, part) in parts.iter().enumerate() {
+            part.stage_row_groups(selection.map(|s| s.0[i].as_slice()))?;
+        }
+        Ok(())
+    }
+
     /// Open a sequential batch stream over all parts (see [`SourceStream`]).
     pub fn open_stream(&self, plan: &ReadPlan<'_>) -> Result<SourceStream<'_>, InputError> {
         let parts = self.parts();

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -5505,6 +5505,66 @@ mod tests {
             assert!(report_remote.remote_fetch.is_some());
         }
 
+        /// #286 + #287: a full remote convert must COALESCE its data-page
+        /// fetches to ~one range request per selected row group. A row
+        /// group's column chunks are a contiguous byte span, so staging that
+        /// span up front (in parallel) turns the whole conversion's reads
+        /// into one request per row group — instead of a separate serial
+        /// request per column chunk per pass (#287), and in particular
+        /// instead of pass 2 re-fetching, cold, the property columns that
+        /// pass 1's geometry-only projection skipped (#286).
+        #[test]
+        fn remote_convert_coalesces_fetches_to_one_request_per_row_group() {
+            let geoms = synthetic_geometries();
+            let n = geoms.len();
+            // Several row groups, each carrying property columns (id, name,
+            // rank) that pass 1's geometry+ranking projection does not fully
+            // read — the #286 pass-2 re-fetch shape.
+            let tin = tempfile::NamedTempFile::new().unwrap();
+            write_input_partition(tin.path(), &geoms, 0..n, Some(2));
+            let bytes = std::fs::read(tin.path()).unwrap();
+            let rg = row_group_spans(&bytes).len();
+            assert!(rg >= 3, "test needs several row groups, got {rg}");
+
+            let opts = ConvertOptions::default();
+
+            // Reference: the local convert of the identical bytes.
+            let tout_local = tempfile::NamedTempFile::new().unwrap();
+            convert_to_overviews(tin.path(), tout_local.path(), &opts).unwrap();
+            let local_ids = read_all_ids(&OverviewReader::open(tout_local.path()).unwrap());
+
+            let source = test_memory_source(bytes, "staged.parquet");
+            let tout = tempfile::NamedTempFile::new().unwrap();
+            let report = convert_to_overviews_source(&source, tout.path(), &opts).unwrap();
+
+            // Staging must not change the output.
+            assert_eq!(
+                read_all_ids(&OverviewReader::open(tout.path()).unwrap()),
+                local_ids,
+                "staged remote convert must match the local convert row-for-row"
+            );
+
+            let stats = report.remote_fetch.expect("remote stats in report");
+            // THE property: one coalesced request per selected row group, plus
+            // a small fixed footer/metadata overhead — NOT ~one request per
+            // column chunk per pass.
+            const FOOTER_SLACK: u64 = 4;
+            assert!(
+                stats.requests <= rg as u64 + FOOTER_SLACK,
+                "expected ~1 request per row group (<= {} for {rg} row groups); \
+                 got {} — fetches not coalesced (#287) or properties re-fetched (#286)",
+                rg as u64 + FOOTER_SLACK,
+                stats.requests,
+            );
+            // Coalescing must not over-fetch: still ≈1× the object (#219).
+            assert!(
+                stats.bytes_fetched <= stats.object_size + stats.object_size / 2,
+                "staging must stay ≈1× the object: {} of {} bytes",
+                stats.bytes_fetched,
+                stats.object_size,
+            );
+        }
+
         // --- multi-partition remote input (v0.7 PR-B) ------------------------
 
         /// Partition bytes for `geoms[range]`, via the shared local writer.
@@ -5581,6 +5641,49 @@ mod tests {
                 summed.object_size, object_total,
                 "ConvertReport.remote_fetch.object_size sums the parts"
             );
+        }
+
+        /// #286 + #287 across the multi-partition path (the demo scenario):
+        /// each remote part must coalesce ITS OWN selected row groups to ~one
+        /// range request per row group, so a prefix of N partitions pays one
+        /// TTFB per row group — not ~one per column chunk per pass.
+        #[test]
+        fn multi_part_remote_coalesces_per_part_row_groups() {
+            let geoms = synthetic_geometries();
+            let n = geoms.len();
+            // Each partition carries several row groups (2 rows each) with
+            // property columns (id, name, rank) that pass 1 skips — the #286
+            // shape, per part.
+            let p0 = partition_bytes(&geoms, 0..5, Some(2));
+            let p1 = partition_bytes(&geoms, 5..9, Some(2));
+            let p2 = partition_bytes(&geoms, 9..n, Some(2));
+            let rg = [&p0, &p1, &p2].map(|b| row_group_spans(b).len());
+            assert!(
+                rg.iter().all(|&r| r >= 2),
+                "each part needs several row groups: {rg:?}"
+            );
+
+            let (source, parts) = crate::input::test_memory_multi_source(vec![
+                ("p0.parquet", p0),
+                ("p1.parquet", p1),
+                ("p2.parquet", p2),
+            ]);
+            let tout = tempfile::NamedTempFile::new().unwrap();
+            convert_to_overviews_sources(&source, tout.path(), &multi_test_options()).unwrap();
+
+            const FOOTER_SLACK: u64 = 4;
+            for (i, part) in parts.iter().enumerate() {
+                let stats = part.fetch_stats().expect("remote part has stats");
+                assert!(
+                    stats.requests <= rg[i] as u64 + FOOTER_SLACK,
+                    "part {i}: expected ~1 request per row group (<= {} for {} \
+                     row groups); got {} — not coalesced (#287) or properties \
+                     re-fetched (#286)",
+                    rg[i] as u64 + FOOTER_SLACK,
+                    rg[i],
+                    stats.requests,
+                );
+            }
         }
 
         /// bbox pruning an ENTIRE part: its row groups are pruned at the

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -134,6 +134,38 @@ fn log_validation_skips(skips_before: u64) {
     }
 }
 
+/// Pass 0 (#286/#287): stage the selected row groups to local disk up front so
+/// the two passes below read from the spill, not the network.
+///
+/// A row group's column chunks are a contiguous span, so each is fetched as ONE
+/// coalesced range request (several in flight per part) and spilled. This
+/// removes the per-column-chunk serial re-fetch (#287) and the cold pass-2
+/// re-fetch of the property columns pass 1's projection skips (#286).
+/// Best-effort and no-op for local input: a staging error is logged and the
+/// passes fall back to the reader's lazy network path (the same bytes, just
+/// uncoalesced), so staging never regresses correctness.
+fn stage_input_pass0(
+    source: &ConvertSource,
+    selected_row_groups: Option<&RowGroupSelection>,
+    row_groups_read: usize,
+) {
+    if !source.is_remote() {
+        return;
+    }
+    let t_stage = Instant::now();
+    match source.stage_selected(selected_row_groups) {
+        Ok(()) => log::info!(
+            "[convert] staged {row_groups_read} selected row group(s) to local \
+             disk in {:.1}s",
+            t_stage.elapsed().as_secs_f64()
+        ),
+        Err(e) => log::warn!(
+            "[convert] input staging failed ({e}); passes will read over the \
+             network (uncoalesced)"
+        ),
+    }
+}
+
 pub(crate) fn convert_streaming_strategy(
     source: &ConvertSource,
     output_path: &Path,
@@ -192,6 +224,10 @@ pub(crate) fn convert_streaming_strategy(
         source.selected_input_bytes(selected_row_groups.as_ref())?,
         options.spill_dir.as_deref(),
     );
+
+    // Pass 0 (#286/#287): stage the selected row groups to local disk so both
+    // passes below read from the spill, not the network.
+    stage_input_pass0(source, selected_row_groups.as_ref(), row_groups_read);
 
     if input_schema
         .fields()

--- a/docs/remote-reads.md
+++ b/docs/remote-reads.md
@@ -60,20 +60,26 @@ What to know:
   (`gpio sort hilbert --add-bbox`, modest `--row-group-size`) is what
   makes the few-percent extract real; a file with 4 giant row groups
   cannot be pruned finer than quarters.
-- **Fetch behavior** — one range request per selected column chunk
-  (the page reader's many small reads are served from a whole-chunk
-  buffer), plus the footer. The parsed footer and a cache of fetched
-  column chunks are held per conversion, so the streaming pipeline's
-  per-pass re-reads are refetch-free within a pass (measured: the
-  default streaming pipeline and `--no-streaming` move identical bytes
-  on a city extract). The cache budget is sized to the largest row
-  group's working set (floored at 256 MiB), so a single row group whose
-  column chunks exceed the floor — e.g. a multi-GB geometry chunk — is
-  no longer evicted mid-read and re-fetched per page (issue #261).
-  Beyond the in-memory cache, every fetched chunk is also spilled to a
-  local temp file, so a chunk evicted between passes — the assign pass,
-  the write pass, and (at higher zoom) a finest-level canonical re-read —
-  is drained from local disk rather than re-fetched over the network.
+- **Fetch behavior** — before the passes run, a remote convert **stages**
+  the selected row groups to the local spill (issues #286/#287). A row
+  group's column chunks are a *contiguous* byte span, so each selected row
+  group is fetched as **one** coalesced range request — several in flight
+  at once, bounded by a memory budget — and sliced into a per-column-chunk
+  buffer both passes then read from local disk (plus the footer, fetched
+  once). This replaces the earlier pattern of one small range request per
+  column chunk issued serially per pass, and in particular means pass 2 no
+  longer re-fetches, cold, the property columns pass 1's geometry+ranking
+  projection skipped (#286). The parsed footer and an in-memory cache of
+  fetched chunks are still held per conversion, so per-pass re-reads are
+  refetch-free within a pass (measured: the default streaming pipeline and
+  `--no-streaming` move identical bytes on a city extract). The cache
+  budget is sized to the largest row group's working set (floored at
+  256 MiB), so a single row group whose column chunks exceed the floor —
+  e.g. a multi-GB geometry chunk — is not evicted mid-read and re-fetched
+  per page (issue #261). Every staged chunk is written to a local temp
+  file, so a chunk touched across passes — the assign pass, the write
+  pass, and (at higher zoom) a finest-level canonical re-read — is drained
+  from local disk rather than re-fetched over the network.
   This bounds a full-file remote conversion to ≈1× the object's bytes
   regardless of pass or level count (issue #219). Measured on
   fieldmaps-adm4 (2.90 GB, z0–14): **96× before #261, 3.0× after #261,
@@ -89,12 +95,14 @@ What to know:
   mid-convert (or the file can't be created), the spill disables itself
   with a log line and later passes fall back to network re-fetch —
   correctness is preserved, only the ≈1× bound degrades.
-- **Latency vs bytes** — requests are issued sequentially, so on a
-  fast link a plain `aws s3 cp` + local convert can still win on wall
-  time (92 MB corpus file, residential fiber: ~3 s download+convert
-  vs ~9 s remote-direct). Remote-direct wins on bytes moved (5.6×
-  less on that extract), on slow/metered links, and whenever you
-  don't want the full file on disk.
+- **Latency vs bytes** — staging issues several range requests in
+  parallel and coalesces each row group into one, so per-request
+  round-trip latency no longer dominates on high-TTFB hosts (issues
+  #286/#287). On a fast link a plain `aws s3 cp` + local convert can
+  still win on wall time (92 MB corpus file, residential fiber: ~3 s
+  download+convert vs ~9 s remote-direct). Remote-direct wins on bytes
+  moved (5.6× less on that extract), on slow/metered links, and whenever
+  you don't want the full file on disk.
 - **Remote output is out of scope** — write locally, then
   `aws s3 cp`.
 - Rust builds: remote input lives behind the `remote` cargo feature of


### PR DESCRIPTION
Fixes #287 and #286 (siblings — both root-caused to the same remote read pattern, so tackled together per the issue notes).

## Problem

Benchmarking the v0.7 multi-partition demo against high-TTFB hosts (source.coop proxy / AWS S3) showed convert sitting at **1–3% CPU**, waiting on the wire:

- **#287** — the remote reader issued range requests essentially **serially** (~1 in flight). Wall-clock ≈ Σ(TTFB) + Σ(bytes/bw), and on high-latency hosts TTFB dominated.
- **#286** — pass 1 projects only geometry + ranking columns, so only those chunks were fetched/spilled. Pass 2 (`projection: None`) then re-fetched the **property columns cold** — ~10 small serial range requests per row group, each paying full TTFB (~1 row group/**minute**).

Measured 0.7 MB/s on Overture-over-S3 vs 13–16 MB/s single-range potential.

## Fix — pass 0: stage selected row groups up front

A row group's column chunks are a **contiguous byte span**, so each selected row group can be fetched as **one** coalesced range request and sliced back into exactly the per-column-chunk spill entries the reader's L2 path already serves from (`chunk.start`-keyed). New `stage_input_pass0()` runs before pass 1 for remote input:

- `RemoteSource::stage_row_groups` — parallel coalesced fetch → slice → spill, with **memory-budgeted concurrency** (a file of huge row groups never holds more than the budget's worth of in-flight spans).
- `InputSource::stage_row_groups` (Local = no-op) + `ConvertSource::stage_selected` dispatch; wired after the #272 spill-space preflight.
- **Zero changes to the hot reader read path** — both passes then read entirely from local disk. Correctness preserved by the existing L3 network fallback; staging is best-effort (a fetch error is logged and the passes fall back to the lazy path, the same bytes just uncoalesced).

## Invariants preserved

- Only **selected** row groups staged → pruned groups never touched, no speculative over-fetch.
- Total network stays **≈1×** the object (#219).
- Chunk-cache memory bound holds (#261); staging honors `--spill-dir` (#272).

## Tests (TDD)

- `remote_convert_coalesces_fetches_to_one_request_per_row_group` — **58 → ≤11** requests for 7 row groups (RED before, GREEN after).
- `multi_part_remote_coalesces_per_part_row_groups` — per-part coalescing across the multi-partition path (the demo scenario).
- Existing bbox-prune, three-pass ≈1×, and byte-identity remote tests still green; local streaming-equivalence tests unaffected.

## ⚠️ Needs sign-off before merge

This PR edits **public docs** (`docs/remote-reads.md`: "Fetch behavior" + "Latency vs bytes"). Flagging for your review — I have **not** merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)