### PR TITLE
feat(export): default per-tile size cap at 500K (tippecanoe parity)

### DIFF
--- a/context/ARCHITECTURE.md
+++ b/context/ARCHITECTURE.md
@@ -133,9 +133,14 @@ through byte-identical; seam-crossers match modulo float/ring-normalization
 noise. The recursion is bounded by the same `tile_ranges_for_bbox` math
 `tiles_for_bbox` uses, so the emitted tile set is unchanged.
 
-The one safety valve is `--tile-size-limit`: an oversized tile gets a
-**single, non-iterative** drop pass shedding its largest-geometry features,
-then is re-encoded once.
+The one safety valve is `--tile-size-limit` (default `500K`, tippecanoe
+parity — issue #280; `0` disables it): an oversized tile gets a **single,
+non-iterative** drop pass, then is re-encoded once. Which features survive
+depends on the tile's geometry (`select_kept_members`): polygon/line tiles
+keep their largest-vertex features (the visual signal); point-dominated
+tiles — where vertex count carries no signal — instead keep a uniform stride
+across member (Hilbert) order, so the surviving dots stay spatially spread
+rather than clumped in one corner.
 
 Border duplication is the expected delta between overview level counts and
 export per-zoom feature totals (a feature spanning a tile seam appears in

--- a/corpus/SWEEPS.md
+++ b/corpus/SWEEPS.md
@@ -236,7 +236,8 @@ dots, z4 = 128,886, z6 = 1.07M), z6–z13 land exactly on the budget
 ladder `N/1.65^(14−z)` with visible gamma-fair density structure
 (Ruhr/Berlin denser, rural protected), at +31 % overview bytes / +40 %
 convert wall on Germany and **+0.3 % bytes** on Moldova. Uncapped coarse
-dot tiles reach 12 MB (Germany z6) — hence the 500K cap in the recipe.
+dot tiles reach 12 MB (Germany z6) — hence the 500K cap in the recipe,
+now the default (#280), applied as a spatially even stride of the dots.
 `--collapse` stays opt-in per spec Q4 (§7.5: type collapse MUST be
 producer-opt-in); the demo viewer gained the circle layer, and the
 empty-level WARN now points at the recipe. Tippecanoe fills the same gap

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -46,6 +46,14 @@ fn parse_size_bytes(s: &str) -> Result<usize, String> {
     })
 }
 
+/// Map a per-tile size-cap CLI value to [`ExportOptions::tile_size_limit`]:
+/// `0` (the off switch, e.g. `--max-tile-size 0`) becomes `None` (cap disabled);
+/// any positive byte count becomes `Some(n)`. The default `500K` therefore caps;
+/// `0` opts out. See issue #280.
+fn size_limit_opt(n: usize) -> Option<usize> {
+    (n > 0).then_some(n)
+}
+
 /// Parse `--in-flight-batches`: `auto` (→ the core-sized sentinel 0) or an
 /// explicit positive integer. See [`resolve_in_flight_batches`] for how the
 /// sentinel is expanded at pass-2 setup.
