### PR TITLE
feat(convert): attribute filter --filter/--where with row-group stats pushdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ the vector-tile tool this project measures itself against — tylertoo runs alon
 - Quality ladder tuned against tippecanoe: class ranking (Overture auto-detect), visibility gates, density budget, point clustering, line coalescing
 - Memory-bounded streaming conversion — a 632k-polygon / 38M-vertex file converts to a full z0–14 overview pyramid in ~45 s at ~1.4 GB peak RSS, or a default z0–6 pyramid in ~7 s at ~0.4 GB (16-core machine)
 - Remote inputs (`s3://`, `https://`, `gs://`) read via byte-range requests — with `--bbox`, extract a city from a remote country-scale file while downloading only the matching row groups ([Remote Reads](docs/remote-reads.md))
+- Attribute filtering (`--filter` / `--where`) — tile only the features matching a SQL-WHERE-style predicate (`"confidence > 0.8"`, `"crop IN ('soy', 'corn')"`), with parquet row-group statistics pushdown so non-matching row groups are never read (or fetched, on remote input); composes with `--bbox` ([Tuning guide](docs/OVERVIEW_TUNING.md#attribute-filter---filter----where))
 - Spec validation (`tylertoo validate`)
 - PMTiles → GeoParquet decoding (`tylertoo decode`) — tippecanoe-decode
   semantics, any PMTiles v3 MVT archive

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -18,6 +18,7 @@ the vector-tile tool this project measures itself against — tylertoo runs alon
 - Quality ladder tuned against tippecanoe: class ranking (Overture auto-detect), visibility gates, density budget, point clustering, line coalescing
 - Memory-bounded streaming conversion — a 632k-polygon / 38M-vertex file converts to a full z0–14 overview pyramid in ~45 s at ~1.4 GB peak RSS, or a default z0–6 pyramid in ~7 s at ~0.4 GB (16-core machine)
 - Remote inputs (`s3://`, `https://`, `gs://`) read via byte-range requests — with `--bbox`, extract a city from a remote country-scale file while downloading only the matching row groups ([Remote Reads](docs/remote-reads.md))
+- Attribute filtering (`--filter` / `--where`) — tile only the features matching a SQL-WHERE-style predicate (`"confidence > 0.8"`, `"crop IN ('soy', 'corn')"`), with parquet row-group statistics pushdown so non-matching row groups are never read (or fetched, on remote input); composes with `--bbox` ([Tuning guide](docs/OVERVIEW_TUNING.md#attribute-filter---filter----where))
 - Spec validation (`tylertoo validate`)
 - PMTiles → GeoParquet decoding (`tylertoo decode`) — tippecanoe-decode
   semantics, any PMTiles v3 MVT archive

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -328,6 +328,21 @@ struct ConvertTuningArgs {
     #[arg(long, help_heading = "Ranking")]
     no_auto_rank: bool,
 
+    /// Attribute filter: only convert features matching this SQL-WHERE-style
+    /// predicate over the input's property columns, e.g.
+    /// "confidence > 0.8", "crop_type IN ('soy', 'corn')",
+    /// "note IS NOT NULL AND (class = 'a' OR class = 'b')".
+    /// Supports =, !=, <, <=, >, >=, IN (...), IS [NOT] NULL, AND/OR/NOT,
+    /// parentheses, 'string' and numeric literals, and "quoted column"
+    /// names; nulls follow SQL three-valued logic (a row is kept only when
+    /// the predicate is TRUE). Evaluated during the pass-1 scan, so it
+    /// composes with --bbox; input row groups whose parquet column
+    /// statistics preclude any match are skipped at the footer level (on
+    /// remote input those byte ranges are never fetched). Aliased as
+    /// --where. See docs/OVERVIEW_TUNING.md.
+    #[arg(long, value_name = "EXPR", alias = "where", help_heading = "Filtering")]
+    filter: Option<String>,
+
     /// GSD tile-band base for the zoom→GSD mapping: gsd(z) = 40075016.69 /
     /// base / 2^z (spec §5.2, cogp-rs default 1024).
     ///
@@ -833,6 +848,7 @@ impl ConvertTuningArgs {
             coalesce_max_level_rows: self.coalesce_max_level_rows,
             coalesce_junction_angle: self.coalesce_junction_angle,
             bbox,
+            filter: self.filter.clone(),
             spill_dir: self.spill_dir.clone(),
         })
     }

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -18,6 +18,7 @@ the vector-tile tool this project measures itself against — tylertoo runs alon
 - Quality ladder tuned against tippecanoe: class ranking (Overture auto-detect), visibility gates, density budget, point clustering, line coalescing
 - Memory-bounded streaming conversion — a 632k-polygon / 38M-vertex file converts to a full z0–14 overview pyramid in ~45 s at ~1.4 GB peak RSS, or a default z0–6 pyramid in ~7 s at ~0.4 GB (16-core machine)
 - Remote inputs (`s3://`, `https://`, `gs://`) read via byte-range requests — with `--bbox`, extract a city from a remote country-scale file while downloading only the matching row groups ([Remote Reads](docs/remote-reads.md))
+- Attribute filtering (`--filter` / `--where`) — tile only the features matching a SQL-WHERE-style predicate (`"confidence > 0.8"`, `"crop IN ('soy', 'corn')"`), with parquet row-group statistics pushdown so non-matching row groups are never read (or fetched, on remote input); composes with `--bbox` ([Tuning guide](docs/OVERVIEW_TUNING.md#attribute-filter---filter----where))
 - Spec validation (`tylertoo validate`)
 - PMTiles → GeoParquet decoding (`tylertoo decode`) — tippecanoe-decode
   semantics, any PMTiles v3 MVT archive

--- a/crates/core/src/input_set.rs
+++ b/crates/core/src/input_set.rs
@@ -142,6 +142,21 @@ impl RowGroupSelection {
     pub fn total_selected(&self) -> usize {
         self.0.iter().map(Vec::len).sum()
     }
+
+    /// Per-part intersection with `other` (#315): a row group survives only
+    /// when both selections keep it, so the bbox covering pruning and the
+    /// attribute-filter statistics pruning compose. Both selections must
+    /// come from the same source (same part count and order).
+    pub fn intersect(&self, other: &RowGroupSelection) -> RowGroupSelection {
+        debug_assert_eq!(self.0.len(), other.0.len());
+        let parts = self
+            .0
+            .iter()
+            .zip(&other.0)
+            .map(|(a, b)| a.iter().copied().filter(|i| b.contains(i)).collect())
+            .collect();
+        RowGroupSelection(parts)
+    }
 }
 
 /// How to read a [`ConvertSource`]: batch size, optional root-column
@@ -432,6 +447,23 @@ impl ConvertSource {
             .metas()?
             .iter()
             .map(|m| crate::overview::convert::select_input_row_groups(&m.parquet, bbox_units))
+            .collect();
+        Ok(RowGroupSelection(per_part))
+    }
+
+    /// Per-part attribute-filter row-group selection (#315): applies the
+    /// bound filter's column-statistics pushdown
+    /// ([`crate::overview::filter::BoundFilter::select_row_groups`]) to each
+    /// part independently. Conservative — groups without usable statistics
+    /// are kept.
+    pub fn select_row_groups_matching(
+        &self,
+        filter: &crate::overview::filter::BoundFilter,
+    ) -> Result<RowGroupSelection, InputError> {
+        let per_part = self
+            .metas()?
+            .iter()
+            .map(|m| filter.select_row_groups(&m.parquet))
             .collect();
         Ok(RowGroupSelection(per_part))
     }

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -391,6 +391,18 @@ pub struct ConvertOptions {
     /// identical either way. Default `None` (full-extent conversion,
     /// byte-identical output to a build without this option).
     pub bbox: Option<[f64; 4]>,
+    /// Attribute filter (#315): a SQL-WHERE-style predicate over the input's
+    /// property columns (`--filter` / `--where`), e.g. `confidence > 0.8`,
+    /// `crop_type IN ('soy', 'corn') AND note IS NOT NULL`. Evaluated during
+    /// the pass-1 scan with SQL three-valued null semantics (a row is kept
+    /// only when the predicate is TRUE), so it composes with
+    /// [`bbox`](Self::bbox) and feeds the same downstream pipeline. Input row
+    /// groups whose parquet column statistics prove the predicate cannot
+    /// match are skipped at the footer level (no data pages read — on remote
+    /// input those byte ranges are never fetched); row groups without usable
+    /// statistics degrade gracefully to the exact per-row evaluation. See
+    /// [`super::filter`] for the grammar. Default `None` (no filtering).
+    pub filter: Option<String>,
     /// Directory for the remote-input disk spill (#219 / #272). A remote
     /// convert stages every fetched column chunk in an anonymous temp file
     /// (growing to ≈1× the touched input bytes) so later passes re-read
@@ -471,6 +483,7 @@ impl Default for ConvertOptions {
             coalesce_max_level_rows: DEFAULT_COALESCE_MAX_LEVEL_ROWS,
             coalesce_junction_angle: DEFAULT_JUNCTION_ANGLE_DEG,
             bbox: None,
+            filter: None,
             spill_dir: None,
         }
     }
@@ -692,6 +705,10 @@ pub enum ConvertError {
     /// non-positive where a positive finite value is required).
     #[error("invalid option: {0}")]
     InvalidConfig(String),
+    /// The attribute filter (#315) failed to parse or bind against the input
+    /// schema (unknown column, type mismatch, unsupported column type).
+    #[error(transparent)]
+    Filter(#[from] super::filter::FilterError),
     /// `--cluster` was requested in partitioning mode. A partitioning row is
     /// read at MANY display zooms (prefix reads, §2.3) but exists at exactly
     /// one level, so a single stored `point_count` cannot reflect "that
@@ -814,6 +831,12 @@ fn validate_options(options: &ConvertOptions) -> Result<(), ConvertError> {
             )));
         }
     }
+    // Attribute filter (#315): fail fast on a syntactically invalid
+    // expression, before any input is opened. Binding (unknown column /
+    // type mismatch) happens later, once the schema is known.
+    if let Some(f) = &options.filter {
+        super::filter::parse_filter(f)?;
+    }
     // in_flight_batches == 0 is the IN_FLIGHT_BATCHES_AUTO sentinel (resolved
     // to available parallelism at pass-2 setup), not an error. Any explicit
     // positive value is honoured verbatim, so there is nothing to reject here.
@@ -914,6 +937,7 @@ fn decode_and_filter_geometries(
     geom_idx: usize,
     geom_field: &Field,
     bbox_units: Option<&[f64; 4]>,
+    filter_mask: Option<&[Option<bool>]>,
 ) -> Result<(RecordBatch, Vec<Geometry<f64>>), ConvertError> {
     let geom_array: Arc<dyn GeoArrowArray> =
         from_arrow_array(full.column(geom_idx).as_ref(), geom_field)
@@ -923,16 +947,26 @@ fn decode_and_filter_geometries(
     let mut geom_skipped = 0usize;
     let keep: Vec<bool> = geom_opts
         .iter()
-        .map(|g| match g.as_ref().filter(|g| usable_geometry(g)) {
-            // Regional extract (#102): drop features whose bbox misses the
-            // requested region exactly, independent of row-group pruning.
-            // (map_or, not is_none_or: the latter is stable only since Rust
-            // 1.82 and the crate MSRV is 1.75.)
-            #[allow(clippy::unnecessary_map_or)]
-            Some(g) => bbox_units.map_or(true, |bb| bboxes_intersect(&geometry_bbox(g), bb)),
-            None => {
-                geom_skipped += 1;
-                false
+        .enumerate()
+        .map(|(i, g)| {
+            // Attribute filter (#315): a row is kept only when the predicate
+            // evaluated TRUE (SQL-UNKNOWN drops, like FALSE).
+            if let Some(mask) = filter_mask {
+                if mask[i] != Some(true) {
+                    return false;
+                }
+            }
+            match g.as_ref().filter(|g| usable_geometry(g)) {
+                // Regional extract (#102): drop features whose bbox misses the
+                // requested region exactly, independent of row-group pruning.
+                // (map_or, not is_none_or: the latter is stable only since Rust
+                // 1.82 and the crate MSRV is 1.75.)
+                #[allow(clippy::unnecessary_map_or)]
+                Some(g) => bbox_units.map_or(true, |bb| bboxes_intersect(&geometry_bbox(g), bb)),
+                None => {
+                    geom_skipped += 1;
+                    false
+                }
             }
         })
         .collect();
@@ -1043,8 +1077,12 @@ pub(crate) fn convert_to_overviews_source_strategy(
     // can be rewritten to the renamed columns. The rename preserves column
     // order, so `read_schema` and `input_schema` share indices.
     let mut options = options.clone();
-    let (input_schema, _renames) = resolve_reserved_column_collisions(&read_schema, &mut options);
+    let (input_schema, renames) = resolve_reserved_column_collisions(&read_schema, &mut options);
     let options = &options;
+
+    // Attribute filter (#315): parse + bind against the (possibly renamed)
+    // input schema. Syntax was already validated in `validate_options`.
+    let bound_filter = bind_attribute_filter(options, &input_schema, &renames)?;
 
     let geom_idx = find_geometry_column(&input_schema).ok_or(ConvertError::NoGeometryColumn)?;
     let geom_field = input_schema.field(geom_idx).clone();
@@ -1054,17 +1092,23 @@ pub(crate) fn convert_to_overviews_source_strategy(
     // Coalescing schema check (Q3).
     validate_coalesce_schema(&input_schema, options)?;
 
-    // Regional extract (#102): prune input row groups by bbox covering
-    // statistics (footer-only), before any data pages are read. Groups
-    // without stats are kept; the exact per-feature filter below guarantees
-    // identical output either way.
+    // Regional extract (#102) + attribute filter (#315): prune input row
+    // groups by footer statistics (bbox covering stats / per-column
+    // min-max-null stats), before any data pages are read. The two prunings
+    // compose by intersection. Groups without stats are kept; the exact
+    // per-feature filters below guarantee identical output either way.
     let row_groups_total = builder.metadata().num_row_groups();
     let bbox_units = options.bbox.map(|b| bbox_to_crs_units(&b, crs));
-    let (builder, row_groups_read) = match &bbox_units {
-        Some(bb) => {
-            let sel = select_input_row_groups(builder.metadata(), bb);
+    let combined_sel = select_input_row_groups_combined(
+        builder.metadata(),
+        bbox_units.as_ref(),
+        bound_filter.as_ref(),
+    );
+    let (builder, row_groups_read) = match combined_sel {
+        Some(sel) => {
             let n = sel.len();
-            log::info!("bbox filter: reading {n}/{row_groups_total} input row groups");
+            let what = pruning_label(bbox_units.is_some(), bound_filter.is_some());
+            log::info!("{what} filter: reading {n}/{row_groups_total} input row groups");
             (builder.with_row_groups(sel), n)
         }
         None => (builder, row_groups_total),
@@ -1083,8 +1127,18 @@ pub(crate) fn convert_to_overviews_source_strategy(
     // they are dropped, from the batch and the geometry vec together, so every
     // downstream index stays aligned (H4: an interleaved null geometry must
     // never shift attributes onto a neighboring row's geometry).
-    let (full, geometries) =
-        decode_and_filter_geometries(full, geom_idx, &geom_field, bbox_units.as_ref())?;
+    // Attribute filter (#315): evaluate the predicate over the full table
+    // once (identity projection — the raw batch carries the full schema, and
+    // the #288 rename is order-preserving so indices line up).
+    let filter_mask: Option<Vec<Option<bool>>> =
+        bound_filter.as_ref().map(|f| f.eval_mask(&full, &|i| i));
+    let (full, geometries) = decode_and_filter_geometries(
+        full,
+        geom_idx,
+        &geom_field,
+        bbox_units.as_ref(),
+        filter_mask.as_deref(),
+    )?;
 
     // Apply the reserved-column renames (#288) to the in-memory table. Columns
     // are positional, so re-associating them with the renamed schema is a
@@ -1565,6 +1619,51 @@ pub(crate) fn select_input_row_groups(
             None => true, // no stats — must read to stay correct
         })
         .collect()
+}
+
+/// Parse + bind [`ConvertOptions::filter`] (#315) against the (possibly
+/// reserved-renamed, #288) input schema. `Ok(None)` when no filter is set.
+pub(super) fn bind_attribute_filter(
+    options: &ConvertOptions,
+    input_schema: &Schema,
+    renames: &[(String, String)],
+) -> Result<Option<super::filter::BoundFilter>, ConvertError> {
+    let Some(src) = options.filter.as_deref() else {
+        return Ok(None);
+    };
+    let expr = super::filter::parse_filter(src)?;
+    Ok(Some(super::filter::BoundFilter::bind(
+        &expr,
+        input_schema,
+        renames,
+    )?))
+}
+
+/// Log label for the active footer-statistics prunings.
+pub(super) fn pruning_label(bbox: bool, filter: bool) -> &'static str {
+    match (bbox, filter) {
+        (true, true) => "bbox+attribute",
+        (true, false) => "bbox",
+        _ => "attribute",
+    }
+}
+
+/// Combined single-file footer-statistics row-group selection: bbox covering
+/// pruning (#102) intersected with attribute-filter statistics pushdown
+/// (#315). `None` when neither pruning is active (read everything).
+fn select_input_row_groups_combined(
+    metadata: &parquet::file::metadata::ParquetMetaData,
+    bbox_units: Option<&[f64; 4]>,
+    filter: Option<&super::filter::BoundFilter>,
+) -> Option<Vec<usize>> {
+    let bbox_sel: Option<Vec<usize>> = bbox_units.map(|bb| select_input_row_groups(metadata, bb));
+    let filter_sel: Option<Vec<usize>> = filter.map(|f| f.select_row_groups(metadata));
+    match (bbox_sel, filter_sel) {
+        (Some(a), Some(b)) => Some(a.into_iter().filter(|i| b.contains(i)).collect()),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    }
 }
 
 /// Find the primary geometry column index (name `geometry`, else first `geom*`).
@@ -5928,6 +6027,224 @@ mod tests {
     }
 
     // ========================================================================
+    // Attribute filter tests (#315)
+    // ========================================================================
+
+    /// One fixture row: `((x, y), confidence, crop)`.
+    type AttrRow = ((f64, f64), Option<f64>, Option<&'static str>);
+
+    /// Multi-row-group input with attribute columns: one row per row group at
+    /// `(x, y)` with `id` = row-group index, plus a nullable `confidence`
+    /// Float64 and a nullable `crop` Utf8 column. One row per row group makes
+    /// per-row-group column statistics exact, so pushdown pruning can bite.
+    fn write_multi_rg_attr_input(path: &Path, rows: &[AttrRow]) {
+        use parquet::file::properties::WriterProperties;
+
+        let geoms: Vec<Geometry<f64>> = rows
+            .iter()
+            .map(|&((x, y), _, _)| Geometry::Point(Point::new(x, y)))
+            .collect();
+        let n = geoms.len();
+        let id = Int64Array::from((0..n as i64).collect::<Vec<_>>());
+        let confidence =
+            arrow_array::Float64Array::from(rows.iter().map(|(_, c, _)| *c).collect::<Vec<_>>());
+        let crop =
+            arrow_array::StringArray::from(rows.iter().map(|(_, _, s)| *s).collect::<Vec<_>>());
+        let geom_arr = build_geometry_array(&geoms);
+        let geom_field = geom_arr.data_type().to_field("geometry", true);
+        let fields = vec![
+            Arc::new(Field::new("id", DataType::Int64, false)),
+            Arc::new(Field::new("confidence", DataType::Float64, true)),
+            Arc::new(Field::new("crop", DataType::Utf8, true)),
+            Arc::new(geom_field),
+        ];
+        let columns: Vec<Arc<dyn Array>> = vec![
+            Arc::new(id),
+            Arc::new(confidence),
+            Arc::new(crop),
+            geom_arr.to_array_ref(),
+        ];
+        let schema = Arc::new(Schema::new(fields));
+        let batch = RecordBatch::try_new(schema.clone(), columns).unwrap();
+
+        let gpq_options = GeoParquetWriterOptionsBuilder::default()
+            .set_encoding(GeoParquetWriterEncoding::WKB)
+            .set_generate_covering(true)
+            .build();
+        let encoder = GeoParquetRecordBatchEncoder::try_new(&schema, &gpq_options).unwrap();
+        let target_schema = encoder.target_schema();
+        let props = WriterProperties::builder()
+            .set_max_row_group_row_count(Some(1))
+            .build();
+        let file = std::fs::File::create(path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, target_schema, Some(props)).unwrap();
+        let mut encoder = encoder;
+        let encoded = encoder.encode_record_batch(&batch).unwrap();
+        writer.write(&encoded).unwrap();
+        writer.append_key_value_metadata(encoder.into_keyvalue().unwrap());
+        writer.close().unwrap();
+    }
+
+    /// Rows: (0,0)/0.1/soy, (10,10)/0.9/corn, (20,20)/0.85/soy, (30,30)/null/rice.
+    fn attr_rows() -> Vec<AttrRow> {
+        vec![
+            ((0.0, 0.0), Some(0.1), Some("soy")),
+            ((10.0, 10.0), Some(0.9), Some("corn")),
+            ((20.0, 20.0), Some(0.85), Some("soy")),
+            ((30.0, 30.0), None, Some("rice")),
+        ]
+    }
+
+    fn attr_opts() -> ConvertOptions {
+        ConvertOptions {
+            mode: Mode::Duplicating,
+            levels: LevelPlan::ZoomRange {
+                min_zoom: 6,
+                max_zoom: 6,
+            },
+            ..Default::default()
+        }
+    }
+
+    /// `--filter "confidence > 0.8"` keeps only the matching features
+    /// (null confidence drops per SQL three-valued logic) AND prunes the
+    /// non-matching row groups via column statistics — in both the streaming
+    /// and in-memory engines.
+    #[test]
+    fn attribute_filter_matches_posthoc_and_prunes_row_groups() {
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        write_multi_rg_attr_input(tin.path(), &attr_rows());
+
+        for streaming in [true, false] {
+            let tout = tempfile::NamedTempFile::new().unwrap();
+            let opts = ConvertOptions {
+                filter: Some("confidence > 0.8".to_string()),
+                streaming,
+                ..attr_opts()
+            };
+            let report = convert_to_overviews(tin.path(), tout.path(), &opts).unwrap();
+            assert_eq!(report.row_groups_total, 4, "streaming={streaming}");
+            // RG0 (0.1) and RG3 (all-null) are provably non-matching by stats.
+            assert_eq!(
+                report.row_groups_read, 2,
+                "stats pushdown did not fire (streaming={streaming})"
+            );
+            let ids = read_all_ids(&OverviewReader::open(tout.path()).unwrap());
+            assert_eq!(ids, vec![1, 2], "streaming={streaming}");
+        }
+    }
+
+    /// `--filter` composes with `--bbox`: row-group selections intersect and
+    /// the per-feature filters both apply.
+    #[test]
+    fn attribute_filter_composes_with_bbox() {
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        write_multi_rg_attr_input(tin.path(), &attr_rows());
+
+        for streaming in [true, false] {
+            let tout = tempfile::NamedTempFile::new().unwrap();
+            let opts = ConvertOptions {
+                // bbox keeps (10,10) and (20,20); filter keeps 0.9 and 0.85;
+                // combined with bbox tightened to exclude (20,20): only id=1.
+                bbox: Some([9.0, 9.0, 11.0, 11.0]),
+                filter: Some("confidence > 0.8".to_string()),
+                streaming,
+                ..attr_opts()
+            };
+            let report = convert_to_overviews(tin.path(), tout.path(), &opts).unwrap();
+            assert_eq!(
+                report.row_groups_read, 1,
+                "bbox+filter selection must intersect (streaming={streaming})"
+            );
+            let ids = read_all_ids(&OverviewReader::open(tout.path()).unwrap());
+            assert_eq!(ids, vec![1], "streaming={streaming}");
+        }
+    }
+
+    /// String equality / IN, IS NULL, and OR-composition semantics.
+    #[test]
+    fn attribute_filter_string_in_and_null_semantics() {
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        write_multi_rg_attr_input(tin.path(), &attr_rows());
+
+        for streaming in [true, false] {
+            // IN over strings.
+            let tout = tempfile::NamedTempFile::new().unwrap();
+            let opts = ConvertOptions {
+                filter: Some("crop IN ('corn', 'rice')".to_string()),
+                streaming,
+                ..attr_opts()
+            };
+            convert_to_overviews(tin.path(), tout.path(), &opts).unwrap();
+            let ids = read_all_ids(&OverviewReader::open(tout.path()).unwrap());
+            assert_eq!(ids, vec![1, 3], "IN (streaming={streaming})");
+
+            // IS NULL keeps exactly the null-confidence row.
+            let tout = tempfile::NamedTempFile::new().unwrap();
+            let opts = ConvertOptions {
+                filter: Some("confidence IS NULL".to_string()),
+                streaming,
+                ..attr_opts()
+            };
+            convert_to_overviews(tin.path(), tout.path(), &opts).unwrap();
+            let ids = read_all_ids(&OverviewReader::open(tout.path()).unwrap());
+            assert_eq!(ids, vec![3], "IS NULL (streaming={streaming})");
+
+            // Three-valued OR: null confidence is rescued by the crop arm.
+            let tout = tempfile::NamedTempFile::new().unwrap();
+            let opts = ConvertOptions {
+                filter: Some("confidence > 0.8 OR crop = 'rice'".to_string()),
+                streaming,
+                ..attr_opts()
+            };
+            convert_to_overviews(tin.path(), tout.path(), &opts).unwrap();
+            let ids = read_all_ids(&OverviewReader::open(tout.path()).unwrap());
+            assert_eq!(ids, vec![1, 2, 3], "OR (streaming={streaming})");
+        }
+    }
+
+    /// Filter errors: bad syntax fails in validation, an unknown column and
+    /// a type mismatch fail at bind — all before any output is written.
+    #[test]
+    fn attribute_filter_error_paths() {
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        write_multi_rg_attr_input(tin.path(), &attr_rows());
+
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        let bad_syntax = ConvertOptions {
+            filter: Some("confidence >".to_string()),
+            ..attr_opts()
+        };
+        let err = convert_to_overviews(tin.path(), tout.path(), &bad_syntax).unwrap_err();
+        assert!(matches!(err, ConvertError::Filter(_)), "got {err:?}");
+
+        let unknown = ConvertOptions {
+            filter: Some("nope = 1".to_string()),
+            ..attr_opts()
+        };
+        let err = convert_to_overviews(tin.path(), tout.path(), &unknown).unwrap_err();
+        assert!(
+            matches!(err, ConvertError::Filter(_)) && err.to_string().contains("unknown column"),
+            "got {err:?}"
+        );
+
+        let mismatch = ConvertOptions {
+            filter: Some("crop > 3".to_string()),
+            ..attr_opts()
+        };
+        let err = convert_to_overviews(tin.path(), tout.path(), &mismatch).unwrap_err();
+        assert!(matches!(err, ConvertError::Filter(_)), "got {err:?}");
+
+        // A filter matching nothing surfaces as NoData, like an empty bbox.
+        let none = ConvertOptions {
+            filter: Some("confidence > 99".to_string()),
+            ..attr_opts()
+        };
+        let err = convert_to_overviews(tin.path(), tout.path(), &none).unwrap_err();
+        assert!(matches!(err, ConvertError::NoData), "got {err:?}");
+    }
+
+    // ========================================================================
     // Remote input tests (#210)
     // ========================================================================
 
@@ -6030,6 +6347,54 @@ mod tests {
         #[test]
         fn bbox_extract_in_memory_fetches_only_selected_row_groups() {
             assert_bbox_extract_fetches_only_selected(false);
+        }
+
+        /// The #315 headline property: a `--filter` convert over a remote
+        /// file must fetch data pages ONLY from the row groups whose column
+        /// statistics permit a match — pruned groups' byte ranges are never
+        /// downloaded at all (fetched-bytes reduction).
+        #[test]
+        fn attribute_filter_remote_fetches_only_matching_row_groups() {
+            // 4 single-row row groups; `confidence > 0.8` stats-selects only
+            // rg 1 (0.9) and rg 2 (0.85); rg 0 (0.1) and rg 3 (null) prune.
+            let tin = tempfile::NamedTempFile::new().unwrap();
+            write_multi_rg_attr_input(tin.path(), &attr_rows());
+            let bytes = std::fs::read(tin.path()).unwrap();
+            let spans = row_group_spans(&bytes);
+            assert_eq!(spans.len(), 4);
+
+            let source = test_memory_source(bytes, "attrs.parquet");
+            let tout = tempfile::NamedTempFile::new().unwrap();
+            let opts = ConvertOptions {
+                filter: Some("confidence > 0.8".to_string()),
+                ..attr_opts()
+            };
+            let report = convert_to_overviews_source(&source, tout.path(), &opts).unwrap();
+
+            assert_eq!(report.row_groups_total, 4);
+            assert_eq!(report.row_groups_read, 2, "filter pushdown must fire");
+            let ids = read_all_ids(&OverviewReader::open(tout.path()).unwrap());
+            assert_eq!(ids, vec![1, 2]);
+
+            // No fetched range may touch a pruned row group's data pages.
+            let fetched = source.fetched_ranges().unwrap();
+            assert!(!fetched.is_empty());
+            for (i, span) in spans.iter().enumerate() {
+                if i == 1 || i == 2 {
+                    continue;
+                }
+                for r in &fetched {
+                    assert!(
+                        r.end <= span.start || r.start >= span.end,
+                        "fetched range {r:?} overlaps PRUNED row group {i} ({span:?})"
+                    );
+                }
+            }
+            let stats = report.remote_fetch.expect("remote stats in report");
+            assert!(
+                stats.bytes_fetched < stats.object_size,
+                "filter extract must move fewer bytes than the object: {stats:?}"
+            );
         }
 
         /// A full (no-bbox) remote conversion must produce the same result as

--- a/crates/core/src/overview/filter.rs
+++ b/crates/core/src/overview/filter.rs
@@ -1,0 +1,1594 @@
+//! Attribute (row) filtering — `--filter` / `--where` (#315).
+//!
+//! A small SQL-WHERE-style predicate over the input's property columns,
+//! evaluated during the pass-1 scan so it composes with `--bbox` and feeds
+//! the same downstream pipeline: a row the predicate does not accept simply
+//! never produces an [`AssignFeature`], exactly like a bbox miss.
+//!
+//! # Grammar (hand-rolled recursive descent — no new dependencies)
+//!
+//! ```text
+//! expr      := or_expr
+//! or_expr   := and_expr ( OR and_expr )*
+//! and_expr  := unary ( AND unary )*
+//! unary     := NOT unary | '(' expr ')' | predicate
+//! predicate := column cmp_op literal
+//!            | column [NOT] IN '(' literal ( ',' literal )* ')'
+//!            | column IS [NOT] NULL
+//! cmp_op    := '=' | '==' | '!=' | '<>' | '<' | '<=' | '>' | '>='
+//! column    := bare identifier | "double-quoted identifier"
+//! literal   := number | 'single-quoted string' | TRUE | FALSE
+//! ```
+//!
+//! Keywords are case-insensitive. The column must be on the left-hand side
+//! of a comparison. String literals escape an embedded quote by doubling it
+//! (`'it''s'`). `= NULL` is rejected with a hint to use `IS NULL`.
+//!
+//! # Null semantics (SQL three-valued logic)
+//!
+//! Comparisons and `IN` over a NULL value yield UNKNOWN, `AND`/`OR`/`NOT`
+//! combine with Kleene logic, and a row is kept only when the whole
+//! expression evaluates to TRUE — so `confidence > 0.8` drops null-confidence
+//! rows, and `NOT (confidence > 0.8)` drops them too (UNKNOWN, not TRUE).
+//! `IS NULL` / `IS NOT NULL` are the explicit null tests and always yield
+//! TRUE/FALSE.
+//!
+//! # Row-group statistics pushdown
+//!
+//! [`BoundFilter::select_row_groups`] prunes input row groups whose parquet
+//! column chunk statistics (min/max/null-count) prove the predicate cannot
+//! match any row — footer-only, no data pages read, which on remote input
+//! means the pruned byte ranges are never fetched. The test is conservative:
+//! missing or non-prunable statistics (and every `NOT (...)` subtree) keep
+//! the row group, and the exact per-row evaluation in pass 1 guarantees
+//! identical output either way. Statistics min/max are valid bounds even
+//! when writers truncate them, so bound-based pruning stays correct.
+//!
+//! Numeric comparisons are performed in `f64` (matching the ranking path's
+//! [`extract_sort_keys`]); Int64 statistics outside the exact-`f64` range
+//! (|v| >= 2^53) are widened before pruning so rounding can never prune a
+//! matching row group.
+
+use std::collections::HashMap;
+
+use arrow_array::cast::AsArray;
+use arrow_array::{Array, RecordBatch};
+use arrow_schema::{DataType, Schema};
+use parquet::file::metadata::{ParquetMetaData, RowGroupMetaData};
+use parquet::file::statistics::Statistics;
+
+use super::convert::extract_sort_keys;
+
+/// Errors from parsing or binding a `--filter` expression.
+#[derive(Debug, thiserror::Error)]
+pub enum FilterError {
+    /// The expression source failed to parse.
+    #[error("invalid --filter expression: {0}")]
+    Parse(String),
+    /// The expression references a column absent from the input schema.
+    #[error("--filter references unknown column {name:?} (input columns: {available})")]
+    UnknownColumn {
+        /// The unresolved column name.
+        name: String,
+        /// Comma-joined available column names, for the error message.
+        available: String,
+    },
+    /// The referenced column has a type the filter cannot evaluate.
+    #[error(
+        "--filter column {name:?} has unsupported type {data_type} \
+         (supported: numeric, string, boolean)"
+    )]
+    UnsupportedColumnType {
+        /// The column name.
+        name: String,
+        /// The Arrow data type found.
+        data_type: String,
+    },
+    /// A literal's type does not match the column's type.
+    #[error("--filter: cannot compare {kind} column {name:?} to {literal}")]
+    TypeMismatch {
+        /// The column name.
+        name: String,
+        /// The column kind ("numeric" / "string" / "boolean").
+        kind: &'static str,
+        /// Description of the offending literal.
+        literal: String,
+    },
+    /// An ordering comparison (`<`, `<=`, `>`, `>=`) on a boolean column.
+    #[error("--filter: ordering comparison on boolean column {name:?} is not supported")]
+    BooleanOrdering {
+        /// The column name.
+        name: String,
+    },
+}
+
+/// A comparison operator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CmpOp {
+    /// `=` / `==`
+    Eq,
+    /// `!=` / `<>`
+    Ne,
+    /// `<`
+    Lt,
+    /// `<=`
+    Le,
+    /// `>`
+    Gt,
+    /// `>=`
+    Ge,
+}
+
+/// A literal value in a filter expression.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Literal {
+    /// A numeric literal (all numerics are `f64`).
+    Number(f64),
+    /// A single-quoted string literal.
+    String(String),
+    /// `TRUE` / `FALSE`.
+    Bool(bool),
+}
+
+impl Literal {
+    fn describe(&self) -> String {
+        match self {
+            Literal::Number(v) => format!("number {v}"),
+            Literal::String(s) => format!("string {s:?}"),
+            Literal::Bool(b) => format!("boolean {b}"),
+        }
+    }
+}
+
+/// A parsed (unbound) filter expression AST.
+#[derive(Debug, Clone, PartialEq)]
+pub enum FilterExpr {
+    /// `column op literal`
+    Compare {
+        /// Left-hand column name.
+        column: String,
+        /// Comparison operator.
+        op: CmpOp,
+        /// Right-hand literal.
+        value: Literal,
+    },
+    /// `column [NOT] IN (l1, l2, ...)`
+    In {
+        /// Column name.
+        column: String,
+        /// The literal list (non-empty).
+        values: Vec<Literal>,
+        /// `NOT IN` when true.
+        negated: bool,
+    },
+    /// `column IS [NOT] NULL`
+    IsNull {
+        /// Column name.
+        column: String,
+        /// `IS NOT NULL` when true.
+        negated: bool,
+    },
+    /// `NOT expr`
+    Not(Box<FilterExpr>),
+    /// `a AND b`
+    And(Box<FilterExpr>, Box<FilterExpr>),
+    /// `a OR b`
+    Or(Box<FilterExpr>, Box<FilterExpr>),
+}
+
+/// Parse a filter expression source string into a [`FilterExpr`].
+pub fn parse_filter(src: &str) -> Result<FilterExpr, FilterError> {
+    let tokens = tokenize(src)?;
+    let mut p = Parser { tokens, pos: 0 };
+    let expr = p.parse_or()?;
+    if p.pos != p.tokens.len() {
+        return Err(FilterError::Parse(format!(
+            "unexpected trailing input at {:?}",
+            p.peek_desc()
+        )));
+    }
+    Ok(expr)
+}
+
+// ---------------------------------------------------------------------------
+// Tokenizer
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq)]
+enum Token {
+    Ident(String),
+    Number(f64),
+    Str(String),
+    LParen,
+    RParen,
+    Comma,
+    Op(CmpOp),
+    And,
+    Or,
+    Not,
+    In,
+    Is,
+    Null,
+    True,
+    False,
+}
+
+fn tokenize(src: &str) -> Result<Vec<Token>, FilterError> {
+    let mut out = Vec::new();
+    let b = src.as_bytes();
+    let mut i = 0usize;
+    while i < b.len() {
+        let c = b[i] as char;
+        match c {
+            ' ' | '\t' | '\r' | '\n' => i += 1,
+            '(' => {
+                out.push(Token::LParen);
+                i += 1;
+            }
+            ')' => {
+                out.push(Token::RParen);
+                i += 1;
+            }
+            ',' => {
+                out.push(Token::Comma);
+                i += 1;
+            }
+            '=' => {
+                i += if b.get(i + 1) == Some(&b'=') { 2 } else { 1 };
+                out.push(Token::Op(CmpOp::Eq));
+            }
+            '!' => {
+                if b.get(i + 1) == Some(&b'=') {
+                    out.push(Token::Op(CmpOp::Ne));
+                    i += 2;
+                } else {
+                    return Err(FilterError::Parse(
+                        "'!' must be followed by '=' (use NOT for negation)".into(),
+                    ));
+                }
+            }
+            '<' => match b.get(i + 1) {
+                Some(&b'=') => {
+                    out.push(Token::Op(CmpOp::Le));
+                    i += 2;
+                }
+                Some(&b'>') => {
+                    out.push(Token::Op(CmpOp::Ne));
+                    i += 2;
+                }
+                _ => {
+                    out.push(Token::Op(CmpOp::Lt));
+                    i += 1;
+                }
+            },
+            '>' => {
+                if b.get(i + 1) == Some(&b'=') {
+                    out.push(Token::Op(CmpOp::Ge));
+                    i += 2;
+                } else {
+                    out.push(Token::Op(CmpOp::Gt));
+                    i += 1;
+                }
+            }
+            '\'' => {
+                // Single-quoted string; '' escapes an embedded quote.
+                let mut s = String::new();
+                i += 1;
+                loop {
+                    match b.get(i) {
+                        None => {
+                            return Err(FilterError::Parse("unterminated string literal".into()))
+                        }
+                        Some(&b'\'') => {
+                            if b.get(i + 1) == Some(&b'\'') {
+                                s.push('\'');
+                                i += 2;
+                            } else {
+                                i += 1;
+                                break;
+                            }
+                        }
+                        Some(_) => {
+                            // Advance by whole UTF-8 chars.
+                            let ch = src[i..].chars().next().expect("in-bounds char");
+                            s.push(ch);
+                            i += ch.len_utf8();
+                        }
+                    }
+                }
+                out.push(Token::Str(s));
+            }
+            '"' => {
+                // Double-quoted identifier; "" escapes an embedded quote.
+                let mut s = String::new();
+                i += 1;
+                loop {
+                    match b.get(i) {
+                        None => {
+                            return Err(FilterError::Parse("unterminated quoted identifier".into()))
+                        }
+                        Some(&b'"') => {
+                            if b.get(i + 1) == Some(&b'"') {
+                                s.push('"');
+                                i += 2;
+                            } else {
+                                i += 1;
+                                break;
+                            }
+                        }
+                        Some(_) => {
+                            let ch = src[i..].chars().next().expect("in-bounds char");
+                            s.push(ch);
+                            i += ch.len_utf8();
+                        }
+                    }
+                }
+                out.push(Token::Ident(s));
+            }
+            '-' | '+' | '0'..='9' | '.' => {
+                let start = i;
+                i += 1; // sign or first digit
+                while i < b.len() && matches!(b[i] as char, '0'..='9' | '.' | 'e' | 'E') {
+                    // Exponent sign: 1e-3
+                    if matches!(b[i] as char, 'e' | 'E')
+                        && matches!(b.get(i + 1), Some(&b'-' | &b'+'))
+                    {
+                        i += 1;
+                    }
+                    i += 1;
+                }
+                let text = &src[start..i];
+                let v: f64 = text
+                    .parse()
+                    .map_err(|_| FilterError::Parse(format!("invalid number literal {text:?}")))?;
+                out.push(Token::Number(v));
+            }
+            c if c.is_ascii_alphabetic() || c == '_' => {
+                let start = i;
+                while i < b.len() && ((b[i] as char).is_ascii_alphanumeric() || b[i] == b'_') {
+                    i += 1;
+                }
+                let word = &src[start..i];
+                out.push(match word.to_ascii_uppercase().as_str() {
+                    "AND" => Token::And,
+                    "OR" => Token::Or,
+                    "NOT" => Token::Not,
+                    "IN" => Token::In,
+                    "IS" => Token::Is,
+                    "NULL" => Token::Null,
+                    "TRUE" => Token::True,
+                    "FALSE" => Token::False,
+                    _ => Token::Ident(word.to_string()),
+                });
+            }
+            other => {
+                return Err(FilterError::Parse(format!(
+                    "unexpected character {other:?}"
+                )))
+            }
+        }
+    }
+    if out.is_empty() {
+        return Err(FilterError::Parse("empty expression".into()));
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+struct Parser {
+    tokens: Vec<Token>,
+    pos: usize,
+}
+
+impl Parser {
+    fn peek(&self) -> Option<&Token> {
+        self.tokens.get(self.pos)
+    }
+
+    fn peek_desc(&self) -> String {
+        match self.peek() {
+            Some(t) => format!("{t:?}"),
+            None => "end of input".to_string(),
+        }
+    }
+
+    fn eat(&mut self, t: &Token) -> bool {
+        if self.peek() == Some(t) {
+            self.pos += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn expect(&mut self, t: Token, what: &str) -> Result<(), FilterError> {
+        if self.eat(&t) {
+            Ok(())
+        } else {
+            Err(FilterError::Parse(format!(
+                "expected {what}, found {}",
+                self.peek_desc()
+            )))
+        }
+    }
+
+    fn parse_or(&mut self) -> Result<FilterExpr, FilterError> {
+        let mut left = self.parse_and()?;
+        while self.eat(&Token::Or) {
+            let right = self.parse_and()?;
+            left = FilterExpr::Or(Box::new(left), Box::new(right));
+        }
+        Ok(left)
+    }
+
+    fn parse_and(&mut self) -> Result<FilterExpr, FilterError> {
+        let mut left = self.parse_unary()?;
+        while self.eat(&Token::And) {
+            let right = self.parse_unary()?;
+            left = FilterExpr::And(Box::new(left), Box::new(right));
+        }
+        Ok(left)
+    }
+
+    fn parse_unary(&mut self) -> Result<FilterExpr, FilterError> {
+        if self.eat(&Token::Not) {
+            return Ok(FilterExpr::Not(Box::new(self.parse_unary()?)));
+        }
+        if self.eat(&Token::LParen) {
+            let e = self.parse_or()?;
+            self.expect(Token::RParen, "')'")?;
+            return Ok(e);
+        }
+        self.parse_predicate()
+    }
+
+    fn parse_predicate(&mut self) -> Result<FilterExpr, FilterError> {
+        let column = match self.peek().cloned() {
+            Some(Token::Ident(name)) => {
+                self.pos += 1;
+                name
+            }
+            _ => {
+                return Err(FilterError::Parse(format!(
+                    "expected a column name, found {}",
+                    self.peek_desc()
+                )))
+            }
+        };
+        match self.peek().cloned() {
+            Some(Token::Op(op)) => {
+                self.pos += 1;
+                let value = self.parse_literal()?;
+                Ok(FilterExpr::Compare { column, op, value })
+            }
+            Some(Token::In) => {
+                self.pos += 1;
+                self.parse_in_list(column, false)
+            }
+            Some(Token::Not) => {
+                self.pos += 1;
+                self.expect(Token::In, "IN after NOT")?;
+                self.parse_in_list(column, true)
+            }
+            Some(Token::Is) => {
+                self.pos += 1;
+                let negated = self.eat(&Token::Not);
+                self.expect(Token::Null, "NULL after IS")?;
+                Ok(FilterExpr::IsNull { column, negated })
+            }
+            _ => Err(FilterError::Parse(format!(
+                "expected a comparison operator, IN, or IS after column \
+                 {column:?}, found {}",
+                self.peek_desc()
+            ))),
+        }
+    }
+
+    fn parse_in_list(&mut self, column: String, negated: bool) -> Result<FilterExpr, FilterError> {
+        self.expect(Token::LParen, "'(' after IN")?;
+        let mut values = vec![self.parse_literal()?];
+        while self.eat(&Token::Comma) {
+            values.push(self.parse_literal()?);
+        }
+        self.expect(Token::RParen, "')' closing the IN list")?;
+        Ok(FilterExpr::In {
+            column,
+            values,
+            negated,
+        })
+    }
+
+    fn parse_literal(&mut self) -> Result<Literal, FilterError> {
+        match self.peek().cloned() {
+            Some(Token::Number(v)) => {
+                self.pos += 1;
+                Ok(Literal::Number(v))
+            }
+            Some(Token::Str(s)) => {
+                self.pos += 1;
+                Ok(Literal::String(s))
+            }
+            Some(Token::True) => {
+                self.pos += 1;
+                Ok(Literal::Bool(true))
+            }
+            Some(Token::False) => {
+                self.pos += 1;
+                Ok(Literal::Bool(false))
+            }
+            Some(Token::Null) => Err(FilterError::Parse(
+                "NULL is not a comparable value; use IS NULL / IS NOT NULL".into(),
+            )),
+            _ => Err(FilterError::Parse(format!(
+                "expected a literal (number, 'string', TRUE, FALSE), found {}",
+                self.peek_desc()
+            ))),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Binding
+// ---------------------------------------------------------------------------
+
+/// The evaluation type class of a filter column.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ColKind {
+    Num,
+    Str,
+    Bool,
+}
+
+impl ColKind {
+    fn name(self) -> &'static str {
+        match self {
+            ColKind::Num => "numeric",
+            ColKind::Str => "string",
+            ColKind::Bool => "boolean",
+        }
+    }
+}
+
+fn column_kind(dt: &DataType) -> Option<ColKind> {
+    match dt {
+        DataType::Int8
+        | DataType::Int16
+        | DataType::Int32
+        | DataType::Int64
+        | DataType::UInt8
+        | DataType::UInt16
+        | DataType::UInt32
+        | DataType::UInt64
+        | DataType::Float32
+        | DataType::Float64 => Some(ColKind::Num),
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Some(ColKind::Str),
+        DataType::Boolean => Some(ColKind::Bool),
+        DataType::Dictionary(_, inner) => match inner.as_ref() {
+            DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Some(ColKind::Str),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// One bound column reference: index into the (possibly reserved-renamed)
+/// input schema for evaluation, plus the ORIGINAL parquet column name for
+/// statistics pushdown (the file's footer always carries pre-rename names).
+#[derive(Debug, Clone)]
+struct BoundCol {
+    idx: usize,
+    parquet_name: String,
+    kind: ColKind,
+}
+
+#[derive(Debug, Clone)]
+enum BoundExpr {
+    Compare {
+        col: BoundCol,
+        op: CmpOp,
+        value: Literal,
+    },
+    In {
+        col: BoundCol,
+        values: Vec<Literal>,
+        negated: bool,
+    },
+    IsNull {
+        col: BoundCol,
+        negated: bool,
+    },
+    Not(Box<BoundExpr>),
+    And(Box<BoundExpr>, Box<BoundExpr>),
+    Or(Box<BoundExpr>, Box<BoundExpr>),
+}
+
+/// A filter expression bound to an input schema: column names resolved to
+/// indices, literal types checked against column types. Ready for per-batch
+/// evaluation ([`Self::eval_mask`]) and row-group statistics pushdown
+/// ([`Self::select_row_groups`]).
+#[derive(Debug, Clone)]
+pub struct BoundFilter {
+    expr: BoundExpr,
+    /// Referenced schema column indices, sorted + deduplicated.
+    columns: Vec<usize>,
+}
+
+impl BoundFilter {
+    /// Bind `expr` against `schema`. `renames` is the reserved-column rename
+    /// list from `resolve_reserved_column_collisions` (#288), as `(old, new)`
+    /// pairs: a filter column matching an OLD (input-file) name resolves to
+    /// the renamed schema column, while pushdown keeps addressing the parquet
+    /// footer by the old name.
+    pub fn bind(
+        expr: &FilterExpr,
+        schema: &Schema,
+        renames: &[(String, String)],
+    ) -> Result<Self, FilterError> {
+        let mut columns = Vec::new();
+        let bound = bind_expr(expr, schema, renames, &mut columns)?;
+        columns.sort_unstable();
+        columns.dedup();
+        Ok(BoundFilter {
+            expr: bound,
+            columns,
+        })
+    }
+
+    /// Schema column indices the filter reads (for pass-1 projection).
+    pub fn columns(&self) -> &[usize] {
+        &self.columns
+    }
+
+    /// Evaluate the filter over `batch`, producing one tri-state result per
+    /// row (`Some(true)` keep / `Some(false)` drop / `None` unknown — dropped
+    /// at the top level per SQL semantics). `proj` maps a schema column index
+    /// to the batch's column index (identity when the batch carries the full
+    /// schema; the pass-1 projection mapping otherwise).
+    pub fn eval_mask(
+        &self,
+        batch: &RecordBatch,
+        proj: &dyn Fn(usize) -> usize,
+    ) -> Vec<Option<bool>> {
+        eval_expr(&self.expr, batch, proj)
+    }
+
+    /// Row groups of `metadata` the filter could match, by column chunk
+    /// statistics — the pruning complement is proven row-group-free of
+    /// matches. Conservative: missing statistics keep the row group.
+    pub fn select_row_groups(&self, metadata: &ParquetMetaData) -> Vec<usize> {
+        // Map top-level primitive parquet column name → leaf chunk index.
+        let mut chunk_idx: HashMap<&str, usize> = HashMap::new();
+        for (i, col) in metadata
+            .file_metadata()
+            .schema_descr()
+            .columns()
+            .iter()
+            .enumerate()
+        {
+            let parts = col.path().parts();
+            if parts.len() == 1 {
+                chunk_idx.insert(parts[0].as_str(), i);
+            }
+        }
+        (0..metadata.num_row_groups())
+            .filter(|&i| rg_can_match(&self.expr, metadata.row_group(i), &chunk_idx))
+            .collect()
+    }
+}
+
+fn bind_expr(
+    expr: &FilterExpr,
+    schema: &Schema,
+    renames: &[(String, String)],
+    columns: &mut Vec<usize>,
+) -> Result<BoundExpr, FilterError> {
+    let bind_col = |name: &str, columns: &mut Vec<usize>| -> Result<BoundCol, FilterError> {
+        // A filter naming a reserved-renamed input column (#288) follows the
+        // rename for schema resolution; pushdown keeps the file-side name.
+        let (schema_name, parquet_name) = match renames
+            .iter()
+            .find(|(old, _)| name.eq_ignore_ascii_case(old))
+        {
+            Some((old, new)) => (new.clone(), old.clone()),
+            None => (name.to_string(), name.to_string()),
+        };
+        // Exact match first, then a unique case-insensitive fallback.
+        let idx = schema.index_of(&schema_name).ok().or_else(|| {
+            let mut found = None;
+            for (i, f) in schema.fields().iter().enumerate() {
+                if f.name().eq_ignore_ascii_case(&schema_name) {
+                    if found.is_some() {
+                        return None; // ambiguous
+                    }
+                    found = Some(i);
+                }
+            }
+            found
+        });
+        let Some(idx) = idx else {
+            let available = schema
+                .fields()
+                .iter()
+                .map(|f| f.name().as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(FilterError::UnknownColumn {
+                name: name.to_string(),
+                available,
+            });
+        };
+        let dt = schema.field(idx).data_type();
+        let Some(kind) = column_kind(dt) else {
+            return Err(FilterError::UnsupportedColumnType {
+                name: name.to_string(),
+                data_type: format!("{dt}"),
+            });
+        };
+        columns.push(idx);
+        Ok(BoundCol {
+            idx,
+            parquet_name,
+            kind,
+        })
+    };
+
+    let check_literal = |col: &BoundCol, lit: &Literal| -> Result<(), FilterError> {
+        let ok = matches!(
+            (col.kind, lit),
+            (ColKind::Num, Literal::Number(_))
+                | (ColKind::Str, Literal::String(_))
+                | (ColKind::Bool, Literal::Bool(_))
+        );
+        if ok {
+            Ok(())
+        } else {
+            Err(FilterError::TypeMismatch {
+                name: col.parquet_name.clone(),
+                kind: col.kind.name(),
+                literal: lit.describe(),
+            })
+        }
+    };
+
+    match expr {
+        FilterExpr::Compare { column, op, value } => {
+            let col = bind_col(column, columns)?;
+            check_literal(&col, value)?;
+            if col.kind == ColKind::Bool && !matches!(op, CmpOp::Eq | CmpOp::Ne) {
+                return Err(FilterError::BooleanOrdering {
+                    name: col.parquet_name,
+                });
+            }
+            Ok(BoundExpr::Compare {
+                col,
+                op: *op,
+                value: value.clone(),
+            })
+        }
+        FilterExpr::In {
+            column,
+            values,
+            negated,
+        } => {
+            let col = bind_col(column, columns)?;
+            for v in values {
+                check_literal(&col, v)?;
+            }
+            Ok(BoundExpr::In {
+                col,
+                values: values.clone(),
+                negated: *negated,
+            })
+        }
+        FilterExpr::IsNull { column, negated } => {
+            let col = bind_col(column, columns)?;
+            Ok(BoundExpr::IsNull {
+                col,
+                negated: *negated,
+            })
+        }
+        FilterExpr::Not(inner) => Ok(BoundExpr::Not(Box::new(bind_expr(
+            inner, schema, renames, columns,
+        )?))),
+        FilterExpr::And(a, b) => Ok(BoundExpr::And(
+            Box::new(bind_expr(a, schema, renames, columns)?),
+            Box::new(bind_expr(b, schema, renames, columns)?),
+        )),
+        FilterExpr::Or(a, b) => Ok(BoundExpr::Or(
+            Box::new(bind_expr(a, schema, renames, columns)?),
+            Box::new(bind_expr(b, schema, renames, columns)?),
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Evaluation (per-batch, three-valued)
+// ---------------------------------------------------------------------------
+
+fn cmp_num(v: f64, op: CmpOp, lit: f64) -> bool {
+    match op {
+        CmpOp::Eq => v == lit,
+        CmpOp::Ne => v != lit,
+        CmpOp::Lt => v < lit,
+        CmpOp::Le => v <= lit,
+        CmpOp::Gt => v > lit,
+        CmpOp::Ge => v >= lit,
+    }
+}
+
+fn cmp_ord<T: Ord + ?Sized>(v: &T, op: CmpOp, lit: &T) -> bool {
+    match op {
+        CmpOp::Eq => v == lit,
+        CmpOp::Ne => v != lit,
+        CmpOp::Lt => v < lit,
+        CmpOp::Le => v <= lit,
+        CmpOp::Gt => v > lit,
+        CmpOp::Ge => v >= lit,
+    }
+}
+
+/// Apply `f` to each row of a string-kinded column (Utf8 / LargeUtf8 /
+/// Utf8View / dictionary-of-string), producing `None` for null rows.
+fn str_mask(col: &dyn Array, f: &dyn Fn(&str) -> bool) -> Vec<Option<bool>> {
+    let n = col.len();
+    match col.data_type() {
+        DataType::Utf8 => {
+            let a = col.as_string::<i32>();
+            (0..n)
+                .map(|i| (!a.is_null(i)).then(|| f(a.value(i))))
+                .collect()
+        }
+        DataType::LargeUtf8 => {
+            let a = col.as_string::<i64>();
+            (0..n)
+                .map(|i| (!a.is_null(i)).then(|| f(a.value(i))))
+                .collect()
+        }
+        DataType::Utf8View => {
+            let a = col.as_string_view();
+            (0..n)
+                .map(|i| (!a.is_null(i)).then(|| f(a.value(i))))
+                .collect()
+        }
+        DataType::Dictionary(_, _) => {
+            let Some(d) = col.as_any_dictionary_opt() else {
+                return vec![None; n];
+            };
+            let values = d.values();
+            let keys = d.normalized_keys();
+            (0..n)
+                .map(|i| {
+                    if col.is_null(i) {
+                        return None;
+                    }
+                    let k = keys[i];
+                    if values.is_null(k) {
+                        return None;
+                    }
+                    let s = match values.data_type() {
+                        DataType::Utf8 => values.as_string::<i32>().value(k),
+                        DataType::LargeUtf8 => values.as_string::<i64>().value(k),
+                        DataType::Utf8View => values.as_string_view().value(k),
+                        _ => return None,
+                    };
+                    Some(f(s))
+                })
+                .collect()
+        }
+        _ => vec![None; n],
+    }
+}
+
+fn eval_expr(
+    expr: &BoundExpr,
+    batch: &RecordBatch,
+    proj: &dyn Fn(usize) -> usize,
+) -> Vec<Option<bool>> {
+    match expr {
+        BoundExpr::Compare { col, op, value } => {
+            let arr = batch.column(proj(col.idx));
+            match (col.kind, value) {
+                (ColKind::Num, Literal::Number(lit)) => extract_sort_keys(arr.as_ref())
+                    .into_iter()
+                    .map(|v| v.map(|v| cmp_num(v, *op, *lit)))
+                    .collect(),
+                (ColKind::Str, Literal::String(lit)) => {
+                    str_mask(arr.as_ref(), &|s| cmp_ord(s, *op, lit.as_str()))
+                }
+                (ColKind::Bool, Literal::Bool(lit)) => {
+                    let a = arr.as_boolean();
+                    (0..a.len())
+                        .map(|i| (!a.is_null(i)).then(|| cmp_ord(&a.value(i), *op, lit)))
+                        .collect()
+                }
+                // Bind-time type checking makes this unreachable.
+                _ => vec![None; batch.num_rows()],
+            }
+        }
+        BoundExpr::In {
+            col,
+            values,
+            negated,
+        } => {
+            let arr = batch.column(proj(col.idx));
+            let member: Vec<Option<bool>> = match col.kind {
+                ColKind::Num => {
+                    let lits: Vec<f64> = values
+                        .iter()
+                        .filter_map(|l| match l {
+                            Literal::Number(v) => Some(*v),
+                            _ => None,
+                        })
+                        .collect();
+                    extract_sort_keys(arr.as_ref())
+                        .into_iter()
+                        .map(|v| v.map(|v| lits.contains(&v)))
+                        .collect()
+                }
+                ColKind::Str => {
+                    let lits: Vec<&str> = values
+                        .iter()
+                        .filter_map(|l| match l {
+                            Literal::String(s) => Some(s.as_str()),
+                            _ => None,
+                        })
+                        .collect();
+                    str_mask(arr.as_ref(), &|s| lits.contains(&s))
+                }
+                ColKind::Bool => {
+                    let lits: Vec<bool> = values
+                        .iter()
+                        .filter_map(|l| match l {
+                            Literal::Bool(b) => Some(*b),
+                            _ => None,
+                        })
+                        .collect();
+                    let a = arr.as_boolean();
+                    (0..a.len())
+                        .map(|i| (!a.is_null(i)).then(|| lits.contains(&a.value(i))))
+                        .collect()
+                }
+            };
+            if *negated {
+                member.into_iter().map(|m| m.map(|b| !b)).collect()
+            } else {
+                member
+            }
+        }
+        BoundExpr::IsNull { col, negated } => {
+            let arr = batch.column(proj(col.idx));
+            (0..arr.len())
+                .map(|i| Some(arr.is_null(i) != *negated))
+                .collect()
+        }
+        // Kleene: NOT UNKNOWN = UNKNOWN.
+        BoundExpr::Not(inner) => eval_expr(inner, batch, proj)
+            .into_iter()
+            .map(|v| v.map(|b| !b))
+            .collect(),
+        BoundExpr::And(a, b) => {
+            let va = eval_expr(a, batch, proj);
+            let vb = eval_expr(b, batch, proj);
+            va.into_iter()
+                .zip(vb)
+                .map(|(x, y)| match (x, y) {
+                    (Some(false), _) | (_, Some(false)) => Some(false),
+                    (Some(true), Some(true)) => Some(true),
+                    _ => None,
+                })
+                .collect()
+        }
+        BoundExpr::Or(a, b) => {
+            let va = eval_expr(a, batch, proj);
+            let vb = eval_expr(b, batch, proj);
+            va.into_iter()
+                .zip(vb)
+                .map(|(x, y)| match (x, y) {
+                    (Some(true), _) | (_, Some(true)) => Some(true),
+                    (Some(false), Some(false)) => Some(false),
+                    _ => None,
+                })
+                .collect()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Row-group statistics pushdown
+// ---------------------------------------------------------------------------
+
+/// Widen an `i64` statistic to a conservative `f64` bound: outside the exact
+/// range (|v| >= 2^53) rounding-to-nearest could tighten the interval, so the
+/// bound is pushed outward by 2 ulp-equivalents before pruning.
+fn widen_i64(v: i64, is_min: bool) -> f64 {
+    const EXACT: i64 = 1 << 53;
+    let f = v as f64;
+    if v.abs() < EXACT {
+        f
+    } else if is_min {
+        f - 2.0 * f.abs() * f64::EPSILON
+    } else {
+        f + 2.0 * f.abs() * f64::EPSILON
+    }
+}
+
+/// `(min, max)` of a numeric column chunk as `f64` bounds, when available.
+fn num_bounds(stats: &Statistics) -> Option<(f64, f64)> {
+    match stats {
+        Statistics::Int32(s) => Some((*s.min_opt()? as f64, *s.max_opt()? as f64)),
+        Statistics::Int64(s) => Some((
+            widen_i64(*s.min_opt()?, true),
+            widen_i64(*s.max_opt()?, false),
+        )),
+        Statistics::Float(s) => Some((*s.min_opt()? as f64, *s.max_opt()? as f64)),
+        Statistics::Double(s) => Some((*s.min_opt()?, *s.max_opt()?)),
+        _ => None,
+    }
+}
+
+/// `(min, max)` of a string column chunk, when available and valid UTF-8.
+/// Writer truncation keeps these valid bounds (a truncated max is adjusted
+/// upward), so bound-based pruning stays conservative.
+fn str_bounds(stats: &Statistics) -> Option<(&str, &str)> {
+    match stats {
+        Statistics::ByteArray(s) => Some((
+            std::str::from_utf8(s.min_opt()?.data()).ok()?,
+            std::str::from_utf8(s.max_opt()?.data()).ok()?,
+        )),
+        _ => None,
+    }
+}
+
+fn bool_bounds(stats: &Statistics) -> Option<(bool, bool)> {
+    match stats {
+        Statistics::Boolean(s) => Some((*s.min_opt()?, *s.max_opt()?)),
+        _ => None,
+    }
+}
+
+/// Could `min <= v <= max` hold for some v satisfying `v op lit`?
+fn range_can_match_num(min: f64, max: f64, op: CmpOp, lit: f64) -> bool {
+    match op {
+        CmpOp::Eq => min <= lit && lit <= max,
+        CmpOp::Ne => !(min == max && min == lit),
+        CmpOp::Lt => min < lit,
+        CmpOp::Le => min <= lit,
+        CmpOp::Gt => max > lit,
+        CmpOp::Ge => max >= lit,
+    }
+}
+
+fn range_can_match_ord<T: Ord + ?Sized>(min: &T, max: &T, op: CmpOp, lit: &T) -> bool {
+    match op {
+        CmpOp::Eq => min <= lit && lit <= max,
+        CmpOp::Ne => !(min == max && min == lit),
+        CmpOp::Lt => min < lit,
+        CmpOp::Le => min <= lit,
+        CmpOp::Gt => max > lit,
+        CmpOp::Ge => max >= lit,
+    }
+}
+
+/// Whether the row group could contain a row matching `expr`, judged by
+/// column chunk statistics alone. `true` = must read; `false` = provably no
+/// match (prune). Conservative in every uncertain case.
+fn rg_can_match(expr: &BoundExpr, rg: &RowGroupMetaData, chunk_idx: &HashMap<&str, usize>) -> bool {
+    // Statistics for a bound column's chunk, if locatable.
+    let stats_for = |col: &BoundCol| -> Option<&Statistics> {
+        let i = *chunk_idx.get(col.parquet_name.as_str())?;
+        rg.column(i).statistics()
+    };
+    // A comparison / IN only matches non-null values: an all-null chunk can
+    // never satisfy one.
+    let all_null = |col: &BoundCol| -> bool {
+        stats_for(col)
+            .and_then(|s| s.null_count_opt())
+            .is_some_and(|nc| nc == rg.num_rows() as u64)
+    };
+    let value_can_match = |col: &BoundCol, op: CmpOp, lit: &Literal| -> bool {
+        let Some(stats) = stats_for(col) else {
+            return true;
+        };
+        match lit {
+            Literal::Number(l) => match num_bounds(stats) {
+                Some((min, max)) => range_can_match_num(min, max, op, *l),
+                None => true,
+            },
+            Literal::String(l) => match str_bounds(stats) {
+                Some((min, max)) => range_can_match_ord(min, max, op, l.as_str()),
+                None => true,
+            },
+            Literal::Bool(l) => match bool_bounds(stats) {
+                Some((min, max)) => range_can_match_ord(&min, &max, op, l),
+                None => true,
+            },
+        }
+    };
+
+    match expr {
+        BoundExpr::Compare { col, op, value } => !all_null(col) && value_can_match(col, *op, value),
+        BoundExpr::In {
+            col,
+            values,
+            negated,
+        } => {
+            if all_null(col) {
+                return false;
+            }
+            if *negated {
+                // NOT IN can only be pruned when the chunk is constant AND
+                // that constant is in the list.
+                !values.iter().all(|v| {
+                    // v constant-excludes the chunk iff Ne can't match.
+                    !value_can_match(col, CmpOp::Ne, v)
+                })
+            } else {
+                values.iter().any(|v| value_can_match(col, CmpOp::Eq, v))
+            }
+        }
+        BoundExpr::IsNull { col, negated } => {
+            let Some(stats) = stats_for(col) else {
+                return true;
+            };
+            let Some(nc) = stats.null_count_opt() else {
+                return true;
+            };
+            if *negated {
+                // IS NOT NULL: prune only an all-null chunk.
+                nc < rg.num_rows() as u64
+            } else {
+                // IS NULL: prune a null-free chunk.
+                nc > 0
+            }
+        }
+        // `NOT (subtree)` cannot be inverted from a can-match bound
+        // conservatively — keep the row group; per-row eval decides.
+        BoundExpr::Not(_) => true,
+        BoundExpr::And(a, b) => rg_can_match(a, rg, chunk_idx) && rg_can_match(b, rg, chunk_idx),
+        BoundExpr::Or(a, b) => rg_can_match(a, rg, chunk_idx) || rg_can_match(b, rg, chunk_idx),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::{ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray};
+    use arrow_schema::Field;
+    use std::sync::Arc;
+
+    // ---- parser ----------------------------------------------------------
+
+    #[test]
+    fn parses_simple_comparison() {
+        let e = parse_filter("confidence > 0.8").unwrap();
+        assert_eq!(
+            e,
+            FilterExpr::Compare {
+                column: "confidence".into(),
+                op: CmpOp::Gt,
+                value: Literal::Number(0.8),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_all_comparison_operators() {
+        for (src, op) in [
+            ("x = 1", CmpOp::Eq),
+            ("x == 1", CmpOp::Eq),
+            ("x != 1", CmpOp::Ne),
+            ("x <> 1", CmpOp::Ne),
+            ("x < 1", CmpOp::Lt),
+            ("x <= 1", CmpOp::Le),
+            ("x > 1", CmpOp::Gt),
+            ("x >= 1", CmpOp::Ge),
+        ] {
+            let e = parse_filter(src).unwrap();
+            assert_eq!(
+                e,
+                FilterExpr::Compare {
+                    column: "x".into(),
+                    op,
+                    value: Literal::Number(1.0),
+                },
+                "source {src:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn parses_string_and_bool_and_negative_literals() {
+        assert_eq!(
+            parse_filter("name = 'it''s'").unwrap(),
+            FilterExpr::Compare {
+                column: "name".into(),
+                op: CmpOp::Eq,
+                value: Literal::String("it's".into()),
+            }
+        );
+        assert_eq!(
+            parse_filter("active = true").unwrap(),
+            FilterExpr::Compare {
+                column: "active".into(),
+                op: CmpOp::Eq,
+                value: Literal::Bool(true),
+            }
+        );
+        assert_eq!(
+            parse_filter("t <= -2.5e3").unwrap(),
+            FilterExpr::Compare {
+                column: "t".into(),
+                op: CmpOp::Le,
+                value: Literal::Number(-2500.0),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_in_not_in_is_null() {
+        assert_eq!(
+            parse_filter("crop IN ('soy', 'corn')").unwrap(),
+            FilterExpr::In {
+                column: "crop".into(),
+                values: vec![
+                    Literal::String("soy".into()),
+                    Literal::String("corn".into())
+                ],
+                negated: false,
+            }
+        );
+        assert_eq!(
+            parse_filter("id not in (1, 2, 3)").unwrap(),
+            FilterExpr::In {
+                column: "id".into(),
+                values: vec![
+                    Literal::Number(1.0),
+                    Literal::Number(2.0),
+                    Literal::Number(3.0)
+                ],
+                negated: true,
+            }
+        );
+        assert_eq!(
+            parse_filter("note IS NULL").unwrap(),
+            FilterExpr::IsNull {
+                column: "note".into(),
+                negated: false,
+            }
+        );
+        assert_eq!(
+            parse_filter("note is not null").unwrap(),
+            FilterExpr::IsNull {
+                column: "note".into(),
+                negated: true,
+            }
+        );
+    }
+
+    #[test]
+    fn precedence_or_below_and_below_not() {
+        // a = 1 OR b = 2 AND NOT c = 3  ==  a=1 OR (b=2 AND (NOT c=3))
+        let e = parse_filter("a = 1 OR b = 2 AND NOT c = 3").unwrap();
+        let FilterExpr::Or(left, right) = e else {
+            panic!("top must be OR, got {e:?}");
+        };
+        assert!(matches!(*left, FilterExpr::Compare { .. }));
+        let FilterExpr::And(al, ar) = *right else {
+            panic!("right of OR must be AND");
+        };
+        assert!(matches!(*al, FilterExpr::Compare { .. }));
+        assert!(matches!(*ar, FilterExpr::Not(_)));
+    }
+
+    #[test]
+    fn parses_parentheses_and_quoted_identifiers() {
+        let e = parse_filter("(a = 1 OR b = 2) AND \"weird col\" >= 7").unwrap();
+        let FilterExpr::And(l, r) = e else {
+            panic!("top must be AND");
+        };
+        assert!(matches!(*l, FilterExpr::Or(_, _)));
+        assert_eq!(
+            *r,
+            FilterExpr::Compare {
+                column: "weird col".into(),
+                op: CmpOp::Ge,
+                value: Literal::Number(7.0),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_errors() {
+        for bad in [
+            "",
+            "confidence >",
+            "confidence > > 1",
+            "x = NULL",
+            "IN (1)",
+            "x IN ()",
+            "x IN (1",
+            "(a = 1",
+            "a = 'unterminated",
+            "a = 1 extra",
+            "a ! 1",
+        ] {
+            assert!(
+                matches!(parse_filter(bad), Err(FilterError::Parse(_))),
+                "expected parse error for {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn null_literal_comparison_hints_is_null() {
+        let err = parse_filter("x = NULL").unwrap_err();
+        assert!(err.to_string().contains("IS NULL"), "got: {err}");
+    }
+
+    // ---- bind + eval -----------------------------------------------------
+
+    fn test_batch() -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("confidence", DataType::Float64, true),
+            Field::new("crop", DataType::Utf8, true),
+            Field::new("id", DataType::Int64, false),
+            Field::new("active", DataType::Boolean, true),
+        ]));
+        let confidence: ArrayRef = Arc::new(Float64Array::from(vec![
+            Some(0.9),
+            Some(0.5),
+            None,
+            Some(0.85),
+        ]));
+        let crop: ArrayRef = Arc::new(StringArray::from(vec![
+            Some("soy"),
+            Some("corn"),
+            Some("soy"),
+            None,
+        ]));
+        let id: ArrayRef = Arc::new(Int64Array::from(vec![0, 1, 2, 3]));
+        let active: ArrayRef = Arc::new(BooleanArray::from(vec![
+            Some(true),
+            Some(false),
+            None,
+            Some(true),
+        ]));
+        RecordBatch::try_new(schema, vec![confidence, crop, id, active]).unwrap()
+    }
+
+    fn eval(src: &str) -> Vec<Option<bool>> {
+        let batch = test_batch();
+        let expr = parse_filter(src).unwrap();
+        let bound = BoundFilter::bind(&expr, &batch.schema(), &[]).unwrap();
+        bound.eval_mask(&batch, &|i| i)
+    }
+
+    #[test]
+    fn eval_numeric_comparison_with_nulls() {
+        // Row 2 has null confidence → UNKNOWN, dropped at the top level.
+        assert_eq!(
+            eval("confidence > 0.8"),
+            vec![Some(true), Some(false), None, Some(true)]
+        );
+    }
+
+    #[test]
+    fn eval_three_valued_not_and_or() {
+        // NOT propagates UNKNOWN (row 2 stays None, is not resurrected).
+        assert_eq!(
+            eval("NOT confidence > 0.8"),
+            vec![Some(false), Some(true), None, Some(false)]
+        );
+        // UNKNOWN AND FALSE = FALSE; UNKNOWN AND TRUE = UNKNOWN.
+        assert_eq!(
+            eval("confidence > 0.8 AND crop = 'soy'"),
+            vec![Some(true), Some(false), None, None]
+        );
+        // UNKNOWN OR TRUE = TRUE.
+        assert_eq!(
+            eval("confidence > 0.8 OR crop = 'soy'"),
+            vec![Some(true), Some(false), Some(true), Some(true)]
+        );
+    }
+
+    #[test]
+    fn eval_in_and_is_null() {
+        assert_eq!(
+            eval("crop IN ('soy', 'wheat')"),
+            vec![Some(true), Some(false), Some(true), None]
+        );
+        assert_eq!(
+            eval("crop NOT IN ('soy')"),
+            vec![Some(false), Some(true), Some(false), None]
+        );
+        assert_eq!(
+            eval("confidence IS NULL"),
+            vec![Some(false), Some(false), Some(true), Some(false)]
+        );
+        assert_eq!(
+            eval("crop IS NOT NULL"),
+            vec![Some(true), Some(true), Some(true), Some(false)]
+        );
+        assert_eq!(
+            eval("id IN (1, 3)"),
+            vec![Some(false), Some(true), Some(false), Some(true)]
+        );
+    }
+
+    #[test]
+    fn eval_bool_and_string_ordering() {
+        assert_eq!(
+            eval("active = true"),
+            vec![Some(true), Some(false), None, Some(true)]
+        );
+        // Lexicographic string ordering.
+        assert_eq!(
+            eval("crop >= 'soy'"),
+            vec![Some(true), Some(false), Some(true), None]
+        );
+    }
+
+    #[test]
+    fn bind_errors() {
+        let batch = test_batch();
+        let schema = batch.schema();
+        let unknown = parse_filter("nope = 1").unwrap();
+        assert!(matches!(
+            BoundFilter::bind(&unknown, &schema, &[]),
+            Err(FilterError::UnknownColumn { .. })
+        ));
+        let mismatch = parse_filter("crop > 3").unwrap();
+        assert!(matches!(
+            BoundFilter::bind(&mismatch, &schema, &[]),
+            Err(FilterError::TypeMismatch { .. })
+        ));
+        let bool_ord = parse_filter("active > false").unwrap();
+        assert!(matches!(
+            BoundFilter::bind(&bool_ord, &schema, &[]),
+            Err(FilterError::BooleanOrdering { .. })
+        ));
+    }
+
+    #[test]
+    fn bind_follows_reserved_renames() {
+        // Input column `level` renamed to `level_` (#288): the filter's
+        // `level` resolves to the renamed schema column, pushdown keeps the
+        // parquet-side name `level`.
+        let schema = Schema::new(vec![
+            Field::new("level_", DataType::Int64, true),
+            Field::new("geometry", DataType::Binary, true),
+        ]);
+        let expr = parse_filter("level >= 2").unwrap();
+        let bound = BoundFilter::bind(
+            &expr,
+            &schema,
+            &[("level".to_string(), "level_".to_string())],
+        )
+        .unwrap();
+        assert_eq!(bound.columns(), &[0]);
+        let BoundExpr::Compare { col, .. } = &bound.expr else {
+            panic!("compare expected");
+        };
+        assert_eq!(col.parquet_name, "level");
+        assert_eq!(col.idx, 0);
+    }
+
+    #[test]
+    fn bind_case_insensitive_fallback() {
+        let batch = test_batch();
+        let expr = parse_filter("CONFIDENCE > 0.8").unwrap();
+        let bound = BoundFilter::bind(&expr, &batch.schema(), &[]).unwrap();
+        assert_eq!(bound.columns(), &[0]);
+    }
+
+    // ---- pushdown --------------------------------------------------------
+
+    /// Write a parquet file with one row group per (confidence, crop) pair
+    /// and return its metadata.
+    fn stats_file(
+        rows: &[(Option<f64>, Option<&str>)],
+    ) -> (tempfile::NamedTempFile, ParquetMetaData) {
+        use parquet::arrow::ArrowWriter;
+        use parquet::file::properties::WriterProperties;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("confidence", DataType::Float64, true),
+            Field::new("crop", DataType::Utf8, true),
+        ]));
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let props = WriterProperties::builder()
+            .set_max_row_group_row_count(Some(1))
+            .build();
+        let mut writer =
+            ArrowWriter::try_new(file.reopen().unwrap(), schema.clone(), Some(props)).unwrap();
+        let conf: ArrayRef = Arc::new(Float64Array::from(
+            rows.iter().map(|(c, _)| *c).collect::<Vec<_>>(),
+        ));
+        let crop: ArrayRef = Arc::new(StringArray::from(
+            rows.iter().map(|(_, s)| *s).collect::<Vec<_>>(),
+        ));
+        let batch = RecordBatch::try_new(schema, vec![conf, crop]).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        let f = std::fs::File::open(file.path()).unwrap();
+        let reader = parquet::file::reader::SerializedFileReader::new(f).unwrap();
+        use parquet::file::reader::FileReader;
+        let meta = reader.metadata().clone();
+        (file, meta)
+    }
+
+    fn selected(src: &str, meta: &ParquetMetaData) -> Vec<usize> {
+        let schema = Schema::new(vec![
+            Field::new("confidence", DataType::Float64, true),
+            Field::new("crop", DataType::Utf8, true),
+        ]);
+        let expr = parse_filter(src).unwrap();
+        let bound = BoundFilter::bind(&expr, &schema, &[]).unwrap();
+        bound.select_row_groups(meta)
+    }
+
+    #[test]
+    fn pushdown_prunes_by_numeric_min_max() {
+        // 4 single-row row groups: confidence 0.1, 0.5, 0.9, null.
+        let (_f, meta) = stats_file(&[
+            (Some(0.1), Some("soy")),
+            (Some(0.5), Some("corn")),
+            (Some(0.9), Some("soy")),
+            (None, Some("rice")),
+        ]);
+        assert_eq!(meta.num_row_groups(), 4);
+        // > 0.8: only RG2 can match (RG3 is all-null → pruned).
+        assert_eq!(selected("confidence > 0.8", &meta), vec![2]);
+        // <= 0.5: RG0, RG1.
+        assert_eq!(selected("confidence <= 0.5", &meta), vec![0, 1]);
+        // = 0.5: RG1 only.
+        assert_eq!(selected("confidence = 0.5", &meta), vec![1]);
+        // IS NULL: RG3 only (others null-free).
+        assert_eq!(selected("confidence IS NULL", &meta), vec![3]);
+        // IS NOT NULL: all but the all-null RG3.
+        assert_eq!(selected("confidence IS NOT NULL", &meta), vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn pushdown_prunes_strings_and_composes_and_or() {
+        let (_f, meta) = stats_file(&[
+            (Some(0.1), Some("soy")),
+            (Some(0.5), Some("corn")),
+            (Some(0.9), Some("soy")),
+            (None, Some("rice")),
+        ]);
+        assert_eq!(selected("crop = 'soy'", &meta), vec![0, 2]);
+        assert_eq!(selected("crop IN ('corn', 'rice')", &meta), vec![1, 3]);
+        // AND intersects; OR unions.
+        assert_eq!(
+            selected("crop = 'soy' AND confidence > 0.8", &meta),
+            vec![2]
+        );
+        assert_eq!(
+            selected("crop = 'corn' OR confidence > 0.8", &meta),
+            vec![1, 2]
+        );
+        // != prunes only a constant chunk equal to the literal (all
+        // single-row chunks here are constant).
+        assert_eq!(selected("crop != 'soy'", &meta), vec![1, 3]);
+        // NOT (...) is conservative: keeps everything.
+        assert_eq!(selected("NOT (crop = 'soy')", &meta), vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn widen_i64_is_conservative_beyond_2p53() {
+        let big = (1i64 << 53) + 1;
+        assert!(widen_i64(big, true) < big as f64);
+        assert!(widen_i64(big, false) > big as f64);
+        assert_eq!(widen_i64(42, true), 42.0);
+        assert_eq!(widen_i64(-42, false), -42.0);
+    }
+}

--- a/crates/core/src/overview/mod.rs
+++ b/crates/core/src/overview/mod.rs
@@ -17,6 +17,7 @@ pub mod cluster;
 pub mod coalesce;
 pub mod convert;
 pub mod export;
+pub mod filter;
 #[cfg(test)]
 mod hostile;
 pub mod level;

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -256,6 +256,30 @@ fn build_level_schemas(
     (source_schema, cluster_schema, out_schema)
 }
 
+/// Combined per-part footer-statistics row-group selection for the streaming
+/// path: bbox covering pruning (#102) intersected with attribute-filter
+/// statistics pushdown (#315). `None` when neither pruning is active.
+fn select_row_groups_streaming(
+    source: &ConvertSource,
+    bbox_units: Option<&[f64; 4]>,
+    filter: Option<&super::filter::BoundFilter>,
+) -> Result<Option<RowGroupSelection>, ConvertError> {
+    let bbox_selection: Option<RowGroupSelection> = match bbox_units {
+        Some(bb) => Some(source.select_row_groups(bb)?),
+        None => None,
+    };
+    let filter_selection: Option<RowGroupSelection> = match filter {
+        Some(f) => Some(source.select_row_groups_matching(f)?),
+        None => None,
+    };
+    Ok(match (bbox_selection, filter_selection) {
+        (Some(a), Some(b)) => Some(a.intersect(&b)),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    })
+}
+
 pub(crate) fn convert_streaming_strategy(
     source: &ConvertSource,
     output_path: &Path,
@@ -283,26 +307,40 @@ pub(crate) fn convert_streaming_strategy(
     let kv = source.key_value_metadata()?;
     let crs = super::convert::detect_crs_from_kv(kv.as_ref())?;
 
-    // Regional extract (#102): prune input row groups by bbox covering
-    // statistics — footer metadata only, no data pages of skipped groups are
-    // ever read. The selection is PER PART and every pass reads the same
-    // selection in the same part order, so the global row indices addressing
-    // the winner tables stay aligned. Groups without stats are kept; the
-    // exact per-feature filter in pass 1 guarantees identical output either
-    // way.
+    // Reserved-column collisions (#288) are resolved BEFORE row-group
+    // selection so the attribute filter (#315) can bind against the final
+    // (possibly renamed) schema; the rename is metadata-only and never
+    // affects the footer statistics either pruning path reads. See the
+    // full #288 rationale on the block below.
+    let mut options = options.clone();
+    let (input_schema, renames) = resolve_reserved_column_collisions(&input_schema, &mut options);
+    let options = &options;
+
+    // Attribute filter (#315): parse + bind against the input schema.
+    // Syntax was already validated in `validate_options`; binding resolves
+    // column names to indices and type-checks literals.
+    let bound_filter = super::convert::bind_attribute_filter(options, &input_schema, &renames)?;
+
+    // Regional extract (#102) + attribute filter (#315): prune input row
+    // groups by footer statistics — bbox covering stats for `--bbox`,
+    // per-column min/max/null-count stats for `--filter` — before any data
+    // pages are read. The two prunings compose by intersection. The
+    // selection is PER PART and every pass reads the same selection in the
+    // same part order, so the global row indices addressing the winner
+    // tables stay aligned. Groups without stats are kept; the exact
+    // per-feature filters in pass 1 guarantee identical output either way.
     let row_groups_total = source.num_row_groups_total()?;
     let bbox_units = options
         .bbox
         .map(|b| super::convert::bbox_to_crs_units(&b, crs));
-    let selected_row_groups: Option<RowGroupSelection> = match bbox_units.as_ref() {
-        Some(bb) => Some(source.select_row_groups(bb)?),
-        None => None,
-    };
+    let selected_row_groups =
+        select_row_groups_streaming(source, bbox_units.as_ref(), bound_filter.as_ref())?;
     let row_groups_read = selected_row_groups
         .as_ref()
         .map_or(row_groups_total, RowGroupSelection::total_selected);
     if selected_row_groups.is_some() {
-        log::info!("bbox filter: reading {row_groups_read}/{row_groups_total} input row groups");
+        let what = super::convert::pruning_label(options.bbox.is_some(), bound_filter.is_some());
+        log::info!("{what} filter: reading {row_groups_read}/{row_groups_total} input row groups");
     }
     // #267: nudge toward --bbox / download-first for a large whole-file remote
     // convert (quiet for local inputs and effective bbox extracts).
@@ -323,17 +361,16 @@ pub(crate) fn convert_streaming_strategy(
     // passes below read from the spill, not the network.
     stage_input_pass0(source, selected_row_groups.as_ref(), row_groups_read);
 
-    // Reserved-column collisions (#288): rename any input column named `level`
-    // / `point_count` / `coalesced_count` (case-insensitive) instead of
-    // rejecting the file, keeping the reserved output columns authoritative.
-    // The rename preserves column order, so the projection indices pass 1
-    // computes against `input_schema` stay valid against the raw file, and pass
-    // 2 relabels non-geometry columns positionally into the renamed source
-    // schema (`build_source_schema`). `options` is cloned so by-name
-    // ranking/accumulate options can be rewritten to the renamed columns.
-    let mut options = options.clone();
-    let (input_schema, _renames) = resolve_reserved_column_collisions(&input_schema, &mut options);
-    let options = &options;
+    // (Reserved-column collisions, #288, were resolved above, before the
+    // row-group selection: any input column named `level` / `point_count` /
+    // `coalesced_count` (case-insensitive) is renamed instead of rejecting
+    // the file, keeping the reserved output columns authoritative. The
+    // rename preserves column order, so the projection indices pass 1
+    // computes against `input_schema` stay valid against the raw file, and
+    // pass 2 relabels non-geometry columns positionally into the renamed
+    // source schema (`build_source_schema`). `options` was cloned so
+    // by-name ranking/accumulate options could be rewritten to the renamed
+    // columns.)
 
     let geom_idx = find_geometry_column(&input_schema).ok_or(ConvertError::NoGeometryColumn)?;
     let geom_field = input_schema.field(geom_idx).clone();
@@ -361,6 +398,7 @@ pub(crate) fn convert_streaming_strategy(
         &acc_cols,
         selected_row_groups.as_ref(),
         bbox_units.as_ref(),
+        bound_filter.as_ref(),
     )?;
     if skipped_rows > 0 {
         log::warn!(
@@ -1011,21 +1049,20 @@ struct Pass1Output {
 /// ranking provenance block (§3.5), and — when clustering with aggregation —
 /// the per-spec source values (parallel to `acc_cols`). Memory: `O(read
 /// batch)` transient + `O(N)` small per-feature records.
-fn run_pass1(
-    source: &ConvertSource,
-    input_schema: &Schema,
+/// The sorted, deduplicated column projection pass 1 reads: geometry +
+/// ranking candidates + accumulate columns (Q4) + attribute-filter columns
+/// (#315).
+fn pass1_projection(
     geom_idx: usize,
-    options: &ConvertOptions,
+    plan: &RankPlan,
     acc_cols: &[usize],
-    row_groups: Option<&RowGroupSelection>,
-    bbox_units: Option<&[f64; 4]>,
-) -> Result<Pass1Output, ConvertError> {
-    let mut plan = build_rank_plan(input_schema, options)?;
-
-    // Project only the columns pass 1 needs: geometry + ranking candidates +
-    // accumulate columns (Q4).
+    filter: Option<&super::filter::BoundFilter>,
+) -> Vec<usize> {
     let mut cols: Vec<usize> = vec![geom_idx];
-    match &plan {
+    if let Some(f) = filter {
+        cols.extend(f.columns().iter().copied());
+    }
+    match plan {
         RankPlan::ExplicitSort { idx, .. } | RankPlan::ExplicitClass { idx, .. } => cols.push(*idx),
         RankPlan::Auto { roads, confidence } => {
             cols.extend(roads.iter().map(|r| r.idx));
@@ -1038,6 +1075,23 @@ fn run_pass1(
     cols.extend(acc_cols.iter().copied());
     cols.sort_unstable();
     cols.dedup();
+    cols
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_pass1(
+    source: &ConvertSource,
+    input_schema: &Schema,
+    geom_idx: usize,
+    options: &ConvertOptions,
+    acc_cols: &[usize],
+    row_groups: Option<&RowGroupSelection>,
+    bbox_units: Option<&[f64; 4]>,
+    filter: Option<&super::filter::BoundFilter>,
+) -> Result<Pass1Output, ConvertError> {
+    let mut plan = build_rank_plan(input_schema, options)?;
+
+    let cols = pass1_projection(geom_idx, &plan, acc_cols, filter);
     // Original schema index → projected batch column index.
     let proj = |orig: usize| cols.binary_search(&orig).expect("projected column");
 
@@ -1079,6 +1133,12 @@ fn run_pass1(
         geoms_buf.clear();
         extract_geometries_opt_from_array(garr.as_ref(), &mut geoms_buf)?;
 
+        // Attribute filter (#315): evaluate the predicate over the projected
+        // batch once. A row whose result is not TRUE (FALSE or SQL-UNKNOWN)
+        // produces no AssignFeature — exactly like a bbox miss below — while
+        // the row index still advances, keeping row-keyed tables aligned.
+        let filter_mask: Option<Vec<Option<bool>>> = filter.map(|f| f.eval_mask(&batch, &proj));
+
         // `AssignFeature::index` is the GLOBAL ROW index: pass 2 addresses the
         // winner tables by raw row position. Rows with a null, empty, or
         // non-finite geometry produce no feature but still advance the row
@@ -1086,6 +1146,14 @@ fn run_pass1(
         // skipped row must never shift attributes onto a neighbor's geometry).
         let base = num_rows;
         for (i, gopt) in geoms_buf.iter().enumerate() {
+            // Attribute filter (#315): keep only rows where the predicate is
+            // TRUE. The row index still advances (row-keyed tables stay
+            // aligned); the slot stays UNASSIGNED so pass 2 drops it too.
+            if let Some(mask) = &filter_mask {
+                if mask[i] != Some(true) {
+                    continue;
+                }
+            }
             let Some(g) = gopt.as_ref() else {
                 skipped_rows += 1;
                 continue;

--- a/crates/python/README.md
+++ b/crates/python/README.md
@@ -18,6 +18,7 @@ the vector-tile tool this project measures itself against — tylertoo runs alon
 - Quality ladder tuned against tippecanoe: class ranking (Overture auto-detect), visibility gates, density budget, point clustering, line coalescing
 - Memory-bounded streaming conversion — a 632k-polygon / 38M-vertex file converts to a full z0–14 overview pyramid in ~45 s at ~1.4 GB peak RSS, or a default z0–6 pyramid in ~7 s at ~0.4 GB (16-core machine)
 - Remote inputs (`s3://`, `https://`, `gs://`) read via byte-range requests — with `--bbox`, extract a city from a remote country-scale file while downloading only the matching row groups ([Remote Reads](docs/remote-reads.md))
+- Attribute filtering (`--filter` / `--where`) — tile only the features matching a SQL-WHERE-style predicate (`"confidence > 0.8"`, `"crop IN ('soy', 'corn')"`), with parquet row-group statistics pushdown so non-matching row groups are never read (or fetched, on remote input); composes with `--bbox` ([Tuning guide](docs/OVERVIEW_TUNING.md#attribute-filter---filter----where))
 - Spec validation (`tylertoo validate`)
 - PMTiles → GeoParquet decoding (`tylertoo decode`) — tippecanoe-decode
   semantics, any PMTiles v3 MVT archive

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -324,6 +324,16 @@ fn convert_report_to_dict(py: Python<'_>, report: &ConvertReport) -> PyResult<Py
 ///         their data pages (inputs without covering stats read everything
 ///         and rely on the exact per-feature filter). Defaults to None
 ///         (full extent).
+///     filter (str, optional): Attribute filter — a SQL-WHERE-style
+///         predicate over the input's property columns, e.g.
+///         ``"confidence > 0.8"`` or ``"crop IN ('soy', 'corn')"``.
+///         Supports ``=, !=, <, <=, >, >=``, ``IN (...)``,
+///         ``IS [NOT] NULL``, ``AND``/``OR``/``NOT``, and parentheses;
+///         nulls follow SQL three-valued logic (a row is kept only when
+///         the predicate is TRUE). Composes with ``bbox``; input row
+///         groups whose parquet column statistics preclude any match are
+///         skipped without reading their data pages. Defaults to None
+///         (no filtering).
 ///     profile (str, optional): Memory/throughput profile for the single-read
 ///         pass-2 engine: "speed" (buffer output in RAM), "bounded" (spill to
 ///         temporary Arrow IPC files), or "auto" (pick per mode + estimated
@@ -406,6 +416,7 @@ fn convert_report_to_dict(py: Python<'_>, report: &ConvertReport) -> PyResult<Py
     streaming=true,
     read_batch_size=8192,
     bbox=None,
+    filter=None,
     profile="auto",
     in_flight_batches=0,
     spill_dir=None,
@@ -449,6 +460,7 @@ fn overview(
     streaming: bool,
     read_batch_size: usize,
     bbox: Option<(f64, f64, f64, f64)>,
+    filter: Option<String>,
     profile: &str,
     in_flight_batches: usize,
     spill_dir: Option<PathBuf>,
@@ -598,6 +610,7 @@ fn overview(
         coalesce_max_level_rows,
         coalesce_junction_angle,
         bbox: bbox.map(|(xmin, ymin, xmax, ymax)| [xmin, ymin, xmax, ymax]),
+        filter,
         spill_dir,
     };
 

--- a/crates/python/tylertoo.pyi
+++ b/crates/python/tylertoo.pyi
@@ -55,6 +55,7 @@ def overview(
     streaming: bool = True,
     read_batch_size: int = 8192,
     bbox: tuple[float, float, float, float] | None = None,
+    filter: str | None = None,
     profile: str = "auto",
     in_flight_batches: int = 0,
     spill_dir: str | Path | None = None,

--- a/docs/OVERVIEW_TUNING.md
+++ b/docs/OVERVIEW_TUNING.md
@@ -760,6 +760,69 @@ reprojects the bbox internally.
 
 ---
 
+## Attribute filter: `--filter` / `--where`
+
+`--filter <EXPR>` (aliased as `--where`) converts only the features matching a
+SQL-WHERE-style predicate over the input's property columns — the attribute
+analogue of `--bbox`, and it composes with it. Available on both `overview`
+and the one-shot `tiles` facade.
+
+```bash
+# Only high-confidence field boundaries, straight from the source file
+tylertoo tiles fields.parquet fields.pmtiles \
+  --filter "confidence > 0.8" --max-zoom 14
+
+# Composes with --bbox and richer predicates
+tylertoo overview brazil.parquet subset.parquet \
+  --bbox -48.0,-16.0,-47.0,-15.0 \
+  --where "crop_type IN ('soy', 'corn') AND confidence >= 0.5"
+```
+
+**Expression language** (small built-in recursive-descent parser — no SQL
+engine involved):
+
+- Comparisons: `=` (or `==`), `!=` (or `<>`), `<`, `<=`, `>`, `>=`, with the
+  column on the left: `confidence > 0.8`, `country = 'BRA'`, `active = true`.
+- Membership: `col IN (v1, v2, ...)`, `col NOT IN (...)`.
+- Null tests: `col IS NULL`, `col IS NOT NULL`.
+- Boolean composition: `AND`, `OR`, `NOT`, parentheses. `OR` binds loosest,
+  then `AND`, then `NOT`.
+- Literals: numbers (`0.8`, `-2`, `1e6`), single-quoted strings (`'it''s'`
+  escapes a quote), `TRUE`/`FALSE`. Keywords are case-insensitive.
+- Columns: bare identifiers, or `"double quoted"` for names with spaces.
+  Supported column types: numeric (int/uint/float), string, boolean.
+
+**Null semantics** are SQL three-valued logic: a comparison or `IN` over a
+NULL value is UNKNOWN, `AND`/`OR`/`NOT` combine with Kleene logic, and a row
+is kept only when the whole predicate is TRUE. So `confidence > 0.8` drops
+null-confidence rows — and so does `NOT (confidence > 0.8)`. Use
+`IS NULL` / `IS NOT NULL` to test nulls explicitly.
+
+Like `--bbox`, the filter is two-stage:
+
+1. **Row-group pruning** (statistics-based): row groups whose parquet column
+   chunk statistics (min/max/null-count) prove the predicate cannot match are
+   skipped at the footer level — their data pages are never read, and on
+   remote input those byte ranges are never fetched. `AND` intersects the
+   prunable sets, `OR` unions them; `NOT (...)` subtrees and columns without
+   usable statistics conservatively keep the row group.
+2. **Exact per-row evaluation** during the pass-1 scan guarantees identical
+   output whether or not pruning fired.
+
+| Knob | Default | Units | Effect |
+|------|---------|-------|--------|
+| `--filter EXPR` (alias `--where`) | — | predicate | only features where EXPR is TRUE; omit = no filtering |
+
+**Interactions**: the filter runs before level assignment, ranking, density
+budgets, clustering, and coalescing — dropped features simply never enter the
+pipeline, exactly as if the input had been pre-filtered (`ConvertReport.
+input_features` counts only survivors). Check `row_groups_read` vs
+`row_groups_total` to see whether statistics pruning fired; sorting the input
+by a filtered column (or lowering `--row-group-size`) tightens per-row-group
+statistics and prunes more.
+
+---
+
 ## Performance profiles: `--profile`, `--in-flight-batches`
 
 Like the [memory / streaming knobs](#memory--streaming-knobs---no-streaming---read-batch-size),


### PR DESCRIPTION
Closes #315.

Adds `--filter <EXPR>` (alias `--where`) — an attribute predicate over feature columns, evaluated during the pass-1 scan so it composes with `--bbox` and feeds the same downstream pipeline. Available on both `overview` and the `tiles` facade (and as `filter=` in the Python API).

## Decisions on the issue's open questions

**Grammar — small hand-rolled parser, no new dependencies.** A ~350-line recursive-descent parser in the new `overview::filter` module over the arrow/parquet crates already in the tree. DataFusion would add an enormous dependency subtree for a predicate language whose required scope is comparisons + `IN` + `IS NULL` + boolean composition. Supported: `= == != <> < <= > >=`, `IN (...)` / `NOT IN (...)`, `IS [NOT] NULL`, `AND`/`OR`/`NOT`, parentheses, `'string'` (with `''` escape), numeric and `TRUE`/`FALSE` literals, bare or `"quoted"` column names; keywords case-insensitive. Column types: numeric, string (incl. dictionary-of-string), boolean.

**Null semantics — SQL three-valued logic.** Comparisons/`IN` over NULL yield UNKNOWN, `AND`/`OR`/`NOT` combine with Kleene logic, and a row is kept only when the predicate is TRUE (so `confidence > 0.8` and `NOT (confidence > 0.8)` both drop null-confidence rows). `IS NULL` / `IS NOT NULL` are the explicit tests. `= NULL` is rejected at parse with a hint.

**Pushdown — row-group statistics, conservative.** `BoundFilter::select_row_groups` prunes row groups whose column chunk min/max/null-count statistics prove the predicate can't match: footer-only, so pruned groups' data pages are never read and, on remote input, never fetched. `AND` intersects, `OR` unions; `NOT (...)` subtrees, missing stats, and unsupported stat types conservatively keep the group — the exact per-row evaluation in pass 1 guarantees identical output either way. Composes with `--bbox` covering pruning by per-part selection intersection (both passes read the identical selection, keeping the winner-table row indices aligned). Int64 stats beyond the exact-f64 range are widened before pruning so rounding can never prune a matching group.

Reserved-column renames (#288) are followed for schema binding while pushdown keeps the parquet-side (pre-rename) column name; collision resolution now runs before row-group selection in the streaming path (metadata-only, order-preserving — selection inputs are unaffected).

## Acceptance
- `--filter "confidence > 0.8"` tiles only matching features — integration tests assert exact parity with post-hoc filtering in both the streaming and in-memory engines, and a CLI run on `tests/fixtures/realdata/road-detections.parquet` matches DuckDB's count exactly (4/1000).
- Row-group pushdown applied where stats permit — `attribute_filter_matches_posthoc_and_prunes_row_groups` asserts `row_groups_read` drops, and `attribute_filter_remote_fetches_only_matching_row_groups` proves via fetched byte ranges that pruned row groups are never downloaded.
- Composes with `--bbox` — `attribute_filter_composes_with_bbox` (selection intersection + both exact filters).
- Documented — new "Attribute filter" section in `docs/OVERVIEW_TUNING.md` (grammar, null semantics, pushdown, interactions), README feature bullet, CLI `--help`, Python docstring.

## Tests
- `filter::` — 18 unit tests: parser (operators, precedence, quoting, errors), three-valued eval over Arrow batches, stats pushdown on real parquet metadata, i64 widening.
- `convert::tests::attribute_*` — 4 integration tests × streaming/in-memory: post-hoc parity + pruning, bbox composition, string/IN/null semantics, error paths (syntax → validation; unknown column / type mismatch → bind; empty result → NoData).
- `convert::tests::remote_input::attribute_filter_remote_fetches_only_matching_row_groups` — fetched-bytes reduction on remote input.
- Regressions: `bbox` (4), `remote_input::` (12), `multi_part*` (5), `hostile` (30) all pass; clippy `--all-targets --all-features` clean; `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)