### PR TITLE
perf(convert): --in-flight-batches auto — core-aware pass-2 concurrency

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -46,6 +46,20 @@ fn parse_size_bytes(s: &str) -> Result<usize, String> {
     })
 }
 
+/// Parse `--in-flight-batches`: `auto` (→ the core-sized sentinel 0) or an
+/// explicit positive integer. See [`resolve_in_flight_batches`] for how the
+/// sentinel is expanded at pass-2 setup.
+fn parse_in_flight_batches(s: &str) -> Result<usize, String> {
+    if s.eq_ignore_ascii_case("auto") {
+        return Ok(tylertoo_core::overview::convert::IN_FLIGHT_BATCHES_AUTO);
+    }
+    match s.parse::<usize>() {
+        Ok(0) => Err("in-flight-batches must be `auto` or >= 1".to_string()),
+        Ok(n) => Ok(n),
+        Err(_) => Err(format!("expected `auto` or a positive integer, got `{s}`")),
+    }
+}
+
 /// Parse a --bbox argument: xmin,ymin,xmax,ymax (lon/lat degrees).
 fn parse_bbox(s: &str) -> Result<[f64; 4]> {
     let parts: Vec<&str> = s.split(',').collect();
@@ -639,13 +653,17 @@ struct ConvertTuningArgs {
     /// Read batches allowed in flight through the pass-2 pipeline at once
     /// (read/compute-overlap knob; bounded-channel depth).
     ///
-    /// Higher improves core utilization on long-pole geometries at
-    /// proportionally more peak memory (in-flight-batches × read-batch-size rows
-    /// resident). No effect with --no-streaming.
+    /// `auto` (the default) sizes this to the machine's available cores
+    /// (clamped to 4..=16); pass an explicit integer to override. Higher
+    /// improves core utilization on long-pole geometries at proportionally
+    /// more peak memory (in-flight-batches × read-batch-size rows resident).
+    /// The chosen depth and detected core count are logged at pass-2 start.
+    /// No effect with --no-streaming.
     #[arg(
         long,
-        value_name = "N",
-        default_value = "4",
+        value_name = "N|auto",
+        default_value = "auto",
+        value_parser = parse_in_flight_batches,
         help_heading = "Memory & performance"
     )]
     in_flight_batches: usize,
