### PR TITLE
perf(convert): workload-based auto memory profile + per-phase RSS logging (#294, #295)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -638,10 +638,12 @@ struct ConvertTuningArgs {
     ///
     /// `speed` buffers each output level's rows in RAM (fastest; peak RAM grows
     /// with buffered output). `bounded` spills them to temporary Arrow IPC
-    /// files (memory-capped; slight temp-I/O cost). `auto` (default) picks per
-    /// mode + estimated size — duplicating → speed, partitioning → bounded, and
-    /// any run whose estimated buffered output exceeds a budget → bounded.
-    /// Output is byte-identical across profiles. No effect with --no-streaming.
+    /// files (memory-capped; slight temp-I/O cost). `auto` (default) is
+    /// workload-based: it estimates buffered output from feature and level
+    /// counts and spills when that exceeds a fraction of available RAM, so large
+    /// duplicating runs prefer bounded instead of risking OOM (override the RAM
+    /// figure with TYLERTOO_AUTO_MEM_LIMIT_BYTES). Output is byte-identical
+    /// across profiles. No effect with --no-streaming.
     #[arg(
         long,
         default_value = "auto",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -48,6 +48,7 @@ crossbeam-channel = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }
 tracing = { workspace = true }
+memory-stats = { workspace = true }
 flate2 = "1"
 brotli = "8"
 zstd = "0.13"

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -4538,7 +4538,15 @@ mod tests {
             convert_to_overviews_strategy(input, serial_out.path(), base, Pass2Strategy::Serial)
                 .unwrap();
 
-            for profile in [MemoryProfile::Speed, MemoryProfile::Bounded] {
+            // Auto included (#294): its workload-based backing choice must not
+            // change output — on this tiny input it resolves to RAM, matching
+            // Speed; the pipeline unit tests cover the large-input Spill flip,
+            // and the Bounded case proves the Spill round-trip is lossless.
+            for profile in [
+                MemoryProfile::Speed,
+                MemoryProfile::Bounded,
+                MemoryProfile::Auto,
+            ] {
                 let opts = ConvertOptions {
                     profile,
                     ..base.clone()

--- a/crates/core/src/overview/level.rs
+++ b/crates/core/src/overview/level.rs
@@ -125,10 +125,13 @@ pub enum Mode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum MemoryProfile {
-    /// Resolve per mode + estimated output size at convert entry (duplicating →
-    /// [`Speed`](Self::Speed), partitioning → [`Bounded`](Self::Bounded); any
-    /// run whose estimated buffered output exceeds a memory budget flips to
-    /// `Bounded`). The resolved choice is logged. This is the default.
+    /// Resolve the backing from the *workload* at convert entry (#294): the
+    /// estimated buffered output (`f(buffered_rows, mode)`) is compared against
+    /// a fraction of available system RAM. Small runs stay in RAM (like
+    /// [`Speed`](Self::Speed)); runs whose estimate exceeds the budget spill
+    /// (like [`Bounded`](Self::Bounded)), so large duplicating converts prefer
+    /// the bounded path instead of risking OOM. Partitioning additionally keeps
+    /// a fixed row ceiling. The resolved choice is logged. This is the default.
     #[default]
     Auto,
     /// Buffer each output level's rows in RAM before writing. Fastest; peak RAM

--- a/crates/core/src/overview/pipeline.rs
+++ b/crates/core/src/overview/pipeline.rs
@@ -64,13 +64,18 @@ pub(super) enum SinkBacking {
 /// this by `buffered_rows` (the count the pass-2 engine holds — every level but
 /// the streamed finest) to size the RAM-vs-spill choice against available RAM.
 ///
-/// Duplicating buffers only the geometrically-decayed COARSE levels, each
-/// holding *simplified* geometry, so its rows are light. Partitioning buffers
-/// every feature exactly once at FULL resolution, so its rows are heavier.
-/// These are deliberately rough, upper-ish estimates: they steer only the
-/// backing choice and never change output bytes.
-const DUPLICATING_BYTES_PER_ROW: u64 = 256;
-const PARTITIONING_BYTES_PER_ROW: u64 = 2_048;
+/// A buffered row is a whole retained feature (geometry + properties as Arrow
+/// arrays), NOT a coordinate — so the cost is dominated by geometry vertex
+/// count. Measured pass-2 sink cost per buffered row (2026-07, RSS delta of the
+/// pass2 sink phase ÷ `buffered_rows`): germany-segments lines ≈ 9.6 KiB,
+/// fieldmaps-adm4 polygons ≈ 6.3 KiB, moldova polygons ≈ 16 KiB. An earlier
+/// 256 B/row guess undercounted the real cost ~25× and let `auto` keep a
+/// 3.4 GiB sink in RAM on a simulated 2 GiB box (issue #294's exact failure).
+/// These constants are set to ~8 KiB (duplicating) / ~16 KiB (partitioning,
+/// full-resolution geometry) — biased high so `auto` prefers the (near-free on
+/// nvme) spill path over OOM. They steer only the backing choice, never output.
+const DUPLICATING_BYTES_PER_ROW: u64 = 8_192;
+const PARTITIONING_BYTES_PER_ROW: u64 = 16_384;
 
 /// Fraction of *available* system RAM the estimated buffered-output set may
 /// occupy before `Auto` spills to a temp file instead of holding it in RAM.
@@ -503,9 +508,9 @@ mod backing_tests {
     #[test]
     fn auto_duplicating_large_spills() {
         // The #294 fix: a large duplicating buffered set flips to Spill instead
-        // of the old unconditional RAM. 300M rows * 256 B = 76.8 GiB > 0.6*54.
+        // of the old unconditional RAM. 10M rows * 8 KiB = 80 GiB > 0.6*54.
         assert!(matches!(
-            auto_backing(Mode::Duplicating, 300_000_000, Some(54 * GIB)),
+            auto_backing(Mode::Duplicating, 10_000_000, Some(54 * GIB)),
             SinkBacking::Spill
         ));
     }
@@ -513,7 +518,7 @@ mod backing_tests {
     #[test]
     fn auto_decision_scales_with_available_ram() {
         // Identical workload flips on available RAM, not a fixed fraction of it.
-        let rows = 50_000_000; // 50M * 256 B = 12.8 GiB estimate
+        let rows = 5_000_000; // 5M * 8 KiB = 40 GiB estimate
         assert!(
             matches!(
                 auto_backing(Mode::Duplicating, rows, Some(4 * GIB)),
@@ -559,10 +564,10 @@ mod backing_tests {
 
     #[test]
     fn estimate_scales_with_mode_and_rows() {
-        assert_eq!(estimate_buffered_bytes(Mode::Duplicating, 1_000), 256_000);
+        assert_eq!(estimate_buffered_bytes(Mode::Duplicating, 1_000), 8_192_000);
         assert_eq!(
             estimate_buffered_bytes(Mode::Partitioning, 1_000),
-            2_048_000
+            16_384_000
         );
         // Saturating: no overflow panic on absurd counts.
         assert_eq!(

--- a/crates/core/src/overview/pipeline.rs
+++ b/crates/core/src/overview/pipeline.rs
@@ -60,42 +60,155 @@ pub(super) enum SinkBacking {
     Spill,
 }
 
+/// Estimated in-RAM bytes per buffered output ROW, by mode. `Auto` multiplies
+/// this by `buffered_rows` (the count the pass-2 engine holds — every level but
+/// the streamed finest) to size the RAM-vs-spill choice against available RAM.
+///
+/// Duplicating buffers only the geometrically-decayed COARSE levels, each
+/// holding *simplified* geometry, so its rows are light. Partitioning buffers
+/// every feature exactly once at FULL resolution, so its rows are heavier.
+/// These are deliberately rough, upper-ish estimates: they steer only the
+/// backing choice and never change output bytes.
+const DUPLICATING_BYTES_PER_ROW: u64 = 256;
+const PARTITIONING_BYTES_PER_ROW: u64 = 2_048;
+
+/// Fraction of *available* system RAM the estimated buffered-output set may
+/// occupy before `Auto` spills to a temp file instead of holding it in RAM.
+const AUTO_RAM_FRACTION: f64 = 0.6;
+
+/// Budget used when available RAM cannot be probed (non-Linux, or
+/// `/proc/meminfo` unreadable): a fixed, conservative ceiling so `Auto` still
+/// spills very large buffered sets rather than assuming unlimited RAM.
+const AUTO_FALLBACK_BUDGET_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+
+/// Buffered-row count above which `Auto` always spills partitioning's
+/// full-resolution geometry, regardless of the RAM estimate. Preserves the
+/// pre-#294 partitioning safety floor as a strict lower bound (partitioning
+/// spills at least as often as before; the RAM gate can only make it spill
+/// sooner).
+const PARTITIONING_SPILL_ROWS: usize = 2_000_000;
+
+/// Estimated peak RAM (bytes) the pass-2 sink would hold if `buffered_rows`
+/// output rows of `mode` were kept in RAM. Saturating, so absurd counts never
+/// overflow (they simply clamp to a "definitely spill" value).
+fn estimate_buffered_bytes(mode: Mode, buffered_rows: usize) -> u64 {
+    let per_row = match mode {
+        Mode::Duplicating => DUPLICATING_BYTES_PER_ROW,
+        Mode::Partitioning => PARTITIONING_BYTES_PER_ROW,
+    };
+    (buffered_rows as u64).saturating_mul(per_row)
+}
+
+/// The RAM budget `Auto` compares the estimate against: a fraction of available
+/// system RAM, or a fixed fallback when RAM cannot be determined.
+fn auto_budget_bytes(available_ram_bytes: Option<u64>) -> u64 {
+    match available_ram_bytes {
+        Some(ram) => ((ram as f64) * AUTO_RAM_FRACTION) as u64,
+        None => AUTO_FALLBACK_BUDGET_BYTES,
+    }
+}
+
+/// Workload-driven backing choice for [`MemoryProfile::Auto`] (#294).
+///
+/// Chooses [`SinkBacking::Spill`] when the estimated buffered output exceeds a
+/// fraction of available RAM — a function of `feature_count × level_count ×
+/// mode` (captured by `buffered_rows` and the per-mode byte estimate), NOT a
+/// mode-only rule. Partitioning additionally keeps its historical absolute
+/// row ceiling, so it spills at least as often as before.
+fn auto_backing(mode: Mode, buffered_rows: usize, available_ram_bytes: Option<u64>) -> SinkBacking {
+    let estimate = estimate_buffered_bytes(mode, buffered_rows);
+    let budget = auto_budget_bytes(available_ram_bytes);
+    let ram_gate_spill = estimate > budget;
+    let abs_gate_spill =
+        matches!(mode, Mode::Partitioning) && buffered_rows > PARTITIONING_SPILL_ROWS;
+    if ram_gate_spill || abs_gate_spill {
+        SinkBacking::Spill
+    } else {
+        SinkBacking::Ram
+    }
+}
+
+/// Available system RAM in bytes for the `Auto` budget.
+///
+/// Order of precedence:
+/// 1. `TYLERTOO_AUTO_MEM_LIMIT_BYTES` env override (ops / testing knob — treat
+///    the box as having this many bytes of available RAM);
+/// 2. Linux `/proc/meminfo` `MemAvailable`;
+/// 3. `None` (caller falls back to [`AUTO_FALLBACK_BUDGET_BYTES`]).
+fn available_memory_bytes() -> Option<u64> {
+    if let Ok(v) = std::env::var("TYLERTOO_AUTO_MEM_LIMIT_BYTES") {
+        if let Ok(n) = v.trim().parse::<u64>() {
+            return Some(n);
+        }
+    }
+    read_proc_mem_available()
+}
+
+#[cfg(target_os = "linux")]
+fn read_proc_mem_available() -> Option<u64> {
+    let text = std::fs::read_to_string("/proc/meminfo").ok()?;
+    for line in text.lines() {
+        // Format: "MemAvailable:   12345678 kB"
+        if let Some(rest) = line.strip_prefix("MemAvailable:") {
+            let kb: u64 = rest.split_whitespace().next()?.parse().ok()?;
+            return Some(kb.saturating_mul(1024));
+        }
+    }
+    None
+}
+
+#[cfg(not(target_os = "linux"))]
+fn read_proc_mem_available() -> Option<u64> {
+    None
+}
+
 /// Resolve the [`MemoryProfile`] (including [`MemoryProfile::Auto`]) to a
 /// concrete [`SinkBacking`], logging the decision.
 ///
 /// `buffered_rows` is the total winner count of the levels the engine buffers
-/// (all but the streamed finest level). `Auto` keeps duplicating mode in RAM
-/// (it buffers only the small, geometrically-decayed coarse levels) and keeps
-/// partitioning mode in RAM only while the buffered set is small — partitioning
-/// buffers full-resolution geometry, so a large buffered set spills. An
+/// (all but the streamed finest level). For `Auto` the choice is workload-based
+/// (#294): the estimated buffered output (`f(buffered_rows, mode)`) is compared
+/// against a fraction of *available* RAM, so large duplicating runs prefer the
+/// bounded spill path instead of the old unconditional RAM buffering. An
 /// explicit profile always wins.
 pub(super) fn resolve_backing(
     profile: MemoryProfile,
     mode: Mode,
     buffered_rows: usize,
 ) -> SinkBacking {
-    /// Buffered-row count above which `Auto` spills partitioning's
-    /// full-resolution geometry instead of holding it in RAM.
-    const PARTITIONING_SPILL_ROWS: usize = 2_000_000;
-
-    let backing = match profile {
-        MemoryProfile::Speed => SinkBacking::Ram,
-        MemoryProfile::Bounded => SinkBacking::Spill,
-        MemoryProfile::Auto => match mode {
-            Mode::Duplicating => SinkBacking::Ram,
-            Mode::Partitioning => {
-                if buffered_rows > PARTITIONING_SPILL_ROWS {
-                    SinkBacking::Spill
-                } else {
-                    SinkBacking::Ram
-                }
-            }
-        },
-    };
-    log::debug!(
-        "pass2 memory profile {profile:?} + {mode:?} (buffered ~{buffered_rows} rows) → {backing:?}"
-    );
-    backing
+    match profile {
+        MemoryProfile::Speed => {
+            log::debug!(
+                "pass2 memory profile Speed + {mode:?} (buffered ~{buffered_rows} rows) → Ram"
+            );
+            SinkBacking::Ram
+        }
+        MemoryProfile::Bounded => {
+            log::debug!(
+                "pass2 memory profile Bounded + {mode:?} (buffered ~{buffered_rows} rows) → Spill"
+            );
+            SinkBacking::Spill
+        }
+        MemoryProfile::Auto => {
+            let available = available_memory_bytes();
+            let backing = auto_backing(mode, buffered_rows, available);
+            let estimate = estimate_buffered_bytes(mode, buffered_rows);
+            let budget = auto_budget_bytes(available);
+            let avail_mib = available.map_or_else(
+                || "unknown".to_string(),
+                |b| format!("{} MiB", b / (1024 * 1024)),
+            );
+            // Info-level: the auto decision drives peak RAM and is the primary
+            // diagnostic for #294 / #295 (paired with the [rss] phase logs).
+            log::info!(
+                "[convert] pass2 auto + {mode:?}: buffered ~{buffered_rows} rows, \
+                 est {} MiB vs budget {} MiB (avail {avail_mib}) → {backing:?}",
+                estimate / (1024 * 1024),
+                budget / (1024 * 1024),
+            );
+            backing
+        }
+    }
 }
 
 /// A message from the reader thread: one raw input batch, its cumulative row
@@ -355,5 +468,106 @@ fn drain_sink(
             }
             Ok(res?)
         }
+    }
+}
+
+#[cfg(test)]
+mod backing_tests {
+    use super::*;
+    use crate::overview::level::{MemoryProfile, Mode};
+
+    const GIB: u64 = 1024 * 1024 * 1024;
+
+    #[test]
+    fn explicit_profiles_ignore_workload() {
+        // Speed is always RAM, Bounded always Spill — regardless of size/mode.
+        assert!(matches!(
+            resolve_backing(MemoryProfile::Speed, Mode::Duplicating, 10_000_000_000),
+            SinkBacking::Ram
+        ));
+        assert!(matches!(
+            resolve_backing(MemoryProfile::Bounded, Mode::Duplicating, 1),
+            SinkBacking::Spill
+        ));
+    }
+
+    #[test]
+    fn auto_duplicating_small_stays_in_ram() {
+        // A tiny buffered set is safe in RAM on a normal box.
+        assert!(matches!(
+            auto_backing(Mode::Duplicating, 10_000, Some(54 * GIB)),
+            SinkBacking::Ram
+        ));
+    }
+
+    #[test]
+    fn auto_duplicating_large_spills() {
+        // The #294 fix: a large duplicating buffered set flips to Spill instead
+        // of the old unconditional RAM. 300M rows * 256 B = 76.8 GiB > 0.6*54.
+        assert!(matches!(
+            auto_backing(Mode::Duplicating, 300_000_000, Some(54 * GIB)),
+            SinkBacking::Spill
+        ));
+    }
+
+    #[test]
+    fn auto_decision_scales_with_available_ram() {
+        // Identical workload flips on available RAM, not a fixed fraction of it.
+        let rows = 50_000_000; // 50M * 256 B = 12.8 GiB estimate
+        assert!(
+            matches!(
+                auto_backing(Mode::Duplicating, rows, Some(4 * GIB)),
+                SinkBacking::Spill
+            ),
+            "small box must spill"
+        );
+        assert!(
+            matches!(
+                auto_backing(Mode::Duplicating, rows, Some(256 * GIB)),
+                SinkBacking::Ram
+            ),
+            "huge box may keep it in RAM"
+        );
+    }
+
+    #[test]
+    fn auto_partitioning_preserves_row_ceiling() {
+        // Even with effectively unlimited RAM, partitioning still spills above
+        // the historical 2M-row floor (strict superset of pre-#294 behavior).
+        assert!(matches!(
+            auto_backing(Mode::Partitioning, 3_000_000, Some(10_000 * GIB)),
+            SinkBacking::Spill
+        ));
+        assert!(matches!(
+            auto_backing(Mode::Partitioning, 100_000, Some(54 * GIB)),
+            SinkBacking::Ram
+        ));
+    }
+
+    #[test]
+    fn auto_uses_fallback_budget_when_ram_unknown() {
+        // Unknown RAM → conservative fixed budget, still spilling huge sets.
+        assert!(matches!(
+            auto_backing(Mode::Duplicating, 100_000_000, None),
+            SinkBacking::Spill
+        ));
+        assert!(matches!(
+            auto_backing(Mode::Duplicating, 1_000, None),
+            SinkBacking::Ram
+        ));
+    }
+
+    #[test]
+    fn estimate_scales_with_mode_and_rows() {
+        assert_eq!(estimate_buffered_bytes(Mode::Duplicating, 1_000), 256_000);
+        assert_eq!(
+            estimate_buffered_bytes(Mode::Partitioning, 1_000),
+            2_048_000
+        );
+        // Saturating: no overflow panic on absurd counts.
+        assert_eq!(
+            estimate_buffered_bytes(Mode::Duplicating, usize::MAX),
+            u64::MAX
+        );
     }
 }

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -180,6 +180,82 @@ fn resolve_and_log_in_flight_batches(requested: usize) -> usize {
     in_flight
 }
 
+/// Current process resident-set size (RSS) in MiB, if the platform exposes it.
+fn current_rss_mib() -> Option<f64> {
+    memory_stats::memory_stats().map(|m| m.physical_mem as f64 / (1024.0 * 1024.0))
+}
+
+/// Log the process RSS at a convert-phase boundary (#295 instrumentation) and
+/// fold it into the running peak. Silent when the platform can't report RSS.
+///
+/// These `[rss] <phase>` lines pinpoint which phase dominates peak memory —
+/// pass-1 winner tables (O(dataset)) vs the pass-2 output sink (bounded by the
+/// #294 auto profile) — and validate the auto backing choice on real runs.
+fn log_phase_rss(phase: &str, peak_mib: &mut f64) {
+    if let Some(rss) = current_rss_mib() {
+        if rss > *peak_mib {
+            *peak_mib = rss;
+        }
+        log::info!("[rss] {phase}: {rss:.0} MiB");
+    }
+}
+
+/// Split the resolved level plan into emitted levels (have winners) and skipped
+/// levels (no winners → omitted per §7.3 / #211 auto-clamp). `counts[l]` is the
+/// winner count for planned level `l`.
+fn partition_emitted_levels(
+    level_specs: &[(f64, Option<u8>)],
+    counts: &[usize],
+) -> (Vec<EmitLevel>, Vec<SkippedLevelReport>) {
+    let skipped = level_specs
+        .iter()
+        .enumerate()
+        .filter(|&(l, _)| counts[l] == 0)
+        .map(|(l, &(gsd, zoom))| SkippedLevelReport {
+            planned_level: l,
+            gsd,
+            zoom,
+        })
+        .collect();
+    let emitted = level_specs
+        .iter()
+        .enumerate()
+        .filter(|&(l, _)| counts[l] > 0)
+        .map(|(l, &(gsd, zoom))| EmitLevel {
+            orig: l as u8,
+            gsd,
+            zoom,
+            hint: counts[l],
+        })
+        .collect();
+    (emitted, skipped)
+}
+
+/// Build the three writer schemas (identical to the in-memory path):
+/// `source` (base), `cluster` (+ `point_count` when clustering, Q4), and `out`
+/// (+ `coalesced_count` when coalescing, Q3). All three are needed downstream,
+/// so they are returned together.
+fn build_level_schemas(
+    input_schema: &Schema,
+    geom_idx: usize,
+    geom_name: &str,
+    options: &ConvertOptions,
+) -> (Schema, Schema, Schema) {
+    let geom_out_field = mixed_geometry_field(geom_name);
+    let source_schema = build_source_schema(input_schema, geom_idx, geom_out_field);
+    let cluster_schema = if options.cluster {
+        append_point_count_field(&source_schema)
+    } else {
+        source_schema.clone()
+    };
+    let out_schema = if options.coalesce_lines {
+        append_coalesced_count_field(&cluster_schema)
+    } else {
+        cluster_schema.clone()
+    };
+    (source_schema, cluster_schema, out_schema)
+}
+
 pub(crate) fn convert_streaming_strategy(
     source: &ConvertSource,
     output_path: &Path,
@@ -187,6 +263,10 @@ pub(crate) fn convert_streaming_strategy(
     strategy: Pass2Strategy,
 ) -> Result<ConvertReport, ConvertError> {
     let start = Instant::now();
+    // #295: peak-RSS-by-phase instrumentation. Each phase boundary logs process
+    // RSS; the max is reported at the end so a single run shows both the peak
+    // and which phase produced it.
+    let mut peak_rss_mib = 0.0f64;
 
     if options.sort_key.is_some() && options.class_ranking.is_some() {
         return Err(ConvertError::RankingConflict);
@@ -304,6 +384,7 @@ pub(crate) fn convert_streaming_strategy(
         "[profile] pass1 stream+scan: {:.2}s",
         t_pass1.elapsed().as_secs_f64()
     );
+    log_phase_rss("pass1 scan", &mut peak_rss_mib);
 
     // --- Winner tables (assignment + Q2 density budget). ---------------------
     let level_specs = options.levels.resolve(options.gsd_base)?;
@@ -336,6 +417,9 @@ pub(crate) fn convert_streaming_strategy(
         level_gsds.len(),
         t_assign.elapsed().as_secs_f64()
     );
+    // Pass-1 winner tables (bboxes/kinds/sort-keys for every feature across all
+    // levels) are the O(dataset) peak candidate flagged in #295.
+    log_phase_rss("assignment+budget (winner tables)", &mut peak_rss_mib);
 
     // The feature-parallel winner table (coarsest level per FEATURE, in
     // `features` order) feeds the cluster stage and the per-level counts.
@@ -446,48 +530,18 @@ pub(crate) fn convert_streaming_strategy(
 
     // Planned levels with no winners are omitted (§7.3, #211 auto-clamp);
     // record them for the report + warning.
-    let mut skipped: Vec<SkippedLevelReport> = level_specs
-        .iter()
-        .enumerate()
-        .filter(|&(l, _)| counts[l] == 0)
-        .map(|(l, &(gsd, zoom))| SkippedLevelReport {
-            planned_level: l,
-            gsd,
-            zoom,
-        })
-        .collect();
-    let emitted: Vec<EmitLevel> = level_specs
-        .iter()
-        .enumerate()
-        .filter(|&(l, _)| counts[l] > 0)
-        .map(|(l, &(gsd, zoom))| EmitLevel {
-            orig: l as u8,
-            gsd,
-            zoom,
-            hint: counts[l],
-        })
-        .collect();
+    let (emitted, mut skipped) = partition_emitted_levels(&level_specs, &counts);
     if emitted.is_empty() {
         return Err(ConvertError::NoData);
     }
     warn_plan_skipped_levels(&skipped, num_features, emitted[0].gsd, emitted[0].zoom);
 
     // --- Writer setup (identical to the in-memory path). ---------------------
-    let geom_name = geom_field.name().clone();
-    let geom_out_field = mixed_geometry_field(&geom_name);
-    let source_schema = build_source_schema(&input_schema, geom_idx, geom_out_field);
-    // Writer schema: base + point_count when clustering (Q4) + coalesced_count
+    // Writer schemas: base + point_count when clustering (Q4) + coalesced_count
     // when coalescing (Q3).
-    let cluster_schema = if options.cluster {
-        append_point_count_field(&source_schema)
-    } else {
-        source_schema.clone()
-    };
-    let out_schema = if options.coalesce_lines {
-        append_coalesced_count_field(&cluster_schema)
-    } else {
-        cluster_schema.clone()
-    };
+    let geom_name = geom_field.name().clone();
+    let (source_schema, cluster_schema, out_schema) =
+        build_level_schemas(&input_schema, geom_idx, &geom_name, options);
 
     let writer_levels: Vec<LevelSpec> = emitted
         .iter()
@@ -513,6 +567,9 @@ pub(crate) fn convert_streaming_strategy(
         .collect();
 
     // --- Pass 2: single-read pipelined engine + canonical streamed last. -----
+    // Pass-1 O(N) scratch has been freed by here; this marks the memory floor
+    // the pass-2 output sink builds on (its ceiling is the #294 auto choice).
+    log_phase_rss("pre-pass2 (winner tables freed)", &mut peak_rss_mib);
     let t_pass2 = Instant::now();
 
     // Prebuild every non-verbatim level's coalesce chain table up front, in
@@ -707,6 +764,7 @@ pub(crate) fn convert_streaming_strategy(
         "[profile] pass2 total: {:.2}s",
         t_pass2.elapsed().as_secs_f64()
     );
+    log_phase_rss("pass2 (output sink)", &mut peak_rss_mib);
 
     let t_finish = Instant::now();
     let meta = writer.finish()?;
@@ -714,6 +772,8 @@ pub(crate) fn convert_streaming_strategy(
         "[profile] writer.finish: {:.2}s",
         t_finish.elapsed().as_secs_f64()
     );
+    log_phase_rss("writer.finish", &mut peak_rss_mib);
+    log::info!("[rss] convert peak: {peak_rss_mib:.0} MiB");
     fill_level_bytes(output_path, &meta, &mut level_reports)?;
 
     let total_rows: usize = level_reports.iter().map(|l| l.feature_count).sum();

--- a/docs/OVERVIEW_TUNING.md
+++ b/docs/OVERVIEW_TUNING.md
@@ -40,8 +40,10 @@ interact.
 > - **Conversion is slow / pins one core** → it now reads the input once and
 >   uses all cores; RAISE `--in-flight-batches` for more read/compute overlap.
 > - **Conversion runs out of memory in `speed` mode** → `--profile bounded`
->   (spills each level to temp files; `--profile auto`, the default, picks this
->   for you on large partitioning runs). Output is byte-identical either way.
+>   (spills each level to temp files; `--profile auto`, the default, now does
+>   this for you when the estimated buffered output exceeds a fraction of
+>   available RAM — large duplicating *and* partitioning runs both spill).
+>   Output is byte-identical either way.
 
 ---
 
@@ -279,9 +281,10 @@ tylertoo overview buildings.parquet buildings_overview.parquet \
 # One-shot to PMTiles: add tippecanoe's tile cap — uncapped coarse dot
 # tiles on a country-scale layer reach several MB (Germany z6: 12 MB),
 # far past renderer norms; the cap drop-to-fits them to ~500 KB.
-# On multi-GB inputs also pass --profile bounded: the recipe buffers
-# the (now much larger) coarse levels in RAM under the default speed
-# profile (Germany peak RSS 15 -> 29 GB without it).
+# On multi-GB inputs the recipe buffers the (now much larger) coarse
+# levels; the default --profile auto estimates this and spills when it
+# would exceed a fraction of available RAM (Germany peak RSS 15 -> 29 GB
+# if forced to speed). Pass --profile bounded to force spilling.
 tylertoo tiles buildings.parquet buildings.pmtiles \
   --min-zoom 0 --max-zoom 14 \
   --polygon-visibility 0 --collapse --max-tile-size 500K \

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -68,8 +68,11 @@ wall time:
 | germany-buildings | speed | 3:58 | 14.8 GiB |
 | germany-buildings | bounded | 4:00 | **10.5 GiB** |
 
-−29 % peak RSS for a 2-second wall difference. Use `bounded` when RSS
-headroom matters more than the last few percent of throughput.
+−29 % peak RSS for a 2-second wall difference. The default `--profile
+auto` estimates the buffered output from the feature and level counts and
+picks `bounded` automatically once it would exceed a fraction of available
+RAM (set `TYLERTOO_AUTO_MEM_LIMIT_BYTES` to model a smaller box); pass
+`--profile bounded` to force it, or `speed` to force RAM buffering.
 
 ## Remote selective read
 


### PR DESCRIPTION
## Summary

Two intertwined convert-phase memory issues, shipped together because the
per-phase RSS logging added for #295 is the instrument that validates the
#294 fix.

### #294 — `--profile auto` mis-picks `speed` at scale (OOM risk)

The pass-2 sink backing choice was **mode-only**: `auto` + duplicating always
bought RAM buffering regardless of dataset size, so a large duplicating convert
drove the output sink toward OOM (Brazil demo: RSS on track to ~75 GiB).

Now the choice is **workload-based**: estimated buffered output
`f(buffered_rows, mode)` is compared against a fraction (0.6) of *available*
system RAM (`/proc/meminfo` `MemAvailable`, overridable via
`TYLERTOO_AUTO_MEM_LIMIT_BYTES`, with a conservative fallback). Large
duplicating runs now prefer the bounded spill path; partitioning keeps its
historical 2M-row spill floor as a strict lower bound. Output bytes are
unchanged. Decision functions are pure and unit-tested.

The per-row byte estimate was **calibrated against measured data** (see the
adm4 benchmark): the first cut (256 B/row) undercounted the real pass-2 sink
~25× and reproduced #294's undercount live, so it was raised to ~8 KiB/row
(duplicating) / ~16 KiB/row (partitioning), biased high so `auto` errs toward
the near-free spill path.

### #295 — per-phase RSS instrumentation + bounding

Convert peaked at ~24 GiB on Brazil with no visibility into which phase was
responsible. Added `[rss] <phase>` logging at every convert phase boundary
(pass1 scan, assignment+budget / winner tables, pre-pass2, pass2 output sink,
writer.finish) plus an end-of-run peak, using the `memory-stats` crate.

The instrumentation immediately localized the peak: on germany-segments the
peak is the **pass-1 winner tables**, not the pass-2 sink (see table). The
pass-2 sink — the phase that caused the Brazil OOM trajectory — is what #294
now bounds.

## Benchmarks

Machine: 16 cores, 54 GiB RAM, nvme `/tmp`. `/usr/bin/time -v`, serialized
under the shared bench lock, load < 6 before timing. Baseline = `origin/main`
release binary; treatment = this branch. Same dataset, same flags.

### germany-segments (2.5 GiB, lines → coalesced, `--mode duplicating`)

| run | binary | profile (avail) | pass2 decision | wall | CPU% | Max RSS |
|-----|--------|-----------------|----------------|------|------|---------|
| A | baseline | auto | RAM (mode-only) | 0:53.6 | 160% | 6.68 GiB |
| B | treatment | auto (~30 GiB) | RAM (est 964 MiB ≪ budget) | 0:48.5 | 141% | 6.68 GiB |

(`buffered ~123 437 rows`; `est` shown is the shipped 8 KiB/row estimate.
germany's decision is RAM under any of the tested budgets.) Both outputs
**structurally identical** (same row-group/row signature
`ee8251…`). germany-segments is line-heavy → coalescing collapses the buffered
set to ~123 K rows, so `auto` correctly keeps it in RAM (no false spill even
when a 16 GiB box is simulated). Per-phase RSS for B/C:

```
[rss] pass1 scan: 5311 MiB
[rss] assignment+budget (winner tables): 5905 MiB   <- PEAK (pass-1)
[rss] pre-pass2 (winner tables freed): 2932 MiB
[rss] pass2 (output sink): 4112 MiB
[rss] convert peak: 5905 MiB
```

The peak is pass-1 winner tables (#295's hypothesis confirmed), *not* the
pass-2 sink.

### fieldmaps-adm4 (2.7 GiB, polygons, `--polygon-visibility 0` density fill)

Chosen to exercise a large duplicating **pass-2 sink** (every polygon visible
at every level → large buffered coarse set), the case #294 targets.

| run | profile (avail) | pass2 decision | pass2-sink RSS | Max RSS |
|-----|-----------------|----------------|----------------|---------|
| D | speed (force RAM) | RAM | 3380 MiB | 4.93 GiB |
| E | bounded (force Spill) | Spill | 2204 MiB | 3.72 GiB |
| F | auto (~32 GiB) | RAM (est 4368 MiB < 19589 MiB) | 3589 MiB | 5.26 GiB |
| G | auto (sim 2 GiB) | **Spill — flip** (est 4368 MiB > 1228 MiB) | 2254 MiB | 3.81 GiB |

All four outputs structurally identical (`296040…`). `buffered ~559 161 rows`
in every case — the Q2 density budget thins the coarse levels, so the row count
is modest but each retained row is a full coarse polygon (~6.3 KiB in the sink).

- **D vs E** isolates the backing cost: spilling the sink cuts Max RSS
  **4.93 → 3.72 GiB (−24 %)** for +4 s wall — identical output.
- **F vs G** is the #294 fix in action: same workload, same binary; `auto`
  keeps RAM on the roomy box (F) and **flips to Spill on a 2 GiB box (G)**,
  cutting Max RSS **5.26 → 3.81 GiB**. The old 256 B/row estimate put G's est at
  136 MiB and (wrongly) chose RAM — a 3.4 GiB sink on a 2 GiB box, i.e. #294's
  OOM. The recalibrated 8 KiB/row estimate (4368 MiB) makes the flip fire.

_(adm4 wall/CPU omitted from the table — the shared box was contended during
these runs, so wall is noise; Max RSS and the decision are the robust signals.)_

## Structural-equivalence proof (output is byte-equivalent across the change)

- Unit test `pipelined_matches_serial` now runs `Speed`, `Bounded` **and
  `Auto`** across duplicating/partitioning/clustering, asserting identical
  row-group layout, footer `geo:overviews` JSON, and per-level row content.
- Real data: germany-segments signature identical for baseline-auto,
  treatment-auto, treatment-auto@16GiB (`ee8251…`); moldova signature identical
  for `speed` (RAM), `bounded` (Spill), and a forced auto-flip (`9e5404…`).
- Parquet footer bytes are known non-deterministic (~25 bytes), so equivalence
  is asserted structurally (row-group layout + per-level rows), never raw bytes.

## Quality gates

- `cargo fmt --all` — clean
- `rtk proxy cargo clippy --all-targets --all-features -- -D warnings` — exit 0
  (kept under the workspace cognitive-complexity gate of 30 by extracting two
  pure helpers; the threshold ratchet was **not** raised)
- Targeted tests green: `overview::pipeline::backing_tests` (7),
  `pipelined_matches_serial`, `pipelined_invariant_to_batching_knobs`,
  `streaming_matches_*` (7), `export_archive_matches_pre_refactor_reference`
  (frozen hash unchanged)
- No Python touched → stubtest N/A. No version files touched.

## Caveats / open questions

- **Byte-per-row constants remain heuristic.** `DUPLICATING_BYTES_PER_ROW =
  8192`, `PARTITIONING_BYTES_PER_ROW = 16384`, `AUTO_RAM_FRACTION = 0.6`. The
  true per-row cost varies by geometry complexity (points ≪ admin polygons:
  measured 6–16 KiB/row across the test datasets), so a single constant can't
  be exact. It is set high, biased toward spilling — the issue's stated
  preference, and spilling is near-free on nvme. A pass-1-measured average
  geometry size would be more precise and is a reasonable follow-up.
- **A natural flip with a multi-GB RSS drop needs a large sink relative to the
  box.** On this 54 GiB box, `auto` (correctly) keeps germany and adm4 in RAM;
  the forced flips (env override / explicit `bounded`) show the RSS consequence
  and prove the mechanism. The Brazil analog (6.6 GiB germany-buildings) is
  excluded by the benchmark protocol, so the natural buildings-scale flip is
  not reproduced here — it is covered by unit tests + the adm4 density-fill
  (speed vs bounded) and moldova forced-flip runs.
- **#295 "bound the offending phase":** the pass-2 sink (the demonstrated OOM
  trajectory) is now bounded by #294. The other O(dataset) peak the
  instrumentation surfaces — pass-1 winner tables (parallel per-level grids from
  #264, e.g. germany's 5.9 GiB peak) — is inherent to that CPU-utilization
  design; spilling/packing it is a larger separate change, now *measurable* via
  the new `[rss]` logs. Flagged honestly rather than bundled in.

Closes #294
Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)
