### PR TITLE
feat(cli): ergonomic one-step tiles — --keep-overview, controllable temp, visible disk cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,24 @@ pip install tylertoo      # Python
 ## Usage
 
 ```bash
-# One-shot: GeoParquet in, PMTiles out
+# One-shot: GeoParquet in, PMTiles out (recommended)
 tylertoo input.parquet output.pmtiles --min-zoom 0 --max-zoom 14
+
+# Keep the reusable multi-resolution overview file too — one run, both artifacts
+tylertoo input.parquet output.pmtiles --max-zoom 14 \
+  --keep-overview overviews.parquet
 ```
+
+The one-shot form materializes an intermediate overview GeoParquet before
+exporting (at least input-sized — it is **not** zero-disk). Its path and
+size are logged, `--spill-dir` / `$TMPDIR` control where it lives, and a
+free-space preflight warns when the volume looks too small.
 
 ### The Two-Step Workflow
 
-The overview GeoParquet file is the interesting artifact — keep it:
+The overview GeoParquet file is the interesting artifact — build it
+explicitly when you want to validate it, query it, or re-export with
+different flags without re-converting:
 
 ```bash
 # 1. Embed multi-resolution levels in a GeoParquet file
@@ -56,7 +67,8 @@ tylertoo validate overviews.parquet
 tylertoo export-pmtiles overviews.parquet output.pmtiles
 ```
 
-All tuning knobs live on `overview` / `export-pmtiles` — see
+Every tuning knob is available on the one-shot `tiles` command as well as
+on `overview` / `export-pmtiles` — see
 [Overview Tuning](docs/OVERVIEW_TUNING.md). Defaults are calibrated on
 rendered corpus sweeps and are meant to look right out of the box.
 
@@ -98,7 +110,7 @@ convert("input.parquet", "output.pmtiles", min_zoom=0, max_zoom=14)
 
 ## Documentation
 
-- **[Getting Started](docs/getting-started.md)** — Installation, basic usage, the two-step workflow
+- **[Getting Started](docs/getting-started.md)** — Installation, one-shot conversion, the two-step workflow
 - **[Overview Tuning](docs/OVERVIEW_TUNING.md)** — Every generalization knob explained
 - **[Decoding PMTiles](docs/decode.md)** — PMTiles → GeoParquet, limitations included
 - **[API Reference](docs/api-reference.md)** — CLI flags, Python API, Rust API

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -25,6 +25,8 @@ tylertoo-core = { workspace = true, features = ["remote"] }
 clap = { workspace = true }
 anyhow = { workspace = true }
 env_logger = { workspace = true }
+log = { workspace = true }
+fs4 = "0.13"
 indicatif = { workspace = true }
 serde_json = "1"
 tempfile = "3"

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -36,13 +36,24 @@ pip install tylertoo      # Python
 ## Usage
 
 ```bash
-# One-shot: GeoParquet in, PMTiles out
+# One-shot: GeoParquet in, PMTiles out (recommended)
 tylertoo input.parquet output.pmtiles --min-zoom 0 --max-zoom 14
+
+# Keep the reusable multi-resolution overview file too — one run, both artifacts
+tylertoo input.parquet output.pmtiles --max-zoom 14 \
+  --keep-overview overviews.parquet
 ```
+
+The one-shot form materializes an intermediate overview GeoParquet before
+exporting (at least input-sized — it is **not** zero-disk). Its path and
+size are logged, `--spill-dir` / `$TMPDIR` control where it lives, and a
+free-space preflight warns when the volume looks too small.
 
 ### The Two-Step Workflow
 
-The overview GeoParquet file is the interesting artifact — keep it:
+The overview GeoParquet file is the interesting artifact — build it
+explicitly when you want to validate it, query it, or re-export with
+different flags without re-converting:
 
 ```bash
 # 1. Embed multi-resolution levels in a GeoParquet file
@@ -56,7 +67,8 @@ tylertoo validate overviews.parquet
 tylertoo export-pmtiles overviews.parquet output.pmtiles
 ```
 
-All tuning knobs live on `overview` / `export-pmtiles` — see
+Every tuning knob is available on the one-shot `tiles` command as well as
+on `overview` / `export-pmtiles` — see
 [Overview Tuning](docs/OVERVIEW_TUNING.md). Defaults are calibrated on
 rendered corpus sweeps and are meant to look right out of the box.
 
@@ -98,7 +110,7 @@ convert("input.parquet", "output.pmtiles", min_zoom=0, max_zoom=14)
 
 ## Documentation
 
-- **[Getting Started](docs/getting-started.md)** — Installation, basic usage, the two-step workflow
+- **[Getting Started](docs/getting-started.md)** — Installation, one-shot conversion, the two-step workflow
 - **[Overview Tuning](docs/OVERVIEW_TUNING.md)** — Every generalization knob explained
 - **[Decoding PMTiles](docs/decode.md)** — PMTiles → GeoParquet, limitations included
 - **[API Reference](docs/api-reference.md)** — CLI flags, Python API, Rust API

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -708,6 +708,12 @@ struct ConvertTuningArgs {
     /// a volume with enough room (a free-space preflight warns about a
     /// projected shortfall). The directory must exist. Local inputs never
     /// spill.
+    ///
+    /// On `tiles` this directory also hosts the removed-after-export
+    /// intermediate overview (#314) — at least input-sized, with its own
+    /// free-space preflight — unless --keep-overview is given (then the
+    /// intermediate goes to that path instead). Location precedence for
+    /// the intermediate: --spill-dir, $TMPDIR, the output directory.
     #[arg(long, value_name = "PATH", help_heading = "Memory & performance")]
     spill_dir: Option<PathBuf>,
 }
