### PR TITLE
perf(export): auto-scale partition wave to available cores (#293)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -60,6 +60,21 @@ fn parse_in_flight_batches(s: &str) -> Result<usize, String> {
     }
 }
 
+/// Parse `--partition-wave`: `auto` (→ the core-sized sentinel
+/// [`tylertoo_core::overview::export::PARTITION_WAVE_AUTO`]) or an explicit
+/// positive integer. See [`tylertoo_core::overview::export::resolve_partition_wave`]
+/// for how the sentinel is expanded at export start.
+fn parse_partition_wave(s: &str) -> Result<usize, String> {
+    if s.eq_ignore_ascii_case("auto") {
+        return Ok(tylertoo_core::overview::export::PARTITION_WAVE_AUTO);
+    }
+    match s.parse::<usize>() {
+        Ok(0) => Err("partition-wave must be `auto` or >= 1".to_string()),
+        Ok(n) => Ok(n),
+        Err(_) => Err(format!("expected `auto` or a positive integer, got `{s}`")),
+    }
+}
+
 /// Parse a --bbox argument: xmin,ymin,xmax,ymax (lon/lat degrees).
 fn parse_bbox(s: &str) -> Result<[f64; 4]> {
     let parts: Vec<&str> = s.split(',').collect();
@@ -205,6 +220,15 @@ struct ExportPmtilesArgs {
     /// different start vertex.
     #[arg(long)]
     no_simple_clip_fastpath: bool,
+
+    /// Partitions processed per band read during export (the export
+    /// concurrency knob). `auto` (the default) sizes this to the machine's
+    /// available cores (clamped to 6..=16); pass an explicit integer to
+    /// override. Wider waves keep more cores busy at proportionally more peak
+    /// memory (one wave of partitions resident). The chosen width and detected
+    /// core count are logged at export start.
+    #[arg(long, value_name = "N|auto", default_value = "auto", value_parser = parse_partition_wave)]
+    partition_wave: usize,
 
     /// Not supported here (single-file subcommand); accepted so the error
     /// can point at `overview`/`tiles` instead of clap's generic message.
@@ -891,6 +915,15 @@ struct TilesArgs {
     #[arg(long, default_value = "8")]
     tile_buffer: u32,
 
+    /// Partitions processed per band read during the export phase (the export
+    /// concurrency knob). `auto` (the default) sizes this to the machine's
+    /// available cores (clamped to 6..=16); pass an explicit integer to
+    /// override. Wider waves keep more cores busy at proportionally more peak
+    /// memory (one wave of partitions resident). The chosen width and detected
+    /// core count are logged at export start.
+    #[arg(long, value_name = "N|auto", default_value = "auto", value_parser = parse_partition_wave)]
+    partition_wave: usize,
+
     /// Enable verbose output (per-level and per-zoom breakdowns).
     #[arg(short, long)]
     verbose: bool,
@@ -1112,6 +1145,7 @@ fn run_tiles(args: TilesArgs) -> Result<()> {
         extent: 4096,
         tile_size_limit: args.max_tile_size,
         simple_clip_fastpath: !args.no_simple_clip_fastpath,
+        partition_wave: args.partition_wave,
     };
     let export_report = export_pmtiles(overview_tmp.path(), &output, &export_opts)
         .map_err(|e| anyhow::anyhow!("export failed: {e}"))?;
@@ -1407,6 +1441,7 @@ fn run_export_pmtiles(args: ExportPmtilesArgs) -> Result<()> {
         extent: 4096,
         tile_size_limit: args.tile_size_limit,
         simple_clip_fastpath: !args.no_simple_clip_fastpath,
+        partition_wave: args.partition_wave,
     };
 
     println!(
@@ -1738,6 +1773,55 @@ mod tests {
         assert_eq!(a.tuning.profile, "bounded");
         assert!(a.tuning.cluster);
         assert!(a.tuning.no_coalesce_lines);
+    }
+
+    #[test]
+    fn parse_partition_wave_accepts_auto_and_positive() {
+        // `auto` maps to the core-sized sentinel; case-insensitive.
+        assert_eq!(
+            parse_partition_wave("auto").unwrap(),
+            tylertoo_core::overview::export::PARTITION_WAVE_AUTO
+        );
+        assert_eq!(parse_partition_wave("AUTO").unwrap(), 0);
+        // Explicit positive integers pass through (6 keeps the old behavior).
+        assert_eq!(parse_partition_wave("6").unwrap(), 6);
+        assert_eq!(parse_partition_wave("32").unwrap(), 32);
+        // Explicit 0 is rejected (use `auto`); non-numeric is rejected.
+        assert!(parse_partition_wave("0").is_err());
+        assert!(parse_partition_wave("banana").is_err());
+    }
+
+    #[test]
+    fn tiles_partition_wave_defaults_auto_and_overrides() {
+        // Default is the auto sentinel (0) on the one-shot command.
+        let default = parse_tiles(&[]);
+        assert_eq!(
+            default.partition_wave,
+            tylertoo_core::overview::export::PARTITION_WAVE_AUTO
+        );
+        // Explicit override is honoured verbatim.
+        let overridden = parse_tiles(&["--partition-wave", "6"]);
+        assert_eq!(overridden.partition_wave, 6);
+    }
+
+    #[test]
+    fn export_pmtiles_partition_wave_defaults_auto_and_overrides() {
+        let parse_export = |flags: &[&str]| -> ExportPmtilesArgs {
+            let mut argv = vec!["tylertoo", "export-pmtiles", "in.parquet", "out.pmtiles"];
+            argv.extend_from_slice(flags);
+            match Cli::try_parse_from(argv)
+                .expect("export-pmtiles args should parse")
+                .command
+            {
+                Command::ExportPmtiles(a) => a,
+                other => panic!("expected export-pmtiles subcommand, got {other:?}"),
+            }
+        };
+        assert_eq!(
+            parse_export(&[]).partition_wave,
+            tylertoo_core::overview::export::PARTITION_WAVE_AUTO
+        );
+        assert_eq!(parse_export(&["--partition-wave", "12"]).partition_wave, 12);
     }
 
     #[test]

--- a/crates/core/src/overview/export.rs
+++ b/crates/core/src/overview/export.rs
@@ -16,7 +16,7 @@
 //!    at level `k`'s zoom".
 //! 3. **Partition pass**: split the zoom's tiles into contiguous ascending
 //!    `(x, y)` ranges of roughly [`DEFAULT_PARTITION_TARGET`] members each, then
-//!    process them in **waves** of [`PARTITION_WAVE`] partitions. Each wave
+//!    process them in **waves** of [`resolve_partition_wave`] partitions. Each wave
 //!    reads the band **once** (row groups pruned to the wave's combined bbox),
 //!    splits every feature into its tiles with a **top-down recursive quadtree
 //!    cascade** (see [`feature_tile_members`]) — each feature clipped once per
@@ -45,7 +45,7 @@
 //! ## Memory ceiling
 //!
 //! Peak working set is `O(one wave of partitions + writer state)` (waves are
-//! [`PARTITION_WAVE`] partitions processed concurrently): each in-flight
+//! [`resolve_partition_wave`] partitions processed concurrently): each in-flight
 //! partition holds its (feature × intersecting-tile) clipped members plus its
 //! encoded tiles, bounded by the partition target — **not** the zoom band's
 //! feature count.
@@ -135,6 +135,15 @@ pub struct ExportOptions {
     /// vertex, so disable it (`--no-simple-clip-fastpath`) only when byte-stable
     /// tile output is required.
     pub simple_clip_fastpath: bool,
+    /// Number of partitions processed per band read (the export concurrency
+    /// knob). Default [`PARTITION_WAVE_AUTO`], which [`resolve_partition_wave`]
+    /// expands to the machine's available parallelism (clamped to
+    /// `[PARTITION_WAVE_MIN, PARTITION_WAVE_MAX]`) at export start; any explicit
+    /// positive value is honoured verbatim. Wider waves keep more cores busy at
+    /// proportionally more peak memory (`O(partition_wave)` partitions
+    /// resident) and read a wider combined-bbox band per wave. Output is
+    /// byte-identical for every value — the wave is a scheduling concern only.
+    pub partition_wave: usize,
 }
 
 impl Default for ExportOptions {
@@ -145,6 +154,7 @@ impl Default for ExportOptions {
             extent: DEFAULT_EXTENT,
             tile_size_limit: None,
             simple_clip_fastpath: true,
+            partition_wave: PARTITION_WAVE_AUTO,
         }
     }
 }
@@ -264,15 +274,76 @@ pub fn zoom_for_level(meta: &OverviewsMeta, level_idx: usize) -> u8 {
 /// holding the whole zoom in memory.
 const DEFAULT_PARTITION_TARGET: usize = 32_768;
 
-/// Number of partitions grouped into one wave. A wave reads the level band
-/// **once** (row groups pruned to the wave's combined bbox), decodes it a single
-/// time, and routes the decoded features to its partitions — so a level costs
-/// `ceil(P / PARTITION_WAVE)` band reads instead of one per partition (issue
-/// #228). Peak memory stays at O(`PARTITION_WAVE` partitions), and one shared
-/// decode per wave (rather than one per partition) also lowers the peak. Waves
-/// complete in order, so the writer still receives tiles in ascending `(x, y)`
-/// order.
-const PARTITION_WAVE: usize = 6;
+/// Sentinel for [`ExportOptions::partition_wave`] requesting automatic sizing
+/// from the machine's available parallelism (see [`resolve_partition_wave`]).
+/// This is the library default so an export uses the cores it is given without
+/// the caller having to know the box (#293).
+pub const PARTITION_WAVE_AUTO: usize = 0;
+
+/// Lower clamp for the auto-sized partition wave. Matches the historical
+/// hard-coded width (#228): auto never schedules *narrower* than the tuned
+/// baseline, so a small box behaves exactly as before.
+pub const PARTITION_WAVE_MIN: usize = 6;
+
+/// Upper clamp for the auto-sized partition wave.
+///
+/// The wave width is the export's peak-memory knob: each in-flight partition
+/// holds its clipped geometries + encoded tiles resident, so peak memory is
+/// `O(PARTITION_WAVE partitions)` (see the wave doc below). Auto-sizing to raw
+/// core count would let a many-core box widen the wave without bound and
+/// balloon the export memory transient that #295 is already tracking — going
+/// from the old width of 6 to 16 already lifts the resident wave set ~2.7×. We
+/// therefore cap auto at 16: it saturates the 16-core target box the issue was
+/// filed from (16-wide waves, ~2× fewer serial waves at z12–z14) while holding
+/// the memory transient to a known, bounded multiple of the old baseline.
+///
+/// A fixed cap is deliberately preferred over a `/proc/meminfo`-derived RAM
+/// budget here: the latter is Linux-only, non-deterministic run-to-run, and
+/// would couple export scheduling to transient free memory. Bounding the
+/// dataset-scaled memory peak is #295's job; this knob should stay a simple,
+/// portable, deterministic scheduling cap. Power users who want a wider wave
+/// (and accept the memory cost) can still pass an explicit value, which is
+/// honoured verbatim past this cap.
+pub const PARTITION_WAVE_MAX: usize = 16;
+
+/// Resolve a requested partition-wave width to a concrete value.
+///
+/// [`PARTITION_WAVE_AUTO`] (0) auto-sizes from
+/// [`std::thread::available_parallelism`], clamped to
+/// `[PARTITION_WAVE_MIN, PARTITION_WAVE_MAX]`; any explicit positive value is
+/// honoured verbatim (uncapped — the caller opted in to the memory cost).
+///
+/// The output is a **scheduling** parameter only: it sets how many partitions
+/// are processed per band read, never which features land in which tile or the
+/// order tiles reach the writer. Every wave width therefore produces a
+/// byte-identical archive (pinned by `export_wave_width_is_byte_invariant` and
+/// the partition-invariance / frozen-hash tests).
+pub fn resolve_partition_wave(requested: usize) -> usize {
+    if requested == PARTITION_WAVE_AUTO {
+        std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(PARTITION_WAVE_MIN)
+            .clamp(PARTITION_WAVE_MIN, PARTITION_WAVE_MAX)
+    } else {
+        requested
+    }
+}
+
+/// Resolve the partition-wave width (auto-sizing from available cores when the
+/// caller left it at [`PARTITION_WAVE_AUTO`]) and log the chosen width alongside
+/// the detected core count once at export start, so export core utilization is
+/// observable rather than a mystery (#293) — mirrors the pass-2 parallelism
+/// log line in the convert streaming path.
+fn resolve_and_log_partition_wave(requested: usize) -> usize {
+    let wave = resolve_partition_wave(requested);
+    log::info!(
+        "[export] partition wave: {wave} partition(s) per band read ({} core(s) detected)",
+        std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(0)
+    );
+    wave
+}
 
 /// Arrow batch size for the partition read passes (the parquet reader default
 /// of 1024 rows makes the per-batch parallel clip sections too small to load-
@@ -324,6 +395,10 @@ fn export_pmtiles_with_partition_target(
     let num_levels = reader.num_levels();
     let min_zoom = zoom_for_level(&meta, 0);
     let max_zoom = zoom_for_level(&meta, num_levels - 1);
+
+    // Resolve the partition-wave width once (auto-sizes from available cores
+    // when the caller left it at PARTITION_WAVE_AUTO) and surface it (#293).
+    let partition_wave = resolve_and_log_partition_wave(options.partition_wave);
 
     // Writer: field metadata + layer name are derived from the first level's
     // schema (property columns, level/covering excluded).
@@ -397,12 +472,12 @@ fn export_pmtiles_with_partition_target(
         let mut tile_feature_count = 0usize;
         let mut oversized = 0usize;
         let mut write_secs = 0f64;
-        let total_waves = partitions.len().div_ceil(PARTITION_WAVE);
+        let total_waves = partitions.len().div_ceil(partition_wave);
         // Within-level progress (#229): a long finest level is where runs get
         // stuck, so emit a throttled wave counter. If it advances the level is
         // slow; if it freezes the level is stuck — diagnosable in minutes.
         let mut last_wave_log = Instant::now();
-        for (wave_idx, wave) in partitions.chunks(PARTITION_WAVE).enumerate() {
+        for (wave_idx, wave) in partitions.chunks(partition_wave).enumerate() {
             let results: Vec<Vec<EncodedTile>> = process_wave(&ctx, wave)?;
             let t_write = Instant::now();
             for tiles in &results {
@@ -806,7 +881,7 @@ fn plan_partitions(
 /// `(x, y)` order.
 ///
 /// This replaces the old per-partition re-read (issue #228): instead of `P`
-/// independent band reads + decodes per level, a wave of `PARTITION_WAVE`
+/// independent band reads + decodes per level, a wave of `partition_wave`
 /// partitions shares a single read + decode. Byte-identical to the per-partition
 /// path — each partition receives exactly the members with key in its
 /// `[key_lo, key_hi]` window (a tile's clipped geometry is window-independent),
@@ -2008,6 +2083,62 @@ mod tests {
         assert_eq!(r_many.total_tiles, r_one.total_tiles);
         assert_eq!(r_many.total_tile_features, r_one.total_tile_features);
         assert_eq!(r_many.oversized_tiles, r_one.oversized_tiles);
+    }
+
+    #[test]
+    fn resolve_partition_wave_auto_and_explicit() {
+        // Auto (0) sizes from available parallelism, clamped to [MIN, MAX].
+        let auto = resolve_partition_wave(PARTITION_WAVE_AUTO);
+        assert!(
+            (PARTITION_WAVE_MIN..=PARTITION_WAVE_MAX).contains(&auto),
+            "auto wave {auto} outside [{PARTITION_WAVE_MIN}, {PARTITION_WAVE_MAX}]"
+        );
+        let cores = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(PARTITION_WAVE_MIN);
+        assert_eq!(
+            auto,
+            cores.clamp(PARTITION_WAVE_MIN, PARTITION_WAVE_MAX),
+            "auto must equal core count clamped to the configured range"
+        );
+        // Explicit values pass through verbatim, including above the auto cap.
+        assert_eq!(resolve_partition_wave(1), 1);
+        assert_eq!(resolve_partition_wave(6), 6);
+        assert_eq!(
+            resolve_partition_wave(PARTITION_WAVE_MAX + 100),
+            PARTITION_WAVE_MAX + 100
+        );
+    }
+
+    /// The archive must be byte-identical regardless of wave width: the wave is
+    /// a scheduling parameter (how many partitions share a band read), never a
+    /// change to tile membership or write order. A narrow explicit wave (1) and
+    /// a wide one (16) must produce exactly the same bytes — this is the
+    /// equivalence gate for #293's auto-scaling default.
+    #[test]
+    fn export_wave_width_is_byte_invariant() {
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        equivalence_fixture(tin.path());
+        let t_narrow = tempfile::NamedTempFile::new().unwrap();
+        let t_wide = tempfile::NamedTempFile::new().unwrap();
+        let narrow = ExportOptions {
+            layer_name: "ref".to_string(),
+            partition_wave: 1,
+            ..Default::default()
+        };
+        let wide = ExportOptions {
+            layer_name: "ref".to_string(),
+            partition_wave: 16,
+            ..Default::default()
+        };
+        // Force many partitions so multiple waves actually form at both widths.
+        export_pmtiles_with_partition_target(tin.path(), t_narrow.path(), &narrow, 1).unwrap();
+        export_pmtiles_with_partition_target(tin.path(), t_wide.path(), &wide, 1).unwrap();
+        assert_eq!(
+            std::fs::read(t_narrow.path()).unwrap(),
+            std::fs::read(t_wide.path()).unwrap(),
+            "archive bytes diverge between wave widths 1 and 16"
+        );
     }
 
     // --- recursive splitter equivalence (issue #226) -------------------------

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -99,6 +99,8 @@ fn convert(
         extent: 4096,
         tile_size_limit,
         simple_clip_fastpath,
+        // Convenience wrapper: use the core auto default (core-sized wave).
+        partition_wave: tylertoo_core::overview::export::PARTITION_WAVE_AUTO,
     };
 
     // Intermediate overview file next to the output (same filesystem);
@@ -657,6 +659,12 @@ fn overview(
 ///         Faster fine-zoom polygon export; output is render-equivalent on
 ///         simple rings but stores them rotated to a different start vertex.
 ///         Defaults to True; set False for byte-stable tile output.
+///     partition_wave (int, optional): Partitions processed per band read
+///         during export (the export concurrency knob). Defaults to 0, which
+///         auto-sizes to the machine's available cores (clamped to 6..=16);
+///         pass an explicit positive integer to override. Wider waves keep
+///         more cores busy at proportionally more peak memory. Output is
+///         byte-identical for every value (the wave is a scheduling concern).
 ///
 /// Returns:
 ///     dict: Export report with keys "mode", "min_zoom", "max_zoom", "zooms"
@@ -674,7 +682,7 @@ fn overview(
 ///     ...                         layer_name="admin")
 ///     >>> print(report["total_tiles"])
 #[pyfunction]
-#[pyo3(signature = (input, output, *, layer_name="overview", tile_buffer=8, extent=4096, tile_size_limit=None, simple_clip_fastpath=true))]
+#[pyo3(signature = (input, output, *, layer_name="overview", tile_buffer=8, extent=4096, tile_size_limit=None, simple_clip_fastpath=true, partition_wave=0))]
 #[allow(clippy::too_many_arguments)] // mirrors the Python kwarg signature
 fn export_pmtiles(
     py: Python<'_>,
@@ -685,6 +693,7 @@ fn export_pmtiles(
     extent: u32,
     tile_size_limit: Option<usize>,
     simple_clip_fastpath: bool,
+    partition_wave: usize,
 ) -> PyResult<Py<PyDict>> {
     let options = ExportOptions {
         layer_name: layer_name.to_string(),
@@ -692,6 +701,7 @@ fn export_pmtiles(
         extent,
         tile_size_limit,
         simple_clip_fastpath,
+        partition_wave,
     };
     let input_path = Path::new(input).to_path_buf();
     let output_path = Path::new(output).to_path_buf();

--- a/crates/python/tylertoo.pyi
+++ b/crates/python/tylertoo.pyi
@@ -68,5 +68,6 @@ def export_pmtiles(
     extent: int = 4096,
     tile_size_limit: int | None = None,
     simple_clip_fastpath: bool = True,
+    partition_wave: int = 0,
 ) -> dict[str, Any]: ...
 def validate(file: str) -> dict[str, Any]: ...


### PR DESCRIPTION
## What changed

Export is the single longest phase of a large convert, and it was compute-bound but **core-starved**: the partition-wave width (how many partitions share one band read) was the hard-coded constant `PARTITION_WAVE = 6`. On a 16-core box z12–z14 serialized into 108–308 waves at ~741% CPU while ~10 cores sat idle.

This makes the wave core-aware, mirroring the established `--in-flight-batches auto` pattern:

- **Core** (`crates/core/src/overview/export.rs`): new `ExportOptions::partition_wave` (default `PARTITION_WAVE_AUTO` = 0). `resolve_partition_wave()` expands the sentinel from `std::thread::available_parallelism()` clamped to `[PARTITION_WAVE_MIN=6, PARTITION_WAVE_MAX=16]`; any explicit positive value is honoured verbatim (uncapped). The resolved width + detected core count is logged once at export start.
- **CLI** (`crates/cli/src/main.rs`): `--partition-wave <N|auto>` (default `auto`) on both `export-pmtiles` and `tiles`, with a `parse_partition_wave` validator (`auto` → 0; explicit 0 rejected).
- **Python** (`crates/python/src/lib.rs` + `tylertoo.pyi`): `export_pmtiles(partition_wave=0)` for parity; stub verified by `mypy.stubtest` with the CI allowlist.

Passing an explicit `--partition-wave 6` reproduces the old behavior exactly.

## Memory tradeoff (why the cap)

The wave is the export's peak-memory knob: peak working set is `O(one wave of partitions)` resident (each in-flight partition holds its clipped geometries + encoded tiles). Auto-sizing to raw core count would let a many-core box widen the wave without bound and worsen the export memory transient that **#295** is already tracking.

Auto is therefore **capped at 16**: it saturates the 16-core target box the issue was filed from while bounding the transient to a known multiple of the old baseline. A fixed cap is deliberately preferred over a `/proc/meminfo`-derived RAM budget — the latter is Linux-only, non-deterministic run-to-run, and would couple scheduling to transient free memory. Bounding the *dataset-scaled* memory peak is #295's job; this knob stays a simple, portable, deterministic scheduling cap. Power users who want a wider wave (and accept the cost) can pass a larger explicit value.

The naive 6→16 estimate was ~2.7× peak memory; the measured increase was **1.44×** (partitions are not all full-sized), i.e. better than the worst case.

## Benchmark

Export-phase only, back-to-back under one lock hold, load-gated to 1-min load < 6 before timing. 16-core / 54 GiB box. Dataset: `overture-germany-segments.parquet` (2.4 GiB lines) → overview parquet (z0–14, 5.16 GiB, z14 = 19.2M features), then `export-pmtiles` on that overview. Both runs produced 293,248 tiles / 53,063,526 features. One run each (`/usr/bin/time -v`).

| Metric | Baseline (`wave=6`, origin/main) | Auto (`wave=16`, this PR) | Δ |
|---|---|---|---|
| Wall clock | 530.25 s (8:50) | 389.32 s (6:29) | **1.36× faster** (−26.6%) |
| CPU utilization | 482% | 614% | +132 pts |
| Max RSS | 601,656 KB (~588 MiB) | 868,604 KB (~848 MiB) | 1.44× |

Auto log line at export start:
```
[export] partition wave: 16 partition(s) per band read (16 core(s) detected)
```

## Equivalence proof

The wave is a **scheduling** parameter only — it never changes tile membership or write order — so output must be byte-identical for every width.

- **Benchmark `cmp`**: baseline and auto PMTiles are byte-identical (both exactly 2,474,675,455 bytes; `cmp` reported no difference).
- **Frozen-archive-hash test**: `export_archive_matches_pre_refactor_reference` still passes under the new `auto` default (hash `390f2b1c51a8a29c` unchanged).
- **New unit test**: `export_wave_width_is_byte_invariant` exports the same fixture at widths 1 and 16 and asserts identical archive bytes.
- Existing `partitioned_export_is_partition_invariant` still passes.

## Quality gates

- `cargo clippy --all-targets --all-features -- -D warnings` — clean (exit 0).
- `cargo fmt --all --check` — clean.
- Targeted core tests: `resolve_partition_wave_auto_and_explicit`, `export_wave_width_is_byte_invariant`, `partitioned_export_is_partition_invariant`, `export_archive_matches_pre_refactor_reference` — all pass.
- CLI parse tests: `parse_partition_wave_accepts_auto_and_positive`, `tiles_partition_wave_defaults_auto_and_overrides`, `export_pmtiles_partition_wave_defaults_auto_and_overrides` — all pass.
- Python: `mypy.stubtest tylertoo --allowlist stubtest-allowlist.txt` — success; runtime signature exposes `partition_wave=0`.
- Version files untouched.

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)