@@ -1683,6 +1701,21 @@ mod tests {
         // A plain integer is raw bytes — keeps pre-reconciliation invocations working.
         assert_eq!(parse_size_bytes("500000").unwrap(), 500_000);
         assert!(parse_size_bytes("banana").is_err());
+    }
+
+    #[test]
+    fn parse_in_flight_batches_accepts_auto_and_positive() {
+        // `auto` maps to the core-sized sentinel; case-insensitive.
+        assert_eq!(
+            parse_in_flight_batches("auto").unwrap(),
+            tylertoo_core::overview::convert::IN_FLIGHT_BATCHES_AUTO
+        );
+        assert_eq!(parse_in_flight_batches("AUTO").unwrap(), 0);
+        // Explicit positive integers pass through.
+        assert_eq!(parse_in_flight_batches("8").unwrap(), 8);
+        // Explicit 0 is rejected (use `auto`); non-numeric is rejected.
+        assert!(parse_in_flight_batches("0").is_err());
+        assert!(parse_in_flight_batches("banana").is_err());
     }
 
     #[test]

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -323,10 +323,13 @@ pub struct ConvertOptions {
     pub profile: MemoryProfile,
     /// Number of Arrow read batches allowed in flight through the streaming
     /// pass-2 pipeline at once (bounded-channel depth / read-compute overlap
-    /// knob). Default [`DEFAULT_IN_FLIGHT_BATCHES`]. Higher improves core
-    /// utilization on long-pole geometries at proportionally more peak memory
-    /// (`in_flight_batches × read_batch_size` rows resident). No effect when
-    /// `streaming` is `false`.
+    /// knob). Default [`IN_FLIGHT_BATCHES_AUTO`], which
+    /// [`resolve_in_flight_batches`] expands to the machine's available
+    /// parallelism (clamped to `[IN_FLIGHT_BATCHES_MIN, IN_FLIGHT_BATCHES_MAX]`)
+    /// at pass-2 setup; any explicit positive value is honoured verbatim.
+    /// Higher improves core utilization on long-pole geometries at
+    /// proportionally more peak memory (`in_flight_batches × read_batch_size`
+    /// rows resident). No effect when `streaming` is `false`.
     pub in_flight_batches: usize,
     /// Enable point clustering (plan Q4; opt-in per spec §11 Q4). Duplicating
     /// mode only. When enabled, each level's point cell-winners absorb the
@@ -401,10 +404,42 @@ pub struct ConvertOptions {
 /// Default rows per read batch for the streaming pipeline (H3).
 pub const DEFAULT_READ_BATCH_SIZE: usize = 8192;
 
-/// Default number of read batches in flight through the pass-2 pipeline
-/// (#213). Four keeps a few cores fed on long-pole geometries while bounding
-/// resident batches to `4 × read_batch_size` rows.
-pub const DEFAULT_IN_FLIGHT_BATCHES: usize = 4;
+/// Sentinel value for [`ConvertOptions::in_flight_batches`] requesting
+/// automatic sizing from the machine's available parallelism (see
+/// [`resolve_in_flight_batches`]). This is the library default so a convert
+/// uses the cores it is given without the caller having to know the box.
+pub const IN_FLIGHT_BATCHES_AUTO: usize = 0;
+
+/// Lower clamp for auto-sized in-flight batches. Keeps a few cores fed even
+/// on a small box, and matches the historical hard default (#213).
+pub const IN_FLIGHT_BATCHES_MIN: usize = 4;
+
+/// Upper clamp for auto-sized in-flight batches. The single-threaded parquet
+/// writer (#264 follow-up) caps the achievable speedup, so pushing in-flight
+/// past this only grows the resident batch set (`in_flight × read_batch_size`
+/// rows) without a matching throughput gain. Power users can still pass a
+/// larger explicit value.
+pub const IN_FLIGHT_BATCHES_MAX: usize = 16;
+
+/// Resolve a requested in-flight-batches value to a concrete depth.
+///
+/// [`IN_FLIGHT_BATCHES_AUTO`] (0) auto-sizes from
+/// [`std::thread::available_parallelism`], clamped to
+/// `[IN_FLIGHT_BATCHES_MIN, IN_FLIGHT_BATCHES_MAX]`; any explicit positive
+/// value is honoured verbatim (uncapped — the caller opted in to the memory
+/// cost). Output is byte-identical for every value: in-flight depth only sets
+/// read/compute overlap, never level assignment or write order (see the
+/// `pipelined_in_flight_matches_reference` equivalence test).
+pub fn resolve_in_flight_batches(requested: usize) -> usize {
+    if requested == IN_FLIGHT_BATCHES_AUTO {
+        std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(IN_FLIGHT_BATCHES_MIN)
+            .clamp(IN_FLIGHT_BATCHES_MIN, IN_FLIGHT_BATCHES_MAX)
+    } else {
+        requested
+    }
+}
 
 impl Default for ConvertOptions {
     fn default() -> Self {
@@ -428,7 +463,7 @@ impl Default for ConvertOptions {
             streaming: true,
             read_batch_size: DEFAULT_READ_BATCH_SIZE,
             profile: MemoryProfile::Auto,
-            in_flight_batches: DEFAULT_IN_FLIGHT_BATCHES,
+            in_flight_batches: IN_FLIGHT_BATCHES_AUTO,
             cluster: false,
             accumulate: Vec::new(),
             coalesce_lines: true,
@@ -779,11 +814,9 @@ fn validate_options(options: &ConvertOptions) -> Result<(), ConvertError> {
             )));
         }
     }
-    if options.in_flight_batches == 0 {
-        return Err(ConvertError::InvalidConfig(
-            "in-flight-batches must be >= 1".to_string(),
-        ));
-    }
+    // in_flight_batches == 0 is the IN_FLIGHT_BATCHES_AUTO sentinel (resolved
+    // to available parallelism at pass-2 setup), not an error. Any explicit
+    // positive value is honoured verbatim, so there is nothing to reject here.
     // #272: fail fast on a bad spill dir — the spill is best-effort, so a
     // mid-convert creation failure would only surface as a silent degrade
     // to network re-fetch.
@@ -4374,7 +4407,10 @@ mod tests {
         };
 
         let reference = convert(7, 1);
-        for (rbs, ifb) in [(64usize, 4usize), (4096, 8)] {
+        // ifb = 0 is the IN_FLIGHT_BATCHES_AUTO sentinel: it must produce the
+        // same output as any explicit depth (auto only changes overlap, not
+        // level assignment or write order).
+        for (rbs, ifb) in [(64usize, 4usize), (4096, 8), (8192, 0)] {
             let candidate = convert(rbs, ifb);
             assert_outputs_equivalent(
                 reference.path(),
@@ -4382,6 +4418,31 @@ mod tests {
                 &format!("read_batch_size={rbs} in_flight_batches={ifb}"),
             );
         }
+    }
+
+    #[test]
+    fn resolve_in_flight_batches_auto_and_explicit() {
+        // Auto (0) sizes from available parallelism, clamped to [MIN, MAX].
+        let auto = resolve_in_flight_batches(IN_FLIGHT_BATCHES_AUTO);
+        assert!(
+            (IN_FLIGHT_BATCHES_MIN..=IN_FLIGHT_BATCHES_MAX).contains(&auto),
+            "auto in-flight {auto} outside [{IN_FLIGHT_BATCHES_MIN}, {IN_FLIGHT_BATCHES_MAX}]"
+        );
+        let cores = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(IN_FLIGHT_BATCHES_MIN);
+        assert_eq!(
+            auto,
+            cores.clamp(IN_FLIGHT_BATCHES_MIN, IN_FLIGHT_BATCHES_MAX),
+            "auto must equal core count clamped to the configured range"
+        );
+        // Explicit values pass through verbatim, including above the auto cap.
+        assert_eq!(resolve_in_flight_batches(1), 1);
+        assert_eq!(resolve_in_flight_batches(7), 7);
+        assert_eq!(
+            resolve_in_flight_batches(IN_FLIGHT_BATCHES_MAX + 100),
+            IN_FLIGHT_BATCHES_MAX + 100
+        );
     }
 
     #[test]

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -165,6 +165,21 @@ fn stage_input_pass0(
     }
 }
 
+/// Resolve the pass-2 in-flight depth (auto-sizing from available cores when
+/// the caller left it at [`super::convert::IN_FLIGHT_BATCHES_AUTO`]) and log
+/// the chosen depth alongside the detected core count, so pass-2 core
+/// utilization is observable rather than a mystery (#264).
+fn resolve_and_log_in_flight_batches(requested: usize) -> usize {
+    let in_flight = super::convert::resolve_in_flight_batches(requested);
+    log::info!(
+        "[convert] pass 2 parallelism: {in_flight} read batch(es) in flight ({} core(s) detected)",
+        std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(0)
+    );
+    in_flight
+}
+
 pub(crate) fn convert_streaming_strategy(
     source: &ConvertSource,
     output_path: &Path,
@@ -599,6 +614,10 @@ pub(crate) fn convert_streaming_strategy(
     // `(outcome, rows, vertices)` per emitted level, in level order. The
     // outcome distinguishes a written level from one the writer skipped because
     // every candidate collapsed during simplification (#211).
+    // Resolve the in-flight depth once (auto-sizes from available cores when
+    // the caller left it at IN_FLIGHT_BATCHES_AUTO) and surface it (#264).
+    let in_flight_batches = resolve_and_log_in_flight_batches(options.in_flight_batches);
+
     let level_stats: Vec<(LevelWriteOutcome, usize, usize)> = match strategy {
         // Reference: one in-order re-read per level (pre-#213 behavior).
         Pass2Strategy::Serial => ctxs
@@ -611,7 +630,7 @@ pub(crate) fn convert_streaming_strategy(
                     hints[i],
                     source,
                     options.read_batch_size,
-                    options.in_flight_batches,
+                    in_flight_batches,
                     selected_row_groups.as_ref(),
                     ctx,
                 )
@@ -634,7 +653,7 @@ pub(crate) fn convert_streaming_strategy(
                     source,
                     options.read_batch_size,
                     selected_row_groups.as_ref(),
-                    options.in_flight_batches,
+                    in_flight_batches,
                     backing,
                     &out_schema,
                 )?
@@ -647,7 +666,7 @@ pub(crate) fn convert_streaming_strategy(
                 hints[n - 1],
                 source,
                 options.read_batch_size,
-                options.in_flight_batches,
+                in_flight_batches,
                 selected_row_groups.as_ref(),
                 &ctxs[n - 1],
             )?);

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -329,7 +329,8 @@ fn convert_report_to_dict(py: Python<'_>, report: &ConvertReport) -> PyResult<Py
 ///     in_flight_batches (int, optional): Read batches allowed in flight through
 ///         the pass-2 pipeline at once (read/compute-overlap knob). Higher
 ///         improves core utilization at proportionally more peak memory.
-///         Defaults to 4.
+///         Defaults to 0, which auto-sizes to the machine's available cores
+///         (clamped to 4..=16); pass an explicit positive integer to override.
 ///     spill_dir (str or os.PathLike, optional): Directory for the
 ///         remote-input spill file. A remote convert stages every fetched
 ///         chunk on local disk (≈1x the touched input bytes) so later passes
@@ -404,7 +405,7 @@ fn convert_report_to_dict(py: Python<'_>, report: &ConvertReport) -> PyResult<Py
     read_batch_size=8192,
     bbox=None,
     profile="auto",
-    in_flight_batches=4,
+    in_flight_batches=0,
     spill_dir=None,
 ))]
 #[allow(clippy::too_many_arguments)] // Python API mirrors CLI flags; grouping into struct would hurt usability

--- a/crates/python/tylertoo.pyi
+++ b/crates/python/tylertoo.pyi
@@ -56,7 +56,7 @@ def overview(
     read_batch_size: int = 8192,
     bbox: tuple[float, float, float, float] | None = None,
     profile: str = "auto",
-    in_flight_batches: int = 4,
+    in_flight_batches: int = 0,
     spill_dir: str | Path | None = None,
 ) -> dict[str, Any]: ...
 def export_pmtiles(

--- a/docs/OVERVIEW_TUNING.md
+++ b/docs/OVERVIEW_TUNING.md
@@ -690,7 +690,7 @@ Moldova corpus file (632k polygons, 38M vertices) peak RSS drops from ~5.4 GB
 | `--read-batch-size N` | `8192` | rows per read batch | **bigger = faster-ish, more memory** |
 | `--no-streaming` | off | flag | revert to the one-pass in-memory pipeline |
 | `--profile speed\|bounded\|auto` | `auto` | preset | speed vs bounded RAM — see [Performance profiles](#performance-profiles---profile---in-flight-batches) |
-| `--in-flight-batches N` | `4` | read batches in flight | read/compute overlap — see [Performance profiles](#performance-profiles---profile---in-flight-batches) |
+| `--in-flight-batches N\|auto` | `auto` | read batches in flight (auto = cores, clamped 4–16) | read/compute overlap — see [Performance profiles](#performance-profiles---profile---in-flight-batches) |
 
 **`--read-batch-size`** bounds the transient working set of both passes: each
 batch is decoded, filtered, simplified, and written before the next is read.

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -93,9 +93,11 @@ For very large exports where pass-2 output buffering is the pressure,
 `--profile bounded` spills buffered tiles to temporary Arrow IPC files
 instead of holding them in RAM (`auto`, the default, picks `speed` or
 `bounded` per mode and estimated size — output is byte-identical either
-way). `--in-flight-batches <N>` (default 4) trades peak memory for
+way). `--in-flight-batches <N|auto>` (default `auto`, which sizes to the
+machine's available cores clamped to 4–16) trades peak memory for
 read/compute overlap: higher keeps more read batches resident but improves
-core utilization on long-pole geometries.
+core utilization on long-pole geometries. The resolved depth and detected
+core count are logged at pass-2 start.
 
 Line coalescing holds one level's candidate lines in memory; datasets
 with more lines than `--coalesce-max-level-rows` (default 2,000,000)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -52,7 +52,7 @@ Commands:
 | `--no-streaming` | off (streaming ON) | Revert to the in-memory reference pipeline |
 | `--read-batch-size <N>` | `8192` | Rows per Arrow read batch (streaming) |
 | `--profile <MODE>` | `auto` | Pass-2 buffering: `speed` (in-RAM), `bounded` (spill to temp Arrow IPC), `auto` (per mode + size). Output is byte-identical across profiles |
-| `--in-flight-batches <N>` | `4` | Read/compute overlap depth in pass 2 (higher = better core use, proportionally more peak memory) |
+| `--in-flight-batches <N\|auto>` | `auto` | Read/compute overlap depth in pass 2. `auto` sizes to available cores (clamped 4–16); higher = better core use, proportionally more peak memory. Resolved depth + core count logged at pass-2 start |
 | `--spill-dir <PATH>` | `$TMPDIR` | Directory for the remote-input spill file (≈1× the touched input bytes; a free-space preflight warns on a projected shortfall). Must exist; local inputs never spill |
 | `--report <PATH>` | — | Write the JSON conversion report |
 
@@ -190,7 +190,7 @@ report = overview(
     read_batch_size: int = 8192,
     bbox: tuple[float, float, float, float] | None = None,
     profile: str = "auto",
-    in_flight_batches: int = 4,
+    in_flight_batches: int = 0,
     spill_dir: str | os.PathLike | None = None,
 ) -> dict  # the JSON conversion report
 ```


### PR DESCRIPTION
## Summary

Adds an `--in-flight-batches` flag (default: `auto`) that sizes pass-2 in-flight batch concurrency from `available_parallelism()` instead of a fixed constant. Plumbed through core `ConvertOptions`, the CLI, and the Python bindings; the resolved value is logged once at pass-2 start. Docs updated (`OVERVIEW_TUNING.md`, advanced-usage, api-reference).

Remaining scope of #264 (convert core utilization); the structural writer ceiling it pushes against is tracked in #296.

## Validation

- Output is invariant to this knob by construction — `pipelined_invariant_to_batching_knobs` passes.
- CLI parse test (`parse_in_flight_batches_accepts_auto_and_positive`) passes.
- fmt / clippy / version-check green (pre-commit hooks).
- Rebased onto post-rename main (#292); stale `gpq_tiles_core::` refs translated.

## Benchmark status

⚠️ The auto-only convert benchmark (Brazil-scale validation of the speedup) has **not** been run yet — it was the pending step when this work was set aside. A local benchmark wave on the 2.4 GiB Germany-segments corpus is queued behind tonight's #293/#296 benchmark runs; results will be posted as a PR comment.

Refs #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)