@@ -949,6 +955,17 @@ struct TilesArgs {
     #[arg(long, value_name = "PATH")]
     report: Option<PathBuf>,
 
+    /// Write the intermediate overview GeoParquet to PATH and RETAIN it,
+    /// instead of a temp file removed after the export — one run then yields
+    /// both artifacts: the reusable multi-resolution overview (queryable,
+    /// re-exportable, see `tylertoo overview`) and the PMTiles. The PMTiles
+    /// output is identical either way. Without this flag the intermediate is
+    /// written to --spill-dir if given, else $TMPDIR if set, else the output
+    /// directory, and deleted once the export finishes (see the note on the
+    /// materialized intermediate under --spill-dir).
+    #[arg(long, value_name = "PATH")]
+    keep_overview: Option<PathBuf>,
+
     /// Enable verbose output (per-level and per-zoom breakdowns).
     #[arg(short, long)]
     verbose: bool,
@@ -1100,12 +1117,6 @@ fn run_convert(
     .map_err(|e| anyhow::anyhow!("overview conversion failed: {e}"))
 }
 
-/// Run `tylertoo tiles`: the one-shot GeoParquet → PMTiles facade.
-///
-/// Chains the two product pipelines through a temporary overview file:
-/// `overview` (convert, with default knobs) → `export-pmtiles`. The temp
-/// file lives next to the output (same filesystem) and is removed on both
-/// success and failure via [`tempfile::NamedTempFile`]'s drop guard.
 /// Resolve the level plan shared by `overview` and `tiles`: an explicit
 /// `--gsd` list (comma-separated meters, strictly decreasing) overrides the
 /// `--min-zoom`/`--max-zoom` range. Kept in one place so the two commands
@@ -1130,6 +1141,135 @@ fn resolve_level_plan(
     }
 }
 
