### PR TITLE
feat(core): tmpfs spill-dir warning (#273) + pass-1 traversal fusion (#274)

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -67,6 +67,11 @@ bytes = "1"
 fs4 = { version = "0.13", optional = true }
 glob = "0.3"
 
+# Linux-only: statfs(2) for best-effort tmpfs/ramfs detection of the
+# remote-input spill directory (#273). Compiles to a no-op elsewhere.
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"
+
 [build-dependencies]
 prost-build = { workspace = true }
 

--- a/crates/core/src/fs_probe.rs
+++ b/crates/core/src/fs_probe.rs
@@ -1,0 +1,100 @@
+//! Best-effort detection of RAM-backed (tmpfs/ramfs) directories.
+//!
+//! The remote-input disk spill (#219/#272) writes ≈1× the input to a local
+//! temp file so later convert passes read from disk instead of re-fetching
+//! over the network. If that temp directory lives on a RAM-backed filesystem
+//! (tmpfs or ramfs — the common default for `/tmp` and always for `/dev/shm`),
+//! the spill trades network bytes for **memory pressure** rather than disk,
+//! defeating its purpose and risking OOM on large inputs. #273 warns when the
+//! resolved spill directory is RAM-backed and points users at `--spill-dir`.
+//!
+//! Detection is Linux-only via `statfs(2)` and strictly best-effort: any error
+//! (unsupported platform, `statfs` failure, missing path) yields `None`, and
+//! callers stay silent on `None`. It never fails the conversion.
+
+use std::path::Path;
+
+/// tmpfs superblock magic (`man 2 statfs`, `linux/magic.h`).
+#[cfg(target_os = "linux")]
+const TMPFS_MAGIC: u32 = 0x0102_1994;
+/// ramfs superblock magic (`linux/magic.h`).
+#[cfg(target_os = "linux")]
+const RAMFS_MAGIC: u32 = 0x8584_58f6;
+
+/// Whether `path` resides on a RAM-backed filesystem (tmpfs or ramfs).
+///
+/// - `Some(true)`  — `statfs` reports a tmpfs/ramfs superblock magic.
+/// - `Some(false)` — `statfs` succeeded and the filesystem is something else.
+/// - `None`        — detection is unavailable (non-Linux) or errored
+///   (`statfs` failed, e.g. the path does not exist). Best-effort: callers
+///   must treat `None` as "don't know" and stay silent.
+#[cfg(target_os = "linux")]
+pub fn is_ram_backed(path: &Path) -> Option<bool> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let c_path = CString::new(path.as_os_str().as_bytes()).ok()?;
+    // SAFETY: `statfs` writes into a caller-provided `struct statfs`. A zeroed
+    // value is a valid initial state, and `c_path` is a valid NUL-terminated
+    // C string that outlives the call.
+    let mut buf = unsafe { std::mem::zeroed::<libc::statfs>() };
+    let rc = unsafe { libc::statfs(c_path.as_ptr(), &mut buf) };
+    if rc != 0 {
+        return None;
+    }
+    // `f_type`'s integer width/signedness varies by libc/arch; the magic
+    // values are 32-bit, so truncate to `u32` for a width-independent compare.
+    let fs_type = buf.f_type as u32;
+    Some(fs_type == TMPFS_MAGIC || fs_type == RAMFS_MAGIC)
+}
+
+/// Non-Linux stub: detection unavailable, always `None` (compile-time no-op).
+#[cfg(not(target_os = "linux"))]
+pub fn is_ram_backed(_path: &Path) -> Option<bool> {
+    None
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    /// `/dev/shm` is tmpfs on essentially every Linux system — the canonical
+    /// RAM-backed directory. Detection must flag it.
+    #[test]
+    fn detects_tmpfs_dev_shm() {
+        let shm = Path::new("/dev/shm");
+        if !shm.exists() {
+            eprintln!("skipping detects_tmpfs_dev_shm: /dev/shm absent");
+            return;
+        }
+        assert_eq!(
+            is_ram_backed(shm),
+            Some(true),
+            "/dev/shm must be detected as RAM-backed"
+        );
+    }
+
+    /// The repo checkout lives on real disk in this environment. Detection
+    /// must not flag a real-disk path (the property that matters: we never
+    /// warn spuriously).
+    #[test]
+    fn real_disk_not_flagged() {
+        let cwd = std::env::current_dir().expect("cwd");
+        assert_ne!(
+            is_ram_backed(&cwd),
+            Some(true),
+            "a real-disk working directory must not be flagged RAM-backed"
+        );
+    }
+
+    /// A nonexistent path makes `statfs` fail; detection is best-effort and
+    /// returns `None` (never an error, never a false positive).
+    #[test]
+    fn missing_path_is_undetectable() {
+        assert_eq!(
+            is_ram_backed(Path::new("/nonexistent/tylertoo-fs-probe-273")),
+            None,
+            "an unresolvable path must yield None, not a warning"
+        );
+    }
+}