@@ -202,12 +210,14 @@ struct ExportPmtilesArgs {
     #[arg(long, default_value = "8")]
     tile_buffer: u32,
 
-    /// Optional per-tile MVT size limit (e.g., "500K", "1M", or raw bytes).
-    /// When a tile exceeds it, a single non-iterative drop pass sheds the
-    /// lowest-priority (smallest) features for that tile only. Omit to enforce
-    /// no limit. Aliased as --max-tile-size for parity with the `tiles` command.
-    #[arg(long, value_name = "SIZE", alias = "max-tile-size", value_parser = parse_size_bytes)]
-    tile_size_limit: Option<usize>,
+    /// Per-tile MVT size cap (e.g., "500K", "1M", or raw bytes). When a tile
+    /// exceeds it, a single non-iterative drop pass sheds features for that tile
+    /// only (largest-first for polygons/lines; a uniform spatial stride for
+    /// point tiles). Defaults to 500K (tippecanoe parity, #280); pass 0 to
+    /// disable the cap. Aliased as --max-tile-size for parity with the `tiles`
+    /// command.
+    #[arg(long, value_name = "SIZE", alias = "max-tile-size", default_value = "500K", value_parser = parse_size_bytes)]
+    tile_size_limit: usize,
 
     /// Write the JSON export report to this path.
     #[arg(long, value_name = "PATH")]
@@ -985,11 +995,13 @@ struct TilesArgs {
     layer_name: Option<String>,
 
     /// Maximum tile size (e.g., "500K", "1M", or raw bytes). When a tile
-    /// exceeds this limit, the export sheds its lowest-priority features in a
-    /// single non-iterative pass. Aliased as --tile-size-limit for parity with
+    /// exceeds this limit, the export sheds features in a single non-iterative
+    /// pass (largest-first for polygons/lines; a uniform spatial stride for
+    /// point tiles). Defaults to 500K (tippecanoe parity, #280); pass 0 to
+    /// disable the cap. Aliased as --tile-size-limit for parity with
     /// `export-pmtiles`.
-    #[arg(long, value_name = "SIZE", alias = "tile-size-limit", value_parser = parse_size_bytes)]
-    max_tile_size: Option<usize>,
+    #[arg(long, value_name = "SIZE", alias = "tile-size-limit", default_value = "500K", value_parser = parse_size_bytes)]
+    max_tile_size: usize,
 
     /// Disable the simple-clip fast path (issue #239), forcing the i_overlay
     /// boundary-bridge fallback on every polygon clip. The fast path is on by
@@ -1447,7 +1459,7 @@ fn run_tiles(args: TilesArgs) -> Result<()> {
         layer_name,
         tile_buffer: args.tile_buffer,
         extent: 4096,
-        tile_size_limit: args.max_tile_size,
+        tile_size_limit: size_limit_opt(args.max_tile_size),
         simple_clip_fastpath: !args.no_simple_clip_fastpath,
         partition_wave: args.partition_wave,
     };
@@ -1743,7 +1755,7 @@ fn run_export_pmtiles(args: ExportPmtilesArgs) -> Result<()> {
         layer_name: args.layer_name,
         tile_buffer: args.tile_buffer,
         extent: 4096,
-        tile_size_limit: args.tile_size_limit,
+        tile_size_limit: size_limit_opt(args.tile_size_limit),
         simple_clip_fastpath: !args.no_simple_clip_fastpath,
         partition_wave: args.partition_wave,
     };
@@ -2030,6 +2042,18 @@ mod tests {
         {
             Command::Tiles(a) => *a,
             other => panic!("expected tiles subcommand, got {other:?}"),
+        }
+    }
+
+    fn parse_export(flags: &[&str]) -> ExportPmtilesArgs {
+        let mut argv = vec!["tylertoo", "export-pmtiles", "in.parquet", "out.pmtiles"];
+        argv.extend_from_slice(flags);
+        match Cli::try_parse_from(argv)
+            .expect("export-pmtiles args should parse")
+            .command
+        {
+            Command::ExportPmtiles(a) => a,
+            other => panic!("expected export-pmtiles subcommand, got {other:?}"),
         }
     }
 
@@ -2361,8 +2385,20 @@ mod tests {
         // The two spellings are aliases and both accept human-readable sizes.
         let a = parse_tiles(&["--max-tile-size", "500K"]);
         let b = parse_tiles(&["--tile-size-limit", "500K"]);
-        assert_eq!(a.max_tile_size, Some(500 * 1024));
+        assert_eq!(a.max_tile_size, 500 * 1024);
         assert_eq!(a.max_tile_size, b.max_tile_size);
+    }
+
+    #[test]
+    fn tile_size_cap_defaults_to_500k_and_zero_disables() {
+        // #280: the per-tile cap is on by default at 500K on both commands.
+        assert_eq!(parse_tiles(&[]).max_tile_size, 500 * 1024);
+        assert_eq!(parse_export(&[]).tile_size_limit, 500 * 1024);
+
+        // `0` is the off switch: the CLI value maps to `None` (cap disabled).
+        assert_eq!(parse_tiles(&["--max-tile-size", "0"]).max_tile_size, 0);
+        assert_eq!(size_limit_opt(0), None);
+        assert_eq!(size_limit_opt(500 * 1024), Some(500 * 1024));
     }
 
     #[test]

--- a/crates/core/src/overview/export.rs
+++ b/crates/core/src/overview/export.rs
@@ -129,6 +129,13 @@ const DEFAULT_EXTENT: u32 = 4096;
 /// use 8 to match the tile pipeline's historical default).
 const DEFAULT_TILE_BUFFER_PX: u32 = 8;
 
+/// Default per-tile MVT size cap, in bytes (500 KiB — matches what `500K`
+/// parses to and tippecanoe's on-by-default 500K bar; issue #280). A tile whose
+/// encoded MVT exceeds this trips the single-pass drop valve (see
+/// [`ExportOptions::tile_size_limit`]). Set `tile_size_limit` to `None` (CLI:
+/// `--max-tile-size 0`; Python: `tile_size_limit=0`) to disable the cap.
+pub const DEFAULT_TILE_SIZE_LIMIT: usize = 500 * 1024;
+
 /// Web Mercator projected half-extent in meters (EPSG:3857 axis range is
 /// `±WEBMERC_HALF_M`). Used only to reproject a 3857 overview to lon/lat so the
 /// (geographic) tile grid math applies.
@@ -145,12 +152,16 @@ pub struct ExportOptions {
     pub tile_buffer: u32,
     /// MVT tile extent (integer tile-local resolution). Default 4096.
     pub extent: u32,
-    /// Optional per-tile MVT size limit in **bytes**. When set, a tile whose
-    /// encoded size exceeds the limit triggers the single, non-iterative safety
-    /// valve: its lowest-priority features (ranked by geometry size — see the
-    /// module docs on why the assignment sort key is not recoverable per-row)
-    /// are dropped in one pass and the tile is re-encoded once. When `None`, no
-    /// size limit is enforced and `oversized_tiles` is always 0.
+    /// Per-tile MVT size limit in **bytes**. When `Some(limit)` with
+    /// `limit > 0`, a tile whose encoded size exceeds the limit triggers the
+    /// single, non-iterative safety valve: [`select_kept_members`] chooses which
+    /// features survive (largest-first for sized geometries, uniform spatial
+    /// stride for point-dominated tiles — see that function) and the tile is
+    /// re-encoded once. When `None` (or `Some(0)`), no size limit is enforced
+    /// and `oversized_tiles` is always 0.
+    ///
+    /// Defaults to `Some(`[`DEFAULT_TILE_SIZE_LIMIT`]`)` (500 KiB — tippecanoe
+    /// parity, issue #280).
     pub tile_size_limit: Option<usize>,
     /// Skip the i_overlay boundary-bridge fallback for features whose rings are
     /// already proven simple (issue #239). On a simple ring, Sutherland–Hodgman's
@@ -184,7 +195,7 @@ impl Default for ExportOptions {
             layer_name: "overview".to_string(),
             tile_buffer: DEFAULT_TILE_BUFFER_PX,
             extent: DEFAULT_EXTENT,
-            tile_size_limit: None,
+            tile_size_limit: Some(DEFAULT_TILE_SIZE_LIMIT),
             simple_clip_fastpath: true,
             partition_wave: PARTITION_WAVE_AUTO,
         }
@@ -2546,15 +2557,16 @@ fn encode_tile(
     let data = build_mvt(members.iter(), tb, opts);
 
     match opts.tile_size_limit {
-        Some(limit) if data.len() > limit && members.len() > 1 => {
-            // Single, non-iterative drop pass: rank members by geometry size
-            // (coordinate count) descending — the biggest features carry the
-            // tile's visual signal — and keep a proportional prefix.
-            let mut ranked: Vec<&Member> = members.iter().collect();
-            ranked.sort_by_key(|m| std::cmp::Reverse(m.geom.coords_count()));
+        // `limit > 0` so `Some(0)` is a no-op off switch (the CLI/Python `0`
+        // disable value never reaches here as `Some`, but guard the core API too).
+        Some(limit) if limit > 0 && data.len() > limit && members.len() > 1 => {
+            // Single, non-iterative drop pass. Keep a proportional count and let
+            // `select_kept_members` decide *which* features survive.
             let keep_frac = limit as f64 / data.len() as f64;
             let keep = ((members.len() as f64 * keep_frac).floor() as usize).max(1);
-            let data = build_mvt(ranked.iter().take(keep).copied(), tb, opts);
+            let kept = select_kept_members(members, keep);
+            let keep = kept.len();
+            let data = build_mvt(kept, tb, opts);
             log::warn!(
                 "oversized tile ({} bytes > {limit} limit): dropped {} of {} features (one pass)",
                 data.len(),
@@ -2567,6 +2579,42 @@ fn encode_tile(
             let count = members.len();
             (data, count, false)
         }
+    }
+}
+
+/// Choose which `keep` of `members` survive the oversized-tile drop pass.
+///
+/// The single-pass valve has exactly one per-feature ranking signal — geometry
+/// vertex count — and that signal is degenerate for point tiles, so there are
+/// two regimes:
+///
+/// * **Sized geometries** (lines / polygons): keep the `keep` largest by
+///   coordinate count. The biggest features carry the tile's visual signal;
+///   this is the pre-#280 behaviour and is byte-identical to it.
+/// * **Point-dominated tiles** (every member ≤ 1 coordinate — the #259 dot-fill
+///   recipe collapses dense polygons to centroid points): vertex count carries
+///   no signal, so a size-ranked prefix would just keep whichever points happen
+///   to sort first and clump them in one corner. Instead keep a uniform stride
+///   across member order. Overview rows are Hilbert-sorted (§ writer), so a
+///   tile's members arrive in space-filling-curve order; an even stride
+///   therefore spreads the survivors across the tile — the same spatially
+///   uniform thinning tippecanoe achieves by dropping every Nth feature in
+///   sequence.
+///
+/// `keep` is clamped to `1..=members.len()`.
+fn select_kept_members(members: &[Member], keep: usize) -> Vec<&Member> {
+    let n = members.len();
+    let keep = keep.clamp(1, n);
+    let point_like = members.iter().all(|m| m.geom.coords_count() <= 1);
+    if point_like {
+        // Evenly spaced indices 0, n/keep, 2n/keep, … — strictly increasing and
+        // in-bounds because keep ≤ n.
+        (0..keep).map(|i| &members[i * n / keep]).collect()
+    } else {
+        let mut ranked: Vec<&Member> = members.iter().collect();
+        ranked.sort_by_key(|m| std::cmp::Reverse(m.geom.coords_count()));
+        ranked.truncate(keep);
+        ranked
     }
 }
 
@@ -3812,8 +3860,13 @@ mod tests {
         let reader = OverviewReader::open(tmp.path()).unwrap();
         let feats = read_level_features(&reader, 1, Crs::Epsg4326).unwrap();
 
-        // No limit: no oversized tiles.
-        let none = encode_level_tiles(&feats, 6, &ExportOptions::default());
+        // No limit (explicit `None`, since the default is now 500 KiB): no
+        // oversized tiles.
+        let no_limit = ExportOptions {
+            tile_size_limit: None,
+            ..Default::default()
+        };
+        let none = encode_level_tiles(&feats, 6, &no_limit);
         assert!(none.iter().all(|t| !t.oversized));
         let full_count: usize = none.iter().map(|t| t.feature_count).sum();
 
@@ -3832,6 +3885,84 @@ mod tests {
             limited_count < full_count,
             "valve must drop features ({limited_count} !< {full_count})"
         );
+    }
+
+    /// #280: the per-tile cap is on by default at 500 KiB (== what `500K`
+    /// parses to; tippecanoe parity), not disabled.
+    #[test]
+    fn default_export_caps_tiles_at_500_kib() {
+        assert_eq!(DEFAULT_TILE_SIZE_LIMIT, 500 * 1024);
+        assert_eq!(
+            ExportOptions::default().tile_size_limit,
+            Some(DEFAULT_TILE_SIZE_LIMIT)
+        );
+    }
+
+    /// Build a bare point [`Member`] at `(x, y)` for the drop-valve unit tests.
+    fn point_member(x: f64, y: f64, seq: u64) -> Member {
+        Member {
+            key: 0,
+            seq,
+            geom: Geometry::Point(Point::new(x, y)),
+            props: Arc::new(Vec::new()),
+        }
+    }
+
+    /// #280 spatial fairness: on a point-dominated tile, vertex count carries no
+    /// ranking signal, so the valve must keep a uniform stride across member
+    /// (≈ Hilbert) order — not a first-N prefix that would clump survivors.
+    #[test]
+    fn drop_valve_point_tile_keeps_uniform_stride() {
+        let members: Vec<Member> = (0..10).map(|i| point_member(i as f64, 0.0, i)).collect();
+        let kept = select_kept_members(&members, 5);
+        let xs: Vec<f64> = kept
+            .iter()
+            .map(|m| match &m.geom {
+                Geometry::Point(p) => p.x(),
+                _ => unreachable!("built points"),
+            })
+            .collect();
+        // Even stride 0,2,4,6,8 — spread across the tile — not the prefix 0..5.
+        assert_eq!(xs, vec![0.0, 2.0, 4.0, 6.0, 8.0]);
+    }
+
+    /// Sized geometries keep the largest-by-vertex-count survivors (pre-#280
+    /// behaviour, unchanged): the biggest features carry the tile's visual
+    /// signal.
+    #[test]
+    fn drop_valve_sized_tile_keeps_largest() {
+        let members: Vec<Member> = (1..=5)
+            .map(|n| {
+                let coords: Vec<(f64, f64)> = (0..n).map(|k| (k as f64, 0.0)).collect();
+                Member {
+                    key: 0,
+                    seq: n as u64,
+                    geom: Geometry::LineString(LineString::from(coords)),
+                    props: Arc::new(Vec::new()),
+                }
+            })
+            .collect();
+        let kept = select_kept_members(&members, 2);
+        let counts: Vec<usize> = kept.iter().map(|m| m.geom.coords_count()).collect();
+        assert_eq!(counts, vec![5, 4]);
+    }
+
+    /// `Some(0)` is the core off switch (CLI `--max-tile-size 0` / Python
+    /// `tile_size_limit=0` map to it): the valve must never fire, no matter how
+    /// dense the tile.
+    #[test]
+    fn size_limit_zero_disables_valve() {
+        let members: Vec<Member> = (0..64)
+            .map(|i| point_member(-100.0 + i as f64 * 0.001, 40.0, i))
+            .collect();
+        let tb = TileCoord::new(0, 0, 0).bounds();
+        let opts = ExportOptions {
+            tile_size_limit: Some(0),
+            ..Default::default()
+        };
+        let (_data, count, oversized) = encode_tile(&members, &tb, &opts);
+        assert!(!oversized, "Some(0) must disable the cap");
+        assert_eq!(count, members.len());
     }
 
     // --- #235: partitioning single-read fan-out pass 2 -----------------------

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -46,9 +46,11 @@ use tylertoo_core::overview::simplify::{CollapseMode, SimplifyOptions};
 ///     max_zoom (int, optional): Maximum (finest) zoom level. Defaults to 14.
 ///     layer_name (str, optional): Override the MVT layer name (defaults to
 ///         the input filename stem).
-///     tile_size_limit (int, optional): Per-tile MVT size limit in bytes.
-///         A tile exceeding it sheds its lowest-priority features. Defaults
-///         to None (no limit).
+///     tile_size_limit (int, optional): Per-tile MVT size cap in bytes. A tile
+///         exceeding it sheds features in a single pass (largest-first for
+///         polygons/lines; a uniform spatial stride for point tiles). Defaults
+///         to 512000 (500 KiB, tippecanoe parity); pass 0 (or None) to disable
+///         the cap.
 ///     simple_clip_fastpath (bool, optional): Skip the i_overlay boundary-bridge
 ///         fallback for features whose rings are already simple (issue #239).
 ///         Faster fine-zoom polygon export; output is render-equivalent on
@@ -67,7 +69,7 @@ use tylertoo_core::overview::simplify::{CollapseMode, SimplifyOptions};
 ///     >>> convert("buildings.parquet", "buildings.pmtiles", min_zoom=0, max_zoom=14)
 ///     >>> convert("buildings.parquet", "buildings.pmtiles", layer_name="my_layer")
 #[pyfunction]
-#[pyo3(signature = (input, output, min_zoom=0, max_zoom=14, layer_name=None, tile_size_limit=None, simple_clip_fastpath=true))]
+#[pyo3(signature = (input, output, min_zoom=0, max_zoom=14, layer_name=None, tile_size_limit=512000, simple_clip_fastpath=true))]
 #[allow(clippy::too_many_arguments)] // mirrors the Python kwarg signature
 fn convert(
     py: Python<'_>,
@@ -97,7 +99,8 @@ fn convert(
         layer_name,
         tile_buffer: 8,
         extent: 4096,
-        tile_size_limit,
+        // 0 (or None) disables the cap; any positive value is the byte limit.
+        tile_size_limit: tile_size_limit.filter(|&n| n > 0),
         simple_clip_fastpath,
         // Convenience wrapper: use the core auto default (core-sized wave).
         partition_wave: tylertoo_core::overview::export::PARTITION_WAVE_AUTO,
@@ -701,9 +704,11 @@ fn overview(
 ///         (feature seam continuity). Defaults to 8.
 ///     extent (int, optional): MVT tile extent (tile-local resolution).
 ///         Defaults to 4096.
-///     tile_size_limit (int, optional): Per-tile MVT size limit in bytes.
-///         A tile exceeding it sheds its lowest-priority (smallest) features
-///         in a single non-iterative drop pass. Defaults to None (no limit).
+///     tile_size_limit (int, optional): Per-tile MVT size cap in bytes. A tile
+///         exceeding it sheds features in a single non-iterative drop pass
+///         (largest-first for polygons/lines; a uniform spatial stride for
+///         point tiles). Defaults to 512000 (500 KiB, tippecanoe parity); pass
+///         0 (or None) to disable the cap.
 ///     simple_clip_fastpath (bool, optional): Skip the i_overlay boundary-bridge
 ///         fallback for features whose rings are already simple (issue #239).
 ///         Faster fine-zoom polygon export; output is render-equivalent on
@@ -736,7 +741,7 @@ fn overview(
 ///     ...                         layer_name="admin")
 ///     >>> print(report["total_tiles"])
 #[pyfunction]
-#[pyo3(signature = (input, output, *, layer_name="overview", tile_buffer=8, extent=4096, tile_size_limit=None, simple_clip_fastpath=true, partition_wave=0))]
+#[pyo3(signature = (input, output, *, layer_name="overview", tile_buffer=8, extent=4096, tile_size_limit=512000, simple_clip_fastpath=true, partition_wave=0))]
 #[allow(clippy::too_many_arguments)] // mirrors the Python kwarg signature
 fn export_pmtiles(
     py: Python<'_>,
@@ -753,7 +758,8 @@ fn export_pmtiles(
         layer_name: layer_name.to_string(),
         tile_buffer,
         extent,
-        tile_size_limit,
+        // 0 (or None) disables the cap; any positive value is the byte limit.
+        tile_size_limit: tile_size_limit.filter(|&n| n > 0),
         simple_clip_fastpath,
         partition_wave,
     };

--- a/crates/python/tests/test_convert.py
+++ b/crates/python/tests/test_convert.py
@@ -190,6 +190,24 @@ class TestConvertIntegration:
 
             assert output.exists()
 
+    @pytest.mark.parametrize("off_value", [0, None])
+    def test_convert_tile_size_limit_off_switch(self, off_value):
+        """tile_size_limit=0 (or None) disables the default 500 KiB cap (#280)."""
+        input_file = REALDATA_DIR / "open-buildings.parquet"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "output.pmtiles"
+
+            tylertoo.convert(
+                input=str(input_file),
+                output=str(output),
+                min_zoom=0,
+                max_zoom=6,
+                tile_size_limit=off_value,
+            )
+
+            assert output.exists()
+
     def test_convert_cleans_up_temp_overview(self):
         """The intermediate overview file must not be left next to the output."""
         input_file = REALDATA_DIR / "open-buildings.parquet"

--- a/crates/python/tylertoo.pyi
+++ b/crates/python/tylertoo.pyi
@@ -14,7 +14,7 @@ def convert(
     min_zoom: int = 0,
     max_zoom: int = 14,
     layer_name: str | None = None,
-    tile_size_limit: int | None = None,
+    tile_size_limit: int | None = 512000,
     simple_clip_fastpath: bool = True,
 ) -> None: ...
 def overview(
@@ -69,7 +69,7 @@ def export_pmtiles(
     layer_name: str = "overview",
     tile_buffer: int = 8,
     extent: int = 4096,
-    tile_size_limit: int | None = None,
+    tile_size_limit: int | None = 512000,
     simple_clip_fastpath: bool = True,
     partition_wave: int = 0,
 ) -> dict[str, Any]: ...

--- a/docs/OVERVIEW_TUNING.md
+++ b/docs/OVERVIEW_TUNING.md
@@ -280,9 +280,11 @@ tylertoo overview buildings.parquet buildings_overview.parquet \
   --min-zoom 0 --max-zoom 14 \
   --polygon-visibility 0 --collapse
 
-# One-shot to PMTiles: add tippecanoe's tile cap — uncapped coarse dot
+# One-shot to PMTiles. The 500K tile cap is on by default (tippecanoe
+# parity, #280) — shown explicitly here for clarity. Uncapped coarse dot
 # tiles on a country-scale layer reach several MB (Germany z6: 12 MB),
-# far past renderer norms; the cap drop-to-fits them to ~500 KB.
+# far past renderer norms; the cap drop-to-fits them to ~500 KB (keeping a
+# spatially even stride of the dots). Pass --max-tile-size 0 to opt out.
 # On multi-GB inputs the recipe buffers the (now much larger) coarse
 # levels; the default --profile auto estimates this and spills when it
 # would exceed a fraction of available RAM (Germany peak RSS 15 -> 29 GB
@@ -1035,7 +1037,7 @@ that. If you force `speed` on a large partitioning run, watch peak RSS.
 | Wrong roads survive (residential instead of highways) at coarse zoom | add `--class-rank road_class:…` or rely on auto-detect (don't pass `--no-auto-rank`) |
 | Coarse level files are too large / slow | RAISE the thinning factors and/or `--simplify-factor`; or LOWER `--gsd-base` |
 | Small buildings vanish too early | LOWER `--polygon-visibility`; or `--collapse` to keep them as points |
-| Country-scale view of a dense building/parcel layer is empty | `--polygon-visibility 0 --collapse` + a circle layer for points ([dot-fill recipe](#country-scale-dot-fill-for-dense-polygon-layers)); cap tiles with `--max-tile-size 500K` on export |
+| Country-scale view of a dense building/parcel layer is empty | `--polygon-visibility 0 --collapse` + a circle layer for points ([dot-fill recipe](#country-scale-dot-fill-for-dense-polygon-layers)); the `500K` tile cap that keeps coarse dot tiles sane is on by default (#280) |
 | Whole map uniformly too sparse or too dense | move `--gsd-base` (up = denser, down = sparser) instead of tuning each family |
 | Mid zooms have far more features than tippecanoe / duplicating files too large | RAISE `--drop-rate` (density budget); or `--no-density-drop` to turn it off |
 | Density cut is stripping sparse rural areas to keep cities | RAISE `--drop-gamma` (sparse-area protection) |

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -153,8 +153,11 @@ recommended session settings, and the level+bbox viewport query — see
   overzoom beyond it.
 - **Tile size:** `--tile-size-limit SIZE` (accepts `500K`, `1M`, or raw
   bytes; `--max-tile-size` on `tiles` is the same knob) is a single,
-  non-iterative drop pass per oversized tile — the overview density
-  budget is the real sizing mechanism; the limit is a backstop.
+  non-iterative drop pass per oversized tile — largest-first for
+  polygon/line tiles, a uniform spatial stride for point tiles (so dot
+  survivors stay spread, not clumped). Defaults to `500K` (tippecanoe
+  parity, #280); pass `0` to disable it. The overview density budget is
+  the real sizing mechanism; the cap is a backstop.
 - **Border duplication:** a feature spanning a tile seam appears in
   every tile it touches, so per-zoom exported feature totals slightly
   exceed the level counts (~0–7%).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -62,7 +62,7 @@ Commands:
 |------|---------|-------------|
 | `--layer-name <NAME>` | `overview` | MVT layer name written into every tile |
 | `--tile-buffer <PX>` | `8` | Per-tile edge buffer in tile pixels (seam continuity) |
-| `--tile-size-limit <SIZE>` | — | Optional per-tile MVT cap, e.g. `500K`, `1M`, or raw bytes (single non-iterative drop pass). Aliased `--max-tile-size` |
+| `--tile-size-limit <SIZE>` | `500K` | Per-tile MVT cap, e.g. `500K`, `1M`, or raw bytes (single non-iterative drop pass — largest-first for polygons/lines, uniform spatial stride for point tiles). `0` disables the cap. Aliased `--max-tile-size` |
 | `--no-simple-clip-fastpath` | off (fast path on) | Disable the simple-clip fast path (#239), forcing the i_overlay boundary-bridge fallback on every polygon clip. Pass only when byte-stable tile output is required — see the note below |
 | `--report <PATH>` | — | Write the JSON export report |
 
@@ -91,7 +91,7 @@ free-space preflight warns when the chosen volume looks too small (#314).
 | `--bbox <XMIN,YMIN,XMAX,YMAX>` | — | Regional extract (lon/lat degrees); see `overview --bbox` |
 | `--layer-name <NAME>` | derived from input filename | MVT layer name |
 | `--tile-buffer <PX>` | `8` | Per-tile edge buffer in tile pixels (seam continuity) |
-| `--max-tile-size <SIZE>` | — | Per-tile byte cap, e.g. `500K`, `1M`, or raw bytes. Aliased `--tile-size-limit` |
+| `--max-tile-size <SIZE>` | `500K` | Per-tile byte cap, e.g. `500K`, `1M`, or raw bytes. `0` disables the cap. Aliased `--tile-size-limit` |
 | `--no-simple-clip-fastpath` | off (fast path on) | Disable the simple-clip fast path (#239), forcing the i_overlay fallback on every polygon clip; see the note below |
 | `-v, --verbose` | off | Per-level / per-zoom breakdowns |
 
@@ -222,7 +222,7 @@ report = export_pmtiles(
     layer_name: str = "overview",
     tile_buffer: int = 8,
     extent: int = 4096,
-    tile_size_limit: int | None = None,
+    tile_size_limit: int | None = 512000,  # 500 KiB; 0 or None disables the cap
     simple_clip_fastpath: bool = True,  # #239, default on; see CLI note
 ) -> dict  # the JSON export report
 ```
@@ -246,7 +246,7 @@ convert(
     min_zoom: int = 0,
     max_zoom: int = 14,
     layer_name: str | None = None,
-    tile_size_limit: int | None = None,
+    tile_size_limit: int | None = 512000,  # 500 KiB; 0 or None disables the cap
     simple_clip_fastpath: bool = True,  # #239, default on; see CLI note
 ) -> None
 ```


### PR DESCRIPTION
Closes #280. Follow-up to #259 / #278.

## What

Makes the per-tile MVT size cap **on by default at 500 KiB** (tippecanoe parity), across core, CLI, and Python. Previously there was no cap unless `--max-tile-size` was passed, which let the #259 dot-fill recipe emit 12 MB coarse tiles (hence the recipe carried `--max-tile-size 500K` explicitly).

## Changes

- **Default flip.** `ExportOptions::tile_size_limit` → `Some(500 * 1024)` (new `pub const DEFAULT_TILE_SIZE_LIMIT`). CLI `--max-tile-size` / `--tile-size-limit` default to `500K`; Python `tile_size_limit` defaults to `512000`.
- **Off switch.** `--max-tile-size 0` (CLI), `tile_size_limit=0` or `None` (Python), or `None` (core `ExportOptions`) disables the cap. The core encode guard also treats `Some(0)` as off, so the API can't foot-gun a degenerate `keep=1`.
- **Dot-tile spatial fairness (the #280 ask).** The single-pass drop valve ranked features by vertex count — degenerate for points, so a size-ranked prefix just kept whichever points sorted first and clumped them in one corner. New `select_kept_members` keeps a **uniform stride across member (Hilbert) order** for point-dominated tiles (the same spatially-even thinning tippecanoe gets by dropping every Nth feature in sequence). Sized geometries (polygons/lines) still keep the largest-first prefix — **byte-identical to pre-#280**.

## Re-baselining

No frozen-hash re-baseline needed: the sized-geometry drop path is unchanged, and the default 500 KiB cap never binds on any existing fixture (all tiny). The only test that assumed "default = no limit" (`oversized_valve_fires_with_tiny_limit`) now passes `None` explicitly for its no-limit branch.

## Tests

- **core** (`overview::export::tests`, 26 pass): `default_export_caps_tiles_at_500_kib`, `drop_valve_point_tile_keeps_uniform_stride`, `drop_valve_sized_tile_keeps_largest`, `size_limit_zero_disables_valve`, plus the updated valve test.
- **CLI**: `tile_size_cap_defaults_to_500k_and_zero_disables` (default `500K` on both `tiles` and `export-pmtiles`; `0` maps to `None`), updated alias test.
- **Python**: `test_convert_tile_size_limit_off_switch[0/None]`.
- **Integration**: `decode_roundtrip` golden-vs-`tippecanoe-decode` (8 pass) — unaffected by the flip.
- **End-to-end**: `tiles` with the default cap and with `--max-tile-size 0` both produce valid PMTiles; a 2K cap on the dot-fill recipe fires the valve on **5/9** point tiles with correct `oversized_tiles` report wiring.

## Docs

Updated `api-reference.md`, `advanced-usage.md`, `OVERVIEW_TUNING.md`, `getting-started.md`, `context/ARCHITECTURE.md`, and `corpus/SWEEPS.md` to reflect the default and the `0` off switch.

## Design note

Chose `0` as the off switch (over a separate `--no-max-tile-size` flag the issue floated) — one value, no flag-conflict handling, and it reads naturally against the byte-size argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)