+/// Where the removed-after-export intermediate overview of a `tiles` run
+/// lives (#314): `--spill-dir` if given (one knob for everything tylertoo
+/// puts on scratch disk), else an explicitly-set non-empty `$TMPDIR`, else
+/// next to the output (same filesystem as the final artifact), else the
+/// process temp dir. Pure — the env value is injected — so the precedence
+/// is unit-testable.
+fn resolve_intermediate_dir(
+    spill_dir: Option<&std::path::Path>,
+    tmpdir_env: Option<&std::ffi::OsStr>,
+    output: &std::path::Path,
+) -> PathBuf {
+    if let Some(dir) = spill_dir {
+        return dir.to_path_buf();
+    }
+    if let Some(tmpdir) = tmpdir_env.filter(|t| !t.is_empty()) {
+        return PathBuf::from(tmpdir);
+    }
+    output
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_else(std::env::temp_dir)
+}
+
+/// Lower-bound estimate of the intermediate overview's size for the #314
+/// free-space preflight: the local input bytes. A duplicating overview
+/// embeds the finest level verbatim on top of the coarse levels, so it is
+/// at least input-sized. Local file → its size; local directory → sum of
+/// its top-level `.parquet` entries; `--files-from` manifest → sum of the
+/// entries that resolve as local files. Remote/glob shapes return `None`
+/// (the preflight stays quiet rather than guessing).
+fn estimate_local_input_bytes(spec: &InputSpec) -> Option<u64> {
+    fn file_len(p: &std::path::Path) -> Option<u64> {
+        std::fs::metadata(p)
+            .ok()
+            .filter(|m| m.is_file())
+            .map(|m| m.len())
+    }
+    match spec {
+        InputSpec::Path(p) => {
+            let meta = std::fs::metadata(p).ok()?;
+            if meta.is_file() {
+                return Some(meta.len());
+            }
+            if !meta.is_dir() {
+                return None;
+            }
+            let sum: u64 = std::fs::read_dir(p)
+                .ok()?
+                .filter_map(|e| e.ok())
+                .filter(|e| e.path().extension().is_some_and(|x| x == "parquet"))
+                .filter_map(|e| file_len(&e.path()))
+                .sum();
+            (sum > 0).then_some(sum)
+        }
+        InputSpec::Manifest(m) => {
+            let text = std::fs::read_to_string(m).ok()?;
+            let sum: u64 = text
+                .lines()
+                .map(str::trim)
+                .filter(|l| !l.is_empty() && !l.starts_with('#'))
+                .filter_map(|l| file_len(std::path::Path::new(l)))
+                .sum();
+            (sum > 0).then_some(sum)
+        }
+    }
+}
+
+/// #314 preflight safety margin, matching the remote-spill preflight
+/// (#272): warn when free space is below the estimate plus 1/20th (5%).
+const INTERMEDIATE_MARGIN_DENOM: u64 = 20;
+
+/// #314 free-space preflight decision + message (pure, unit-testable).
+/// Returns the warning to emit when the estimated intermediate overview
+/// (a lower bound — the local input bytes) plus a 5% margin exceeds
+/// `available_bytes` on the volume holding `dir`, or `None` when it fits
+/// (or the estimate is unknown/zero).
+fn intermediate_space_warning(
+    estimated_bytes: u64,
+    available_bytes: u64,
+    dir: &std::path::Path,
+) -> Option<String> {
+    if estimated_bytes == 0 {
+        return None;
+    }
+    let need = estimated_bytes + estimated_bytes / INTERMEDIATE_MARGIN_DENOM;
+    if available_bytes >= need {
+        return None;
+    }
+    let gib = |b: u64| b as f64 / (1024.0 * 1024.0 * 1024.0);
+    Some(format!(
+        "the intermediate overview `tiles` materializes (≥ ~{:.1} GiB — a \
+         duplicating overview is at least as large as the input, whose local \
+         size is the estimate) may not fit: {} has {:.1} GiB free ({:.1} GiB \
+         short, including a 5% margin). Point --spill-dir (or --keep-overview) \
+         at a roomier volume, or free up space first.",
+        gib(estimated_bytes),
+        dir.display(),
+        gib(available_bytes),
+        gib(need - available_bytes),
+    ))
+}
+
+/// Emit the #314 intermediate free-space preflight warning, if warranted:
+/// probe the volume holding `dir` and compare against the local-input-bytes
+/// estimate. Quiet when either side is unknowable (remote input, exotic
+/// filesystem) rather than crying wolf.
+fn warn_intermediate_space(spec: &InputSpec, dir: &std::path::Path) {
+    let Some(estimated) = estimate_local_input_bytes(spec) else {
+        return;
+    };
+    let Ok(available) = fs4::available_space(dir) else {
+        return;
+    };
+    if let Some(msg) = intermediate_space_warning(estimated, available, dir) {
+        log::warn!("{msg}");
+    }
+}
+
+/// Run `tylertoo tiles`: the one-shot GeoParquet → PMTiles facade.
+///
+/// Chains the two product pipelines through a materialized intermediate
+/// overview file (`overview` convert → `export-pmtiles`) — this is NOT
+/// zero-disk. The intermediate is retained at `--keep-overview PATH` when
+/// given; otherwise it is a temp file (in `--spill-dir` / `$TMPDIR` / the
+/// output directory, in that order) removed on both success and failure
+/// via [`tempfile::NamedTempFile`]'s drop guard. Its path and size are
+/// always logged, and a free-space preflight warns when the chosen volume
+/// looks too small for it (#314).
 fn run_tiles(args: TilesArgs) -> Result<()> {
     use tylertoo_core::overview::export::{export_pmtiles, ExportOptions};
     use tylertoo_core::overview::level::Mode;
@@ -1159,20 +1299,69 @@ fn run_tiles(args: TilesArgs) -> Result<()> {
         .tuning
         .build_convert_options(Mode::Duplicating, levels, bbox, false)?;
 
-    // Intermediate overview file next to the output (same filesystem);
-    // NamedTempFile removes it on drop — success or failure alike.
-    let tmp_dir = output
+    // Intermediate overview file (#314): retained at --keep-overview when
+    // given; otherwise a temp file in --spill-dir / $TMPDIR / the output
+    // directory, removed on drop — success or failure alike.
+    let (overview_path, overview_tmp): (PathBuf, Option<tempfile::NamedTempFile>) =
+        match &args.keep_overview {
+            Some(path) => {
+                if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+                    anyhow::ensure!(
+                        parent.is_dir(),
+                        "--keep-overview directory {} does not exist",
+                        parent.display()
+                    );
+                }
+                (path.clone(), None)
+            }
+            None => {
+                let dir = resolve_intermediate_dir(
+                    args.tuning.spill_dir.as_deref(),
+                    std::env::var_os("TMPDIR").as_deref(),
+                    &output,
+                );
+                let tmp = tempfile::Builder::new()
+                    .prefix(".tylertoo-overview-")
+                    .suffix(".parquet")
+                    .tempfile_in(&dir)
+                    .with_context(|| {
+                        format!(
+                            "failed to create the intermediate overview file in {} \
+                             (location precedence: --spill-dir, $TMPDIR, the output \
+                             directory)",
+                            dir.display()
+                        )
+                    })?;
+                (tmp.path().to_path_buf(), Some(tmp))
+            }
+        };
+
+    // #314 free-space preflight: the intermediate is at least input-sized,
+    // so warn up front when the chosen volume looks too small.
+    let overview_dir = overview_path
         .parent()
         .filter(|p| !p.as_os_str().is_empty())
         .map(std::path::Path::to_path_buf)
-        .unwrap_or_else(std::env::temp_dir);
-    let overview_tmp = tempfile::Builder::new()
-        .prefix(".tylertoo-overview-")
-        .suffix(".parquet")
-        .tempfile_in(&tmp_dir)
-        .context("failed to create temporary overview file")?;
+        .unwrap_or_else(|| PathBuf::from("."));
+    warn_intermediate_space(&spec, &overview_dir);
 
-    let convert_report = run_convert(&spec, overview_tmp.path(), &options)?;
+    let convert_report = run_convert(&spec, &overview_path, &options)?;
+
+    // #314: the disk cost of the one-shot facade must not be silent — name
+    // the intermediate's path and size, and its fate.
+    let overview_bytes = std::fs::metadata(&overview_path)
+        .map(|m| m.len())
+        .unwrap_or(0);
+    println!(
+        "  intermediate overview: {} ({}{})",
+        overview_path.display(),
+        HumanBytes(overview_bytes),
+        if overview_tmp.is_some() {
+            ", removed after export; --keep-overview PATH retains it"
+        } else {
+            ", retained"
+        }
+    );
 
     if args.verbose {
         println!(
@@ -1192,7 +1381,7 @@ fn run_tiles(args: TilesArgs) -> Result<()> {
         simple_clip_fastpath: !args.no_simple_clip_fastpath,
         partition_wave: args.partition_wave,
     };
-    let export_report = export_pmtiles(overview_tmp.path(), &output, &export_opts)
+    let export_report = export_pmtiles(&overview_path, &output, &export_opts)
         .map_err(|e| anyhow::anyhow!("export failed: {e}"))?;
 
     if args.verbose {
@@ -1818,6 +2007,123 @@ mod tests {
         assert_eq!(a.tuning.profile, "bounded");
         assert!(a.tuning.cluster);
         assert!(a.tuning.no_coalesce_lines);
+    }
+
+    // --- #314 ergonomic one-step: --keep-overview + intermediate location ----
+
+    /// `--keep-overview` parses to a path on `tiles` and defaults to off.
+    #[test]
+    fn tiles_keep_overview_flag_parses() {
+        assert!(parse_tiles(&[]).keep_overview.is_none());
+        let a = parse_tiles(&["--keep-overview", "ov.parquet"]);
+        assert_eq!(a.keep_overview, Some(PathBuf::from("ov.parquet")));
+    }
+
+    /// Intermediate-overview directory precedence (#314): `--spill-dir`
+    /// beats an explicitly-set `$TMPDIR`, which beats the output's own
+    /// directory; a bare output filename with no `$TMPDIR` falls back to
+    /// the process temp dir.
+    #[test]
+    fn resolve_intermediate_dir_precedence() {
+        use std::ffi::OsStr;
+        let out = std::path::Path::new("/data/out/tiles.pmtiles");
+
+        // --spill-dir wins over everything.
+        assert_eq!(
+            resolve_intermediate_dir(
+                Some(std::path::Path::new("/spill")),
+                Some(OsStr::new("/tmpdir")),
+                out
+            ),
+            PathBuf::from("/spill")
+        );
+        // $TMPDIR (explicitly set, non-empty) beats the output directory.
+        assert_eq!(
+            resolve_intermediate_dir(None, Some(OsStr::new("/tmpdir")), out),
+            PathBuf::from("/tmpdir")
+        );
+        // An empty $TMPDIR is ignored.
+        assert_eq!(
+            resolve_intermediate_dir(None, Some(OsStr::new("")), out),
+            PathBuf::from("/data/out")
+        );
+        // Default: next to the output (same filesystem as the final artifact).
+        assert_eq!(
+            resolve_intermediate_dir(None, None, out),
+            PathBuf::from("/data/out")
+        );
+        // Bare output filename: process temp dir fallback.
+        assert_eq!(
+            resolve_intermediate_dir(None, None, std::path::Path::new("tiles.pmtiles")),
+            std::env::temp_dir()
+        );
+    }
+
+    /// #314 free-space preflight: quiet when the estimated intermediate
+    /// (plus the 5% margin) fits, a warning naming the directory, the
+    /// shortfall, and the `--spill-dir` escape hatch when it does not.
+    #[test]
+    fn intermediate_space_warning_thresholds() {
+        let dir = std::path::Path::new("/some/volume");
+        let gib = 1024u64 * 1024 * 1024;
+
+        // Fits comfortably: no warning.
+        assert!(intermediate_space_warning(10 * gib, 11 * gib, dir).is_none());
+        // Exactly the estimate + 5% margin still fits.
+        let est = 20 * gib;
+        assert!(intermediate_space_warning(est, est + est / 20, dir).is_none());
+        // One byte short of the margin: warn, naming dir and remedies.
+        let msg =
+            intermediate_space_warning(est, est + est / 20 - 1, dir).expect("shortfall must warn");
+        assert!(msg.contains("/some/volume"), "names the directory: {msg}");
+        assert!(msg.contains("--spill-dir"), "names the remedy: {msg}");
+        assert!(msg.contains("--keep-overview"), "names the remedy: {msg}");
+        // Zero estimate (unknown/empty input): never warns.
+        assert!(intermediate_space_warning(0, 0, dir).is_none());
+    }
+
+    /// The intermediate size estimate is the local input bytes: file size
+    /// for a file, the sum of top-level .parquet sizes for a directory,
+    /// the sum of existing local manifest entries for --files-from.
+    #[test]
+    fn estimate_local_input_bytes_shapes() {
+        let dir = tempfile::tempdir().unwrap();
+        let f1 = dir.path().join("a.parquet");
+        let f2 = dir.path().join("b.parquet");
+        std::fs::write(&f1, vec![0u8; 100]).unwrap();
+        std::fs::write(&f2, vec![0u8; 50]).unwrap();
+        std::fs::write(dir.path().join("ignored.txt"), vec![0u8; 999]).unwrap();
+
+        // Single file.
+        assert_eq!(
+            estimate_local_input_bytes(&InputSpec::Path(f1.clone())),
+            Some(100)
+        );
+        // Directory: only .parquet entries count.
+        assert_eq!(
+            estimate_local_input_bytes(&InputSpec::Path(dir.path().to_path_buf())),
+            Some(150)
+        );
+        // Nonexistent / remote-looking path: quiet None.
+        assert_eq!(
+            estimate_local_input_bytes(&InputSpec::Path(PathBuf::from("s3://bucket/x.parquet"))),
+            None
+        );
+        // Manifest: sum of existing local entries; comments/blanks skipped.
+        let manifest = dir.path().join("m.txt");
+        std::fs::write(
+            &manifest,
+            format!(
+                "# comment\n{}\n\n{}\ns3://bucket/remote.parquet\n",
+                f1.display(),
+                f2.display()
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            estimate_local_input_bytes(&InputSpec::Manifest(manifest)),
+            Some(150)
+        );
     }
 
     #[test]

--- a/crates/cli/tests/tiles_facade.rs
+++ b/crates/cli/tests/tiles_facade.rs
@@ -89,6 +89,119 @@ fn bare_invocation_rewrites_to_tiles() {
     assert_eq!(&bytes[..PMTILES_MAGIC.len()], PMTILES_MAGIC);
 }
 
+/// #314: `tiles --keep-overview PATH` retains the intermediate overview at
+/// PATH, logs its path + size, and produces a PMTiles archive byte-identical
+/// to running the two-step `overview` → `export-pmtiles` chain by hand.
+#[test]
+fn tiles_keep_overview_retains_and_matches_two_step() {
+    let fixture = Path::new("../../tests/fixtures/realdata/open-buildings.parquet");
+    if !fixture.exists() {
+        eprintln!("Skipping: fixture not found");
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let one_step_out = dir.path().join("one-step.pmtiles");
+    let kept_overview = dir.path().join("kept-overview.parquet");
+
+    // One-shot with --keep-overview (fixed layer name so both runs match).
+    let output = Command::new(tylertoo_bin())
+        .args([
+            "tiles",
+            fixture.to_str().unwrap(),
+            one_step_out.to_str().unwrap(),
+            "--max-zoom",
+            "5",
+            "--layer-name",
+            "parity",
+            "--keep-overview",
+            kept_overview.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run tylertoo tiles --keep-overview");
+    assert!(
+        output.status.success(),
+        "tiles --keep-overview exited with {}: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // The intermediate is retained and is a parquet file.
+    let overview_bytes = std::fs::read(&kept_overview).expect("kept overview must exist");
+    assert_eq!(&overview_bytes[..4], b"PAR1", "kept overview is parquet");
+
+    // The disk cost is not silent: path + size are logged.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("intermediate overview:")
+            && stdout.contains("kept-overview.parquet")
+            && stdout.contains("retained"),
+        "stdout should name the intermediate's path, size, and fate: {stdout}"
+    );
+
+    // Two-step by hand: overview (duplicating, same zooms) → export-pmtiles.
+    let two_step_overview = dir.path().join("two-step-overview.parquet");
+    let two_step_out = dir.path().join("two-step.pmtiles");
+    let status = Command::new(tylertoo_bin())
+        .args([
+            "overview",
+            fixture.to_str().unwrap(),
+            two_step_overview.to_str().unwrap(),
+            "--max-zoom",
+            "5",
+        ])
+        .status()
+        .expect("run tylertoo overview");
+    assert!(status.success(), "overview exited with {status}");
+    let status = Command::new(tylertoo_bin())
+        .args([
+            "export-pmtiles",
+            two_step_overview.to_str().unwrap(),
+            two_step_out.to_str().unwrap(),
+            "--layer-name",
+            "parity",
+        ])
+        .status()
+        .expect("run tylertoo export-pmtiles");
+    assert!(status.success(), "export-pmtiles exited with {status}");
+
+    // PMTiles export is byte-deterministic, so the acceptance bar is exact
+    // byte identity between the one-step and two-step outputs.
+    let one_step = std::fs::read(&one_step_out).expect("read one-step pmtiles");
+    let two_step = std::fs::read(&two_step_out).expect("read two-step pmtiles");
+    assert_eq!(&one_step[..8], PMTILES_MAGIC);
+    assert_eq!(
+        one_step, two_step,
+        "one-step --keep-overview PMTiles must be byte-identical to the two-step chain"
+    );
+}
+
+/// #314: a nonexistent --keep-overview directory fails fast with an error
+/// naming the flag, before any conversion work.
+#[test]
+fn tiles_keep_overview_rejects_missing_directory() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let input = dir.path().join("in.parquet");
+    std::fs::write(&input, b"not really parquet").unwrap();
+
+    let output = Command::new(tylertoo_bin())
+        .args([
+            "tiles",
+            input.to_str().unwrap(),
+            dir.path().join("out.pmtiles").to_str().unwrap(),
+            "--keep-overview",
+            "/nonexistent/tylertoo-314/ov.parquet",
+        ])
+        .output()
+        .expect("run tylertoo tiles");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("keep-overview") && stderr.contains("/nonexistent/tylertoo-314"),
+        "error should name the flag and path, got: {stderr}"
+    );
+}
+
 /// #272: `--spill-dir` parses on both convert subcommands and reaches
 /// `ConvertOptions` — a nonexistent directory is rejected by core option
 /// validation (which runs before any input I/O, so no fixture is needed).

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -36,13 +36,24 @@ pip install tylertoo      # Python
 ## Usage
 
 ```bash
-# One-shot: GeoParquet in, PMTiles out
+# One-shot: GeoParquet in, PMTiles out (recommended)
 tylertoo input.parquet output.pmtiles --min-zoom 0 --max-zoom 14
+
+# Keep the reusable multi-resolution overview file too — one run, both artifacts
+tylertoo input.parquet output.pmtiles --max-zoom 14 \
+  --keep-overview overviews.parquet
 ```
+
+The one-shot form materializes an intermediate overview GeoParquet before
+exporting (at least input-sized — it is **not** zero-disk). Its path and
+size are logged, `--spill-dir` / `$TMPDIR` control where it lives, and a
+free-space preflight warns when the volume looks too small.
 
 ### The Two-Step Workflow
 
-The overview GeoParquet file is the interesting artifact — keep it:
+The overview GeoParquet file is the interesting artifact — build it
+explicitly when you want to validate it, query it, or re-export with
+different flags without re-converting:
 
 ```bash
 # 1. Embed multi-resolution levels in a GeoParquet file
@@ -56,7 +67,8 @@ tylertoo validate overviews.parquet
 tylertoo export-pmtiles overviews.parquet output.pmtiles
 ```
 
-All tuning knobs live on `overview` / `export-pmtiles` — see
+Every tuning knob is available on the one-shot `tiles` command as well as
+on `overview` / `export-pmtiles` — see
 [Overview Tuning](docs/OVERVIEW_TUNING.md). Defaults are calibrated on
 rendered corpus sweeps and are meant to look right out of the box.
 
@@ -98,7 +110,7 @@ convert("input.parquet", "output.pmtiles", min_zoom=0, max_zoom=14)
 
 ## Documentation
 
-- **[Getting Started](docs/getting-started.md)** — Installation, basic usage, the two-step workflow
+- **[Getting Started](docs/getting-started.md)** — Installation, one-shot conversion, the two-step workflow
 - **[Overview Tuning](docs/OVERVIEW_TUNING.md)** — Every generalization knob explained
 - **[Decoding PMTiles](docs/decode.md)** — PMTiles → GeoParquet, limitations included
 - **[API Reference](docs/api-reference.md)** — CLI flags, Python API, Rust API

--- a/crates/python/README.md
+++ b/crates/python/README.md
@@ -36,13 +36,24 @@ pip install tylertoo      # Python
 ## Usage
 
 ```bash
-# One-shot: GeoParquet in, PMTiles out
+# One-shot: GeoParquet in, PMTiles out (recommended)
 tylertoo input.parquet output.pmtiles --min-zoom 0 --max-zoom 14
+
+# Keep the reusable multi-resolution overview file too — one run, both artifacts
+tylertoo input.parquet output.pmtiles --max-zoom 14 \
+  --keep-overview overviews.parquet
 ```
+
+The one-shot form materializes an intermediate overview GeoParquet before
+exporting (at least input-sized — it is **not** zero-disk). Its path and
+size are logged, `--spill-dir` / `$TMPDIR` control where it lives, and a
+free-space preflight warns when the volume looks too small.
 
 ### The Two-Step Workflow
 
-The overview GeoParquet file is the interesting artifact — keep it:
+The overview GeoParquet file is the interesting artifact — build it
+explicitly when you want to validate it, query it, or re-export with
+different flags without re-converting:
 
 ```bash
 # 1. Embed multi-resolution levels in a GeoParquet file
@@ -56,7 +67,8 @@ tylertoo validate overviews.parquet
 tylertoo export-pmtiles overviews.parquet output.pmtiles
 ```
 
-All tuning knobs live on `overview` / `export-pmtiles` — see
+Every tuning knob is available on the one-shot `tiles` command as well as
+on `overview` / `export-pmtiles` — see
 [Overview Tuning](docs/OVERVIEW_TUNING.md). Defaults are calibrated on
 rendered corpus sweeps and are meant to look right out of the box.
 
@@ -98,7 +110,7 @@ convert("input.parquet", "output.pmtiles", min_zoom=0, max_zoom=14)
 
 ## Documentation
 
-- **[Getting Started](docs/getting-started.md)** — Installation, basic usage, the two-step workflow
+- **[Getting Started](docs/getting-started.md)** — Installation, one-shot conversion, the two-step workflow
 - **[Overview Tuning](docs/OVERVIEW_TUNING.md)** — Every generalization knob explained
 - **[Decoding PMTiles](docs/decode.md)** — PMTiles → GeoParquet, limitations included
 - **[API Reference](docs/api-reference.md)** — CLI flags, Python API, Rust API

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -53,7 +53,7 @@ Commands:
 | `--read-batch-size <N>` | `8192` | Rows per Arrow read batch (streaming) |
 | `--profile <MODE>` | `auto` | Pass-2 buffering: `speed` (in-RAM), `bounded` (spill to temp Arrow IPC), `auto` (per mode + size). Output is byte-identical across profiles |
 | `--in-flight-batches <N\|auto>` | `auto` | Read/compute overlap depth in pass 2. `auto` sizes to available cores (clamped 4–16); higher = better core use, proportionally more peak memory. Resolved depth + core count logged at pass-2 start |
-| `--spill-dir <PATH>` | `$TMPDIR` | Directory for the remote-input spill file (≈1× the touched input bytes; a free-space preflight warns on a projected shortfall). Must exist; local inputs never spill |
+| `--spill-dir <PATH>` | `$TMPDIR` | Directory for the remote-input spill file (≈1× the touched input bytes; a free-space preflight warns on a projected shortfall). Must exist; local inputs never spill. On `tiles` it also hosts the removed-after-export intermediate overview (#314) unless `--keep-overview` is given |
 | `--report <PATH>` | — | Write the JSON conversion report |
 
 ### `tylertoo export-pmtiles <INPUT> <OUTPUT>`
@@ -77,11 +77,17 @@ Exit code 0 on pass.
 
 ### `tylertoo tiles <INPUT> <OUTPUT>` (and the bare form)
 
-One-shot facade: overview convert → temporary GeoParquet → export-pmtiles.
+One-shot facade: overview convert → intermediate GeoParquet →
+export-pmtiles. The intermediate overview is materialized on disk (at
+least input-sized — not zero-disk); its path and size are logged, and a
+free-space preflight warns when the chosen volume looks too small (#314).
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--min-zoom <N>` / `--max-zoom <N>` | `0` / `14` | Zoom range (feeds the overview level plan) |
+| `--gsd <GSDS>` | — | Explicit comma-separated GSD ladder (meters, strictly decreasing); overrides the zoom range |
+| `--keep-overview <PATH>` | — | Write the intermediate overview to PATH and retain it (one run, both artifacts); PMTiles output is identical either way |
+| `--report <PATH>` | — | Combined JSON report: a `convert` section and an `export` section |
 | `--bbox <XMIN,YMIN,XMAX,YMAX>` | — | Regional extract (lon/lat degrees); see `overview --bbox` |
 | `--layer-name <NAME>` | derived from input filename | MVT layer name |
 | `--tile-buffer <PX>` | `8` | Per-tile edge buffer in tile pixels (seam continuity) |
@@ -96,8 +102,12 @@ line coalescing, and the memory/performance flags (`--profile`,
 accepted here and threads through to the overview stage unchanged, so a
 one-shot `tiles` run is equivalent to the two-step chain with the same
 flags. `tylertoo tiles --help` groups them under headings. Overview
-**format** options that have no PMTiles meaning (`--mode`, `--gsd`,
-`--cogp-compat`, `--report`) stay on `overview`.
+**format** options that have no PMTiles meaning (`--mode`,
+`--cogp-compat`) stay on `overview`.
+
+Without `--keep-overview`, the intermediate is a temp file — placed in
+`--spill-dir` if given, else `$TMPDIR` if set, else the output's
+directory — and is removed after the export (on failure too).
 
 #### `--no-simple-clip-fastpath` (#239)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -65,11 +65,63 @@ handled too), and any `--sort-key` / `--class-rank` / `--accumulate-attribute`
 that named the renamed column is rewritten to follow it. No preprocessing
 needed.
 
-## The Two-Step Workflow (Recommended)
+## One-Shot Conversion (Recommended)
 
-The product is the **overview GeoParquet file**: one file that embeds
+The fastest way from GeoParquet to a map:
+
+```bash
+tylertoo input.parquet output.pmtiles --min-zoom 0 --max-zoom 14
+# equivalently: tylertoo tiles input.parquet output.pmtiles ...
+```
+
+This runs the overview convert into an intermediate GeoParquet file, then
+exports it to PMTiles. Beyond the essentials (`--min-zoom`, `--max-zoom`,
+`--gsd`, `--layer-name`, `--tile-buffer`, `--max-tile-size`, `--report`,
+`--verbose`), the one-shot command also accepts every convert-tuning knob
+from `overview` — quality and memory alike:
+
+```bash
+# Country-scale dot fill for a dense building layer, memory-bounded,
+# in one shot (see docs/OVERVIEW_TUNING.md, "Country-scale dot fill")
+tylertoo input.parquet output.pmtiles --max-zoom 14 \
+  --polygon-visibility 0 --collapse --max-tile-size 500K \
+  --profile bounded
+```
+
+A `tiles` run is equivalent to the two-step `overview` + `export-pmtiles`
+chain with the same flags. See `tylertoo tiles --help` (flags are grouped
+by heading) and the [API reference](api-reference.md) for the full set.
+
+**It is not zero-disk.** `tiles` materializes the full multi-resolution
+overview on disk before exporting — at least as large as your input (the
+finest level embeds your data verbatim; country-scale runs can reach tens
+of GB). The run always logs the intermediate's path and size, and a
+free-space preflight warns up front when the chosen volume looks too
+small for it.
+
+- `--keep-overview overviews.parquet` writes the intermediate there and
+  **retains** it, so one run yields both artifacts — the reusable
+  multi-resolution overview file and the PMTiles. The PMTiles output is
+  identical either way.
+- Without it, the intermediate is a temp file — placed in `--spill-dir`
+  if given, else `$TMPDIR` if set, else the output's directory — and is
+  removed once the export finishes (on failure too).
+
+## The Two-Step Workflow
+
+The real product is the **overview GeoParquet file**: one file that embeds
 COG-style multi-resolution levels alongside your exact source data. PMTiles
-is an *export* of it.
+is an *export* of it. Prefer the explicit two-step over `tiles` when you
+want to:
+
+- **validate** the overview against the spec before exporting,
+- **iterate on export flags** (layer name, tile size cap, buffer) without
+  re-running the expensive convert each time,
+- use overview-only **format options** (`--mode partitioning`,
+  `--cogp-compat`) that have no PMTiles meaning,
+- **query the overview directly** (DuckDB, GeoPandas) as the primary
+  artifact — though `tiles --keep-overview` covers the simple
+  "I want both files" case in one run.
 
 ```bash
 # 1. Build the overview file (levels for zooms 0..14)
@@ -119,32 +171,6 @@ tylertoo export-pmtiles overviews.parquet output.pmtiles \
   --layer-name roads \       # MVT layer name (default: "overview")
   --tile-size-limit 500000   # optional per-tile byte cap
 ```
-
-## One-Shot Conversion
-
-When you only want the PMTiles and don't care about the intermediate file:
-
-```bash
-tylertoo input.parquet output.pmtiles --min-zoom 0 --max-zoom 14
-# equivalently: tylertoo tiles input.parquet output.pmtiles ...
-```
-
-This runs overview convert into a temporary file, then export. Beyond the
-essentials (`--min-zoom`, `--max-zoom`, `--layer-name`, `--tile-buffer`,
-`--max-tile-size`, `--verbose`), the one-shot command also accepts every
-convert-tuning knob from `overview` — quality and memory alike:
-
-```bash
-# Country-scale dot fill for a dense building layer, memory-bounded,
-# in one shot (see docs/OVERVIEW_TUNING.md, "Country-scale dot fill")
-tylertoo input.parquet output.pmtiles --max-zoom 14 \
-  --polygon-visibility 0 --collapse --max-tile-size 500K \
-  --profile bounded
-```
-
-A `tiles` run is equivalent to the two-step `overview` + `export-pmtiles`
-chain with the same flags. See `tylertoo tiles --help` (flags are grouped
-by heading) and the [API reference](api-reference.md) for the full set.
 
 ## Python
 


### PR DESCRIPTION
Closes #314.

## What

`tylertoo tiles` (and the bare form) already runs the full `overview` → intermediate GeoParquet → `export-pmtiles` chain, but the intermediate was written silently and discarded. This makes it ergonomic (keeping the temp-overview architecture — zero-disk streaming stays a non-goal):

- **`--keep-overview PATH`** — write the intermediate overview to PATH and retain it, so one run yields both artifacts (the reusable multi-resolution overview and the PMTiles). PMTiles output is byte-identical to running the two-step chain by hand (asserted byte-for-byte in an integration test — export is byte-deterministic). Fails fast with a clear error if PATH's directory doesn't exist.
- **Controllable temp location** — without `--keep-overview`, the intermediate temp file goes to `--spill-dir` if given, else `$TMPDIR` if set, else the output's directory (previous default). One knob (`--spill-dir`) now governs everything tylertoo puts on scratch disk.
- **Free-space preflight** — before converting, the free space on the intermediate's volume is checked against a lower-bound estimate (the local input bytes — a duplicating overview embeds the finest level verbatim, so it is at least input-sized) plus the same 5% margin as the #272 remote-spill preflight; a shortfall logs a warning naming the directory, the gap, and the `--spill-dir` / `--keep-overview` remedies. Quiet when the estimate is unknowable (remote/glob input).
- **Visible disk cost** — the intermediate's path, size, and fate (`retained` / `removed after export; --keep-overview PATH retains it`) are always printed after the convert phase.
- **Docs** — `tiles` is now the recommended default in README and `docs/getting-started.md`, stated plainly as *not* zero-disk (intermediate ≥ input size), with explicit guidance on when to prefer the two-step (validate, iterate on export flags, partitioning/`--cogp-compat`, overview-as-primary-artifact). `docs/api-reference.md` gains the new flag rows and drops the stale claim that `--gsd`/`--report` stay on `overview` (they moved to `tiles` in #316/#318).

## Implementation notes

- CLI-only plumbing in `crates/cli/src/main.rs`; core untouched. New pure helpers (`resolve_intermediate_dir`, `estimate_local_input_bytes`, `intermediate_space_warning`) are unit-tested without touching a real volume; the probe uses `fs4::available_space` (same crate core uses for #272).
- New CLI deps: `log` (workspace) for the preflight warning, `fs4` for the probe. `Cargo.lock` is gitignored in this repo.
- The mangled doc comment that #318's merge left fused onto `resolve_level_plan` is untangled; `run_tiles` gets an accurate doc.

## Tests (TDD: red first, then green)

- `tests::tiles_keep_overview_flag_parses`, `tests::resolve_intermediate_dir_precedence`, `tests::intermediate_space_warning_thresholds`, `tests::estimate_local_input_bytes_shapes` — 4 new unit tests.
- `tiles_keep_overview_retains_and_matches_two_step` — integration: one-step `--keep-overview` output is **byte-identical** to the manual two-step chain, the overview file is retained and valid parquet, and stdout names its path/size/fate.
- `tiles_keep_overview_rejects_missing_directory` — fail-fast error names the flag and path.
- All 21 CLI bin unit tests and all 5 `tiles_facade` integration tests pass; `cargo clippy --all-targets -D warnings` clean; pre-commit (fmt, clippy all-features, version check, README sync) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)