--- a/crates/core/src/input.rs
+++ b/crates/core/src/input.rs
@@ -1182,6 +1182,23 @@ pub(crate) mod remote {
         dir: Option<PathBuf>,
     }
 
+    /// #273: the warning to emit when `dir` (the resolved spill directory)
+    /// lives on a RAM-backed filesystem, or `None` when it is real disk or
+    /// detection is unavailable (best-effort). Spilling to tmpfs/ramfs trades
+    /// network bytes for memory pressure, defeating the spill and risking OOM.
+    /// Split out so the wording is unit-testable without capturing a logger.
+    fn ram_backed_spill_warning(dir: &Path) -> Option<String> {
+        (crate::fs_probe::is_ram_backed(dir) == Some(true)).then(|| {
+            format!(
+                "input spill directory {} is on a RAM-backed filesystem \
+                 (tmpfs/ramfs); spilling there consumes memory instead of disk \
+                 and can OOM on large inputs — point --spill-dir (or $TMPDIR) at \
+                 a real-disk location",
+                dir.display()
+            )
+        })
+    }
+
     impl DiskSpill {
         /// Serve a previously spilled chunk, if present. `None` means "not
         /// spilled — fetch it over the network"; a read error disables the
@@ -1214,6 +1231,13 @@ pub(crate) mod remote {
                 return;
             }
             if self.file.is_none() {
+                // #273: warn once (the spill file is created exactly once) when
+                // the resolved directory is RAM-backed. `tempfile()` follows
+                // `std::env::temp_dir()` ($TMPDIR or /tmp) when no dir is set.
+                let resolved = self.dir.clone().unwrap_or_else(std::env::temp_dir);
+                if let Some(msg) = ram_backed_spill_warning(&resolved) {
+                    log::warn!("{msg}");
+                }
                 let created = match self.dir.as_deref() {
                     Some(d) => tempfile::tempfile_in(d),
                     None => tempfile::tempfile(),
@@ -1506,6 +1530,44 @@ pub(crate) mod remote {
             assert!(
                 spill.get(0).is_none(),
                 "create failure must disable the spill"
+            );
+        }
+
+        /// #273: a RAM-backed spill directory produces a warning naming the
+        /// directory and pointing at `--spill-dir`. `/dev/shm` is tmpfs on
+        /// essentially every Linux system.
+        #[cfg(target_os = "linux")]
+        #[test]
+        fn ram_backed_dir_warns_naming_dir_and_flag() {
+            let shm = std::path::Path::new("/dev/shm");
+            if !shm.exists() {
+                eprintln!("skipping ram_backed_dir_warns: /dev/shm absent");
+                return;
+            }
+            let msg = ram_backed_spill_warning(shm)
+                .expect("/dev/shm must produce a RAM-backed spill warning");
+            assert!(msg.contains("/dev/shm"), "names the directory: {msg}");
+            assert!(msg.contains("--spill-dir"), "suggests --spill-dir: {msg}");
+            assert!(
+                msg.contains("RAM-backed"),
+                "explains the RAM-backed hazard: {msg}"
+            );
+        }
+
+        /// #273 counterpart: a real-disk directory is not flagged, so the
+        /// spill path stays silent and functional.
+        #[test]
+        fn real_disk_dir_does_not_warn() {
+            let dir = tempfile::tempdir().unwrap();
+            // Best-effort: on a machine whose $TMPDIR is tmpfs this could be
+            // Some(_); guard on the detection result to stay non-flaky.
+            if crate::fs_probe::is_ram_backed(dir.path()) == Some(true) {
+                eprintln!("skipping real_disk_dir_does_not_warn: tempdir is tmpfs");
+                return;
+            }
+            assert!(
+                ram_backed_spill_warning(dir.path()).is_none(),
+                "a non-RAM-backed dir must not warn"
             );
         }
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -44,6 +44,7 @@ pub mod compression;
 pub mod covering;
 pub mod decode;
 pub mod dedup;
+pub mod fs_probe;
 pub mod input;
 pub mod input_set;
 pub mod ioverlay_clip;

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -1745,6 +1745,138 @@ pub(super) fn feature_kind(g: &Geometry<f64>) -> FeatureKind {
     }
 }
 
+/// Accumulator for [`scan_feature`]: min/max over the bounding-rect coord set
+/// plus a finiteness/non-empty tally over *all* coords.
+#[derive(Debug)]
+struct FeatureScan {
+    min_x: f64,
+    min_y: f64,
+    max_x: f64,
+    max_y: f64,
+    /// A bounding-rect coord was seen (exterior of polygons; every coord of
+    /// other kinds). When false the bbox is undefined ([`geometry_bbox`] → 0s).
+    bbox_seen: bool,
+    /// Any coord at all was seen (matches `usable_geometry`'s non-empty test).
+    any_coord: bool,
+    /// Every coord seen so far is finite (matches `usable_geometry`).
+    finite: bool,
+}
+
+impl FeatureScan {
+    fn new() -> Self {
+        FeatureScan {
+            min_x: f64::INFINITY,
+            min_y: f64::INFINITY,
+            max_x: f64::NEG_INFINITY,
+            max_y: f64::NEG_INFINITY,
+            bbox_seen: false,
+            any_coord: false,
+            finite: true,
+        }
+    }
+
+    /// A coord that counts for BOTH the bounding box and the finiteness tally
+    /// (i.e. a coord `bounding_rect` would include: points, line vertices,
+    /// polygon *exterior* rings).
+    #[inline]
+    fn note_bbox(&mut self, c: geo::Coord<f64>) {
+        self.any_coord = true;
+        if !c.x.is_finite() || !c.y.is_finite() {
+            self.finite = false;
+            return;
+        }
+        self.bbox_seen = true;
+        if c.x < self.min_x {
+            self.min_x = c.x;
+        }
+        if c.y < self.min_y {
+            self.min_y = c.y;
+        }
+        if c.x > self.max_x {
+            self.max_x = c.x;
+        }
+        if c.y > self.max_y {
+            self.max_y = c.y;
+        }
+    }
+
+    /// A coord that counts for finiteness/non-empty only, NOT the bbox —
+    /// polygon *interior* rings, which `bounding_rect` ignores but
+    /// `usable_geometry` (via `coords_iter`) includes.
+    #[inline]
+    fn note_finite_only(&mut self, c: geo::Coord<f64>) {
+        self.any_coord = true;
+        if !c.x.is_finite() || !c.y.is_finite() {
+            self.finite = false;
+        }
+    }
+
+    fn bbox(&self) -> [f64; 4] {
+        if self.bbox_seen {
+            [self.min_x, self.min_y, self.max_x, self.max_y]
+        } else {
+            // Matches `geometry_bbox` when `bounding_rect` is `None`.
+            [0.0, 0.0, 0.0, 0.0]
+        }
+    }
+}
+
+/// Walk `g` into `scan`, distinguishing bbox-contributing coords (exterior
+/// rings) from finiteness-only coords (polygon interiors), recursing through
+/// geometry collections. Mirrors `bounding_rect`'s coord set and
+/// `coords_iter`'s coord set exactly.
+fn scan_geometry_into(g: &Geometry<f64>, scan: &mut FeatureScan) {
+    use geo::coords_iter::CoordsIter;
+    let scan_polygon = |poly: &geo::Polygon<f64>, scan: &mut FeatureScan| {
+        for c in poly.exterior().coords_iter() {
+            scan.note_bbox(c);
+        }
+        for ring in poly.interiors() {
+            for c in ring.coords_iter() {
+                scan.note_finite_only(c);
+            }
+        }
+    };
+    match g {
+        Geometry::Polygon(poly) => scan_polygon(poly, scan),
+        Geometry::MultiPolygon(mp) => {
+            for poly in &mp.0 {
+                scan_polygon(poly, scan);
+            }
+        }
+        Geometry::GeometryCollection(gc) => {
+            for child in &gc.0 {
+                scan_geometry_into(child, scan);
+            }
+        }
+        // Every other kind's `bounding_rect` set == its `coords_iter` set.
+        other => {
+            for c in other.coords_iter() {
+                scan.note_bbox(c);
+            }
+        }
+    }
+}
+
+/// Fused single-traversal replacement for `usable_geometry` + `geometry_bbox`
+/// + `feature_kind` used by the streaming pass-1 scan (#274).
+///
+/// Returns `None` for a geometry `usable_geometry` would reject (empty or any
+/// non-finite coord), otherwise `(feature_kind(g), geometry_bbox(g))`. It is
+/// byte-equivalent to calling those three functions in sequence — the bbox is
+/// exterior-only for polygons, finiteness spans all coords — but walks the
+/// decoded geometry once instead of twice (`usable_geometry` iterated every
+/// coord, then `bounding_rect` iterated the exterior again). The
+/// `scan_feature_matches_components` proptest pins the equivalence.
+pub(super) fn scan_feature(g: &Geometry<f64>) -> Option<(FeatureKind, [f64; 4])> {
+    let mut scan = FeatureScan::new();
+    scan_geometry_into(g, &mut scan);
+    if !scan.finite || !scan.any_coord {
+        return None;
+    }
+    Some((feature_kind(g), scan.bbox()))
+}
+
 /// Count coordinates (vertices) in a geometry.
 pub(super) fn count_vertices(g: &Geometry<f64>) -> usize {
     use geo::coords_iter::CoordsIter;
@@ -2729,6 +2861,61 @@ pub(super) fn fill_level_bytes(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #274: proptest pinning `scan_feature` byte-equivalent to the three
+    /// functions it fuses (`usable_geometry` + `geometry_bbox` + `feature_kind`).
+    /// Generates points/lines/polygons/multis with holes and occasional
+    /// non-finite/empty coords, exercising every parity edge (exterior-only
+    /// polygon bbox, all-coords finiteness, empty-exterior → 0-bbox).
+    mod scan_feature_props {
+        use super::super::{feature_kind, geometry_bbox, scan_feature, usable_geometry};
+        use geo::{Geometry, LineString, MultiLineString, MultiPolygon, Point, Polygon};
+        use proptest::prelude::*;
+
+        fn any_f64() -> impl Strategy<Value = f64> {
+            prop_oneof![
+                8 => -1.0e6f64..1.0e6f64,
+                1 => Just(f64::NAN),
+                1 => prop_oneof![Just(f64::INFINITY), Just(f64::NEG_INFINITY)],
+            ]
+        }
+        fn any_coord() -> impl Strategy<Value = geo::Coord<f64>> {
+            (any_f64(), any_f64()).prop_map(|(x, y)| geo::Coord { x, y })
+        }
+        fn any_ring() -> impl Strategy<Value = LineString<f64>> {
+            proptest::collection::vec(any_coord(), 0..6).prop_map(LineString::new)
+        }
+        fn any_polygon() -> impl Strategy<Value = Polygon<f64>> {
+            (any_ring(), proptest::collection::vec(any_ring(), 0..3))
+                .prop_map(|(ext, ints)| Polygon::new(ext, ints))
+        }
+        fn any_geometry() -> impl Strategy<Value = Geometry<f64>> {
+            prop_oneof![
+                any_coord().prop_map(|c| Geometry::Point(Point::from(c))),
+                proptest::collection::vec(any_coord(), 0..5)
+                    .prop_map(|cs| Geometry::MultiPoint(cs.into_iter().map(Point::from).collect())),
+                any_ring().prop_map(Geometry::LineString),
+                proptest::collection::vec(any_ring(), 0..3)
+                    .prop_map(|ls| Geometry::MultiLineString(MultiLineString::new(ls))),
+                any_polygon().prop_map(Geometry::Polygon),
+                proptest::collection::vec(any_polygon(), 0..3)
+                    .prop_map(|ps| Geometry::MultiPolygon(MultiPolygon::new(ps))),
+            ]
+        }
+
+        proptest! {
+            #[test]
+            fn scan_feature_matches_components(g in any_geometry()) {
+                let expected = if usable_geometry(&g) {
+                    Some((feature_kind(&g), geometry_bbox(&g)))
+                } else {
+                    None
+                };
+                prop_assert_eq!(scan_feature(&g), expected);
+            }
+        }
+    }
+
     use crate::overview::check::validate_file;
     use crate::overview::level::gsd;
     use crate::overview::reader::OverviewReader;

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -73,12 +73,12 @@ use super::convert::{
     append_coalesced_count_field, append_point_count_field, apply_cluster_columns,
     apply_coalesced_count, build_generalization, build_level_batch, build_level_coalesce_table,
     build_source_schema, class_ranking_provenance, coalesce_effective, coalesce_level_chains,
-    count_vertices, extract_class_ranks, extract_sort_keys, feature_kind, fill_level_bytes,
-    find_geometry_column, geometry_bbox, mixed_geometry_field, overture_road_ranking,
-    record_level_outcome, resolve_reserved_column_collisions, usable_geometry,
-    validate_cluster_schema, validate_coalesce_schema, warn_plan_skipped_levels, ClassRanking,
-    CoalesceTable, ConvertError, ConvertOptions, ConvertReport, GroupInterner, SkippedLevelReport,
-    KNOWN_ROAD_CLASSES, ROAD_VOCAB_MIN_DISTINCT,
+    count_vertices, extract_class_ranks, extract_sort_keys, fill_level_bytes, find_geometry_column,
+    mixed_geometry_field, overture_road_ranking, record_level_outcome,
+    resolve_reserved_column_collisions, scan_feature, validate_cluster_schema,
+    validate_coalesce_schema, warn_plan_skipped_levels, ClassRanking, CoalesceTable, ConvertError,
+    ConvertOptions, ConvertReport, GroupInterner, SkippedLevelReport, KNOWN_ROAD_CLASSES,
+    ROAD_VOCAB_MIN_DISTINCT,
 };
 use super::level::{Crs, Mode, RankingProvenance};
 use super::pipeline;
@@ -988,7 +988,15 @@ fn run_pass1(
         // skipped row must never shift attributes onto a neighbor's geometry).
         let base = num_rows;
         for (i, gopt) in geoms_buf.iter().enumerate() {
-            let Some(g) = gopt.as_ref().filter(|g| usable_geometry(g)) else {
+            let Some(g) = gopt.as_ref() else {
+                skipped_rows += 1;
+                continue;
+            };
+            // #274: a single geometry walk yields the usable filter, bbox, and
+            // kind (was `usable_geometry` + `geometry_bbox` + `feature_kind`,
+            // which traversed the coords twice). `None` == unusable (empty or
+            // non-finite), identical to the old `usable_geometry` reject.
+            let Some((kind, fbbox)) = scan_feature(g) else {
                 skipped_rows += 1;
                 continue;
             };
@@ -996,13 +1004,11 @@ fn run_pass1(
             // produces no AssignFeature — its winner-table slot stays at the
             // UNASSIGNED sentinel, so pass 2 drops the row too. The row index
             // still advances (row-keyed tables stay aligned).
-            let fbbox = geometry_bbox(g);
             if let Some(bb) = bbox_units {
                 if !super::convert::bboxes_intersect(&fbbox, bb) {
                     continue;
                 }
             }
-            let kind = feature_kind(g);
             if matches!(kind, FeatureKind::Point) {
                 point_count += 1;
             }


### PR DESCRIPTION
Two follow-ups to the #219 remote-input spill work, in the reader/spill and
convert areas.

## #273 — warn when the spill directory is on tmpfs/ramfs

The remote-input disk spill (#219/#272, and the `--spill-dir` option) writes
≈1× the input to a local temp file so later convert passes read from disk
instead of re-fetching over the network. When that directory is RAM-backed
(tmpfs/ramfs — the common default for `/tmp`, always for `/dev/shm`), the
spill trades network bytes for **memory pressure** instead of disk, defeating
its purpose and risking OOM on large inputs.

- New `fs_probe::is_ram_backed` — best-effort tmpfs/ramfs detection via
  `statfs(2)` (Linux-only; compiles to a no-op elsewhere). Returns
  `Some(true)`/`Some(false)`/`None`; `None` = "don't know" (unsupported
  platform or `statfs` error). It never fails the conversion.
- `DiskSpill::put` warns once, at spill-file creation, when the resolved
  directory is RAM-backed — naming the directory and pointing at `--spill-dir`.
- `libc` added as a Linux-only target dependency.

Detection matches the issue's spec (`f_type == TMPFS_MAGIC`, plus ramfs) and
is width/signedness-independent (truncates `f_type` to `u32` before compare).

### tmpfs-warning demo

Verified end-to-end against a range-capable HTTP server (remote input,
`--spill-dir` pointed at `/dev/shm`, which is tmpfs):

```
$ RUST_LOG=warn tylertoo overview --spill-dir /dev/shm \
    http://host/data.parquet out.parquet
WARN tylertoo_core::input::remote  input spill directory /dev/shm is on a
     RAM-backed filesystem (tmpfs/ramfs); spilling there consumes memory
     instead of disk and can OOM on large inputs — point --spill-dir (or
     $TMPDIR) at a real-disk location

$ RUST_LOG=warn tylertoo overview --spill-dir /tmp \
    http://host/data.parquet out.parquet
# (no warning — /tmp is disk-backed in this environment)
```

Closes #273.

## #274 — reduce redundant geometry work across the two-pass convert

### What shipped (the byte-safe subset)

The streaming pass-1 scan computed each feature's usable filter, bounding box,
and kind with three calls — `usable_geometry` + `geometry_bbox` +
`feature_kind` — that walked the decoded geometry's coordinates **twice**
(`usable_geometry` over every coord, then `bounding_rect` over the exterior).
`scan_feature` fuses them into a **single structural walk**, byte-equivalent
by construction:

- exterior-only bounding box for polygons (matching `bounding_rect`),
- all-coords finiteness/non-empty test (matching `usable_geometry`),
- empty-exterior → zero bbox (matching `geometry_bbox`'s `None` case).

A **proptest** (`scan_feature_matches_components`) pins `scan_feature` to the
exact composition of the three functions across points/lines/polygons/multis
with holes and non-finite/empty coords. The existing
`streaming_matches_in_memory_*` tests confirm the streaming output is unchanged
against the in-memory reference (which still calls the originals).

### What is deferred, and why (Refs #274)

The issue's core ask — reuse pass-1's decoded geometry in pass 2 so a byte is
decoded once, not twice — is **architecturally bounded** and I did not force it:

- **Global assign barrier.** Level assignment (`assign_levels` + density
  budget) is global: it needs every feature's bbox before *any* level is
  written. Pass 2 therefore starts only after pass 1 finishes, so an
  `O(row_group)` decoded-geometry cache cannot bridge the two passes — the row
  group decoded in pass 1 is long gone when pass 2 needs it. Bridging would
  require buffering **all** decoded geometry = `O(file)`, exactly what the
  streaming path exists to avoid (the in-memory path already does this).
- **Cheap-intermediate shortcuts break byte-equivalence.** Reusing the input's
  GeoParquet *covering bbox* column, or computing bbox as a native min/max over
  all coordinates, diverges from the baseline on dirty data: `bounding_rect`
  (and thus the baseline's level assignment) is **exterior-only** for polygons,
  whereas a covering/all-coords bbox spans interior rings too. On a polygon with
  an interior vertex outside the exterior (dirty input this project explicitly
  handles, #211/#242) the bbox — and the assigned level — would differ. The
  finiteness/empty parity is likewise writer-dependent. Not safely
  byte-equivalent, so not shipped.
- **Where the cost actually is.** Profiling (`RUST_LOG=tylertoo_core=debug`)
  shows pass-1 is significant only for vertex-heavy polygons and negligible for
  lines (coalescing dominates there); pass-2 is >95% simplification, not decode.
  So the reachable byte-safe win is the redundant pass-1 traversal, which this
  PR removes.

## Benchmark (convert phase, `overview --mode duplicating`)

Baseline = origin/main (measured on the pre-`scan_feature` binary; #273 does
not touch convert). `/usr/bin/time -v`, page cache warmed, serialized under the
shared machine lock with 1-min load < 6.

| dataset | baseline wall (3 runs) | treatment wall (3 runs) | verdict |
|---|---|---|---|
| `moldova-polygons` (632k polygons, WKB) | 5.04 / 4.97 / 5.02 s | 4.93 / 5.48 / 4.98 s | ~flat (treatment median 4.98 vs 5.02; ~1%, within noise) |
| `segments-lines` (2.4 GiB, 19.2M features) | 43.40 / 43.78 / 43.39 s | 43.17 / 46.06 / 50.55 s | flat (best runs equal; the 46/50 s are concurrent-load outliers) |

Both binaries differ **only** by `scan_feature` (both carry #273, which does
not touch convert). The machine was under heavy concurrent load during the run
(1-min load 5–20), so segments variance is large; the honest read is **no
regression, and a marginal polygon-only improvement** — consistent with the
profile: pass-1 decode dominates only for vertex-heavy polygons, and for WKB
input the WKB parse (unchanged) dominates pass-1, so fusing the two post-decode
traversals is a small slice. Lines are coalescing-dominated, so segments is
flat as expected.

CPU% and Max RSS were unchanged between baseline and treatment (moldova ~164%
CPU / ~470 MiB; segments ~142% CPU / ~6.7 GiB).

## Per-level equivalence proof

Per-level row counts AND order-insensitive content fingerprints
(`bit_xor(hash(row))`, levels mapped from `geo:overviews` row-group ranges)
match between baseline and treatment:

| dataset | geometry | per-level result |
|---|---|---|
| `polygons-ftw-moldova-large` | polygons (WKB) | **EQUIVALENT** — exercises exterior-only polygon-bbox parity |
| `lines-portland-medium` | lines + coalescing | **EQUIVALENT** — exercises the group-interner / coalescing order hazard |
| `monster-coastline` | dirty MultiLineString | **EQUIVALENT** — exercises non-finite / degenerate coord handling |
| `overture-germany-segments` (2.4 GiB) | lines + coalescing, 19.2M features | **EQUIVALENT** — the mandated file; interner hazard at scale |

Each check compares baseline (no `scan_feature`) vs treatment (with
`scan_feature`); all per-level row counts and `bit_xor(hash(row))`
fingerprints match exactly.

The lines datasets (portland, segments) specifically exercise the
order-dependent group-interner / coalescing hazard called out in #274;
monster-coastline exercises the dirty-geometry bbox-parity edge.

## Quality gates

- `cargo fmt --all` — clean
- `cargo clippy --all-targets [--features remote] -D warnings` — clean
- `fs_probe` unit tests, `spill_dir_tests` (incl. tmpfs warning), proptest,
  and `streaming_matches_in_memory_*` equivalence tests — green
- PMTiles frozen-hash export test unchanged (not re-pinned)
- No version changes

## Caveats

- #273 detection is Linux-only and best-effort; other platforms compile to a
  no-op (as the issue specifies).
- #274 ships the byte-safe subset; the cross-pass double-decode is deferred
  (Refs, not Closes) with the architectural rationale above. The mandated lines
  benchmark (segments) is coalescing-dominated, so the pass-1 fusion is ~flat
  there; the win concentrates on vertex-heavy polygon inputs.


🤖 Generated with [Claude Code](https://claude.com/claude-code)