### PR TITLE
feat(overview): H3 aggregate overview levels (#332)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ arrow-array = "58"
 arrow-select = "58"
 arrow-ipc = "58"
 arrow-cast = "58"
-geo = "0.32"
+geo = "0.33"
 geozero = { version = "0.14", features = ["with-wkb", "with-geo"] }
 
 # Protobuf for MVT encoding
@@ -44,6 +44,7 @@ rayon = "1.10"
 rstar = "0.13"
 crossbeam-channel = "0.5"
 dashmap = "6"
+h3o = { version = "0.10", features = ["geo"] }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -422,8 +422,8 @@ struct ConvertTuningArgs {
     collapse_square: bool,
 
     /// Zoom-band representation selector: comma-separated LO-HI:KIND bands,
-    /// e.g. "0-7:point,8-14:geom" or "0-5:square". KIND is geom, point, or
-    /// square.
+    /// e.g. "0-7:point,8-14:geom", "0-5:square", or "0-5:h3,6-14:geom". KIND is
+    /// geom, point, square, or h3.
     ///
     /// point: ALL polygonal features in the band become representative
     /// points (centroid) — "dots zoomed out, polygons zoomed in" in ONE

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -46,6 +46,7 @@ geozero = { workspace = true }
 prost = { workspace = true }
 rayon = { workspace = true }
 crossbeam-channel = { workspace = true }
+h3o = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }
 tracing = { workspace = true }

--- a/crates/core/src/overview/convert.rs
+++ b/crates/core/src/overview/convert.rs
@@ -940,6 +940,45 @@ fn validate_options(options: &ConvertOptions) -> Result<(), ConvertError> {
                 _ => seen_non_point_coarser = true,
             }
         }
+        // H3 aggregate bands (#332). H3 replaces the coarse zooms with cell
+        // aggregates that hand off to real geometry as you zoom in, so it must
+        // be a contiguous prefix from the plan's min zoom (like point), and —
+        // for v1 — it is not composable with the point/square per-feature
+        // bands, which have incompatible per-feature semantics.
+        let has_h3 = options
+            .representation
+            .iter()
+            .any(|b| b.repr == Representation::H3);
+        if has_h3 {
+            if options
+                .representation
+                .iter()
+                .any(|b| matches!(b.repr, Representation::Point | Representation::Square))
+            {
+                return Err(ConvertError::InvalidConfig(
+                    "h3 bands cannot be combined with point or square bands: H3 \
+                     aggregates whole cells whereas point/square transform each \
+                     feature individually"
+                        .to_string(),
+                ));
+            }
+            let mut seen_non_h3_coarser = false;
+            for slot in &claimed {
+                match slot {
+                    Some(Representation::H3) => {
+                        if seen_non_h3_coarser {
+                            return Err(ConvertError::InvalidConfig(
+                                "h3 bands must start at the plan's min zoom and be \
+                                 contiguous from the coarsest level: H3 aggregates the \
+                                 zoomed-out view and hands off to geometry as you zoom in"
+                                    .to_string(),
+                            ));
+                        }
+                    }
+                    _ => seen_non_h3_coarser = true,
+                }
+            }
+        }
     }
     // in_flight_batches == 0 is the IN_FLIGHT_BATCHES_AUTO sentinel (resolved
     // to available parallelism at pass-2 setup), not an error. Any explicit
@@ -986,12 +1025,13 @@ pub(super) fn representation_for_zoom(
         .unwrap_or_default()
 }
 
-/// Parse a representation spec string (#317 / #279): comma-separated
-/// `LO-HI:KIND` (or `Z:KIND`) entries, e.g. `0-7:point,8-14:geom` or
-/// `0-5:square`. KIND is one of `geom` (alias `geometry`), `point`,
-/// `square`. Shared by the CLI and the Python bindings so the grammar has a
-/// single definition; structural validity against the level plan is checked
-/// later by convert-entry validation.
+/// Parse a representation spec string (#317 / #279 / #332): comma-separated
+/// `LO-HI:KIND` (or `Z:KIND`) entries, e.g. `0-7:point,8-14:geom`,
+/// `0-5:square`, or `0-5:h3,6-14:geom`. KIND is one of `geom` (alias
+/// `geometry`), `point`, `square`, or `h3` (H3 aggregate cells; resolution is
+/// auto-derived per zoom). Shared by the CLI and the Python bindings so the
+/// grammar has a single definition; structural validity against the level plan
+/// is checked later by convert-entry validation.
 pub fn parse_representation_spec(spec: &str) -> Result<Vec<RepresentationBand>, String> {
     let mut bands = Vec::new();
     for part in spec.split(',') {
@@ -1006,9 +1046,10 @@ pub fn parse_representation_spec(spec: &str) -> Result<Vec<RepresentationBand>, 
             "geom" | "geometry" => Representation::Geometry,
             "point" => Representation::Point,
             "square" => Representation::Square,
+            "h3" => Representation::H3,
             other => {
                 return Err(format!(
-                    "unknown representation {other:?} (expected geom, point, or square)"
+                    "unknown representation {other:?} (expected geom, point, square, or h3)"
                 ))
             }
         };
@@ -1187,6 +1228,7 @@ fn decode_and_filter_geometries(
 /// [`convert_to_overviews_source`] with an explicit pass-2 [`Pass2Strategy`].
 /// Runs the full option normalization (validation, cluster/accumulate checks,
 /// the partitioning-coalesce-inert rewrite) before dispatching.
+#[allow(clippy::cognitive_complexity)]
 pub(crate) fn convert_to_overviews_source_strategy(
     source: &ConvertSource,
     output_path: &Path,
@@ -1594,9 +1636,31 @@ pub(crate) fn convert_to_overviews_source_strategy(
     // same type so RecordBatch assembly matches.
     let geom_out_field = mixed_geometry_field(&geom_name);
     let source_schema = build_source_schema(&input_schema, geom_idx, geom_out_field.clone());
-    // Writer schema: base + point_count when clustering (Q4) + coalesced_count
-    // when coalescing (Q3).
-    let cluster_schema = if options.cluster {
+    // H3 aggregate bands (#332) reuse the `point_count` column as the cell
+    // feature count, so its presence is implied by H3 just as it is by
+    // clustering. Precompute every feature's representative point once (bbox
+    // center → lon/lat) for the per-level cell binning.
+    let has_h3 = options
+        .representation
+        .iter()
+        .any(|b| b.repr == Representation::H3);
+    let h3_points: Vec<(f64, f64)> = if has_h3 {
+        super::h3agg::rep_points_lonlat(&features, crs)
+    } else {
+        Vec::new()
+    };
+    // H3 cell rows carry NULL for every source attribute (a cell is an
+    // aggregate, not a feature), so those columns must be nullable in the
+    // output schema. Geometry and generated columns are untouched; geom-level
+    // rows keep their real (non-null) values in the now-nullable columns.
+    let source_schema = if has_h3 {
+        relax_source_nullability(&source_schema, geom_idx)
+    } else {
+        source_schema
+    };
+    // Writer schema: base + point_count when clustering (Q4) or H3 (#332) +
+    // coalesced_count when coalescing (Q3).
+    let cluster_schema = if options.cluster || has_h3 {
         append_point_count_field(&source_schema)
     } else {
         source_schema.clone()
@@ -1634,27 +1698,62 @@ pub(crate) fn convert_to_overviews_source_strategy(
 
     let mut level_reports = Vec::with_capacity(emitted.len());
     for (level_idx, e) in emitted.iter().enumerate() {
-        let mut batch = build_level_batch(
-            &source_schema,
-            &full,
-            &non_geom_cols,
-            geom_idx,
-            &e.indices,
-            &e.geoms,
-        )?;
-        if let Some(tables) = &cluster_tables {
-            // Canonical level: singleton clusters, columns verbatim (§2.4).
-            let table = (e.orig != finest).then(|| &tables[e.orig]);
-            batch = apply_cluster_columns(batch, &cluster_schema, &e.indices, table, &acc_cols)?;
-        }
+        let repr = representation_for_zoom(&options.representation, e.zoom);
+        // Row count hint and the index slice that drives the coalesced_count
+        // append: an H3 level emits one row per occupied cell, a geom level one
+        // per surviving feature.
+        // H3 levels report Σ point_count (input features binned), not cell count.
+        let (mut batch, coalesce_idx, feature_count): (RecordBatch, Vec<usize>, usize) =
+            if repr == Representation::H3 {
+                // #332: replace this coarse level's features with H3 cell
+                // aggregates. Binning is over the whole dataset's rep points at
+                // the level's auto-derived resolution — independent of the
+                // per-feature level assignment used by the geom levels.
+                let res = super::level::h3_res_for_gsd(e.gsd);
+                let rows = super::h3agg::aggregate_h3_cells(h3_points.iter().copied(), res);
+                let n_features: usize = rows.iter().map(|r| r.count as usize).sum();
+                let idx = vec![0usize; rows.len()];
+                (
+                    build_h3_level_batch(&cluster_schema, geom_idx, &rows)?,
+                    idx,
+                    n_features,
+                )
+            } else {
+                let mut b = build_level_batch(
+                    &source_schema,
+                    &full,
+                    &non_geom_cols,
+                    geom_idx,
+                    &e.indices,
+                    &e.geoms,
+                )?;
+                // point_count: cluster table when clustering; all-1 when the
+                // column exists only because H3 is present elsewhere.
+                if cluster_tables.is_some() || has_h3 {
+                    let table = cluster_tables
+                        .as_ref()
+                        .filter(|_| e.orig != finest)
+                        .map(|t| &t[e.orig]);
+                    b = apply_cluster_columns(b, &cluster_schema, &e.indices, table, &acc_cols)?;
+                }
+                let n = e.indices.len();
+                (b, e.indices.clone(), n)
+            };
         if options.coalesce_lines {
             // Canonical level (and guard-skipped runs): table is None ⇒ all 1.
-            batch = apply_coalesced_count(batch, &out_schema, &e.indices, e.coalesce.as_ref())?;
+            // H3 cell rows always coalesce to 1 (table None, correct length).
+            let table = if repr == Representation::H3 {
+                None
+            } else {
+                e.coalesce.as_ref()
+            };
+            batch = apply_coalesced_count(batch, &out_schema, &coalesce_idx, table)?;
         }
+        let level_rows = batch.num_rows();
         // SkippedEmpty is unreachable here (every emitted level has >= 1
         // feature), but the bookkeeping stays aligned with the streaming path.
-        let outcome =
-            writer.write_level(level_idx, Some(e.indices.len()), std::iter::once(batch))?;
+        let outcome = writer.write_level(level_idx, Some(level_rows), std::iter::once(batch))?;
+        // H3 levels report Σ point_count (input features binned) as feature_count.
         record_level_outcome(
             outcome,
             SkippedLevelReport {
@@ -1662,8 +1761,8 @@ pub(crate) fn convert_to_overviews_source_strategy(
                 gsd: e.gsd,
                 zoom: e.zoom,
             },
-            e.indices.len(),
-            e.indices.len(),
+            level_rows,
+            feature_count,
             e.vertex_count,
             &mut level_reports,
             &mut skipped,
@@ -2343,6 +2442,72 @@ pub(super) fn build_level_batch(
     }
     Ok(RecordBatch::try_new(
         Arc::new(source_schema.clone()),
+        columns,
+    )?)
+}
+
+/// Mark every non-geometry source column nullable (#332). H3 aggregate cells
+/// carry no per-feature attributes, so the output schema must permit NULLs in
+/// those columns; geometry keeps its own field verbatim. Widening nullability
+/// is safe for the geom levels, whose columns still hold their real values.
+pub(super) fn relax_source_nullability(schema: &Schema, geom_idx: usize) -> Schema {
+    let fields: Vec<Arc<Field>> = schema
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(i, f)| {
+            if i == geom_idx || f.is_nullable() {
+                f.clone()
+            } else {
+                Arc::new(f.as_ref().clone().with_nullable(true))
+            }
+        })
+        .collect();
+    Schema::new_with_metadata(fields, schema.metadata().clone())
+}
+
+/// Build an H3 aggregate level's output batch (#332), shaped to `cluster_schema`
+/// (source columns + `point_count`).
+///
+/// Every source attribute column is NULL — an H3 cell is an aggregate, not a
+/// feature, so it carries no per-feature values (v1 aggregates only a count).
+/// The geometry column holds the cell boundary polygons and `point_count` holds
+/// each cell's feature count, reusing the clustering column so the count rides
+/// the existing writer + MVT-property plumbing with no new schema. The caller
+/// applies [`apply_coalesced_count`] afterwards exactly as for a geom level.
+pub(super) fn build_h3_level_batch(
+    cluster_schema: &Schema,
+    geom_idx: usize,
+    rows: &[super::h3agg::H3CellRow],
+) -> Result<RecordBatch, ConvertError> {
+    use arrow_array::{new_null_array, Int64Array};
+
+    let n = rows.len();
+    let point_count_idx = cluster_schema.fields().len() - 1;
+    debug_assert_eq!(
+        cluster_schema.field(point_count_idx).name(),
+        super::cluster::POINT_COUNT_COLUMN,
+        "H3 batch expects point_count as the last cluster_schema column"
+    );
+
+    let mut columns: Vec<Arc<dyn Array>> = Vec::with_capacity(cluster_schema.fields().len());
+    for (i, field) in cluster_schema.fields().iter().enumerate() {
+        if i == geom_idx {
+            let typ = GeometryType::new(Default::default());
+            let mut b = GeometryBuilder::new(typ).with_prefer_multi(false);
+            b.extend_from_iter(rows.iter().map(|r| Some(&r.geometry)));
+            columns.push(b.finish().to_array_ref());
+        } else if i == point_count_idx {
+            columns.push(Arc::new(Int64Array::from(
+                rows.iter().map(|r| r.count).collect::<Vec<_>>(),
+            )));
+        } else {
+            // Aggregate cells carry no per-feature attribute values.
+            columns.push(new_null_array(field.data_type(), n));
+        }
+    }
+    Ok(RecordBatch::try_new(
+        Arc::new(cluster_schema.clone()),
         columns,
     )?)
 }
@@ -4054,6 +4219,166 @@ mod tests {
         assert!(gen.collapse.is_none(), "no global collapse requested");
     }
 
+    /// THE #332 acceptance anchor (in-memory path): an H3 band yields coarse
+    /// levels of hexagon cells carrying a `point_count`, while the finer levels
+    /// keep the real polygons — one archive, no merge. Cell counts partition
+    /// the input exactly (Σ point_count == feature count).
+    #[test]
+    fn representation_h3_band_cells_coarse_polygons_fine() {
+        use arrow_array::cast::AsArray;
+        use arrow_array::types::Int64Type;
+
+        let geoms = polygon_fixture();
+        let tin = tempfile::NamedTempFile::new().unwrap();
+        let tout = tempfile::NamedTempFile::new().unwrap();
+        write_input(tin.path(), &geoms, false, None);
+
+        let opts = ConvertOptions {
+            mode: Mode::Duplicating,
+            levels: LevelPlan::ZoomRange {
+                min_zoom: 0,
+                max_zoom: 6,
+            },
+            representation: vec![
+                band(0, 3, Representation::H3),
+                band(4, 6, Representation::Geometry),
+            ],
+            streaming: false, // exercise the in-memory pipeline
+            ..Default::default()
+        };
+        let report = convert_to_overviews(tin.path(), tout.path(), &opts).unwrap();
+        assert!(validate_file(tout.path()).unwrap().is_valid());
+
+        let reader = OverviewReader::open(tout.path()).unwrap();
+        for (idx, lvl) in report.levels.iter().enumerate() {
+            let zoom = lvl.zoom.expect("zoom-range plan records zooms");
+            if zoom <= 3 {
+                // H3 levels: every geometry is a hexagon cell (Polygon /
+                // MultiPolygon) and the per-cell counts sum to the input size.
+                let mut total: i64 = 0;
+                let mut any = false;
+                for batch in reader.read_level(idx, None).unwrap() {
+                    let batch = batch.unwrap();
+                    let gcol = batch.column(batch.schema().index_of("geometry").unwrap());
+                    let field = batch
+                        .schema()
+                        .field(batch.schema().index_of("geometry").unwrap())
+                        .clone();
+                    let garr: Arc<dyn GeoArrowArray> =
+                        from_arrow_array(gcol.as_ref(), &field).unwrap();
+                    let mut gvec = Vec::new();
+                    extract_geometries_from_array(garr.as_ref(), &mut gvec).unwrap();
+                    for g in &gvec {
+                        assert!(
+                            matches!(g, Geometry::Polygon(_) | Geometry::MultiPolygon(_)),
+                            "H3 level z{zoom} must be cell polygons, got {g:?}"
+                        );
+                        any = true;
+                    }
+                    let pc = batch
+                        .column(batch.schema().index_of("point_count").unwrap())
+                        .as_primitive::<Int64Type>()
+                        .clone();
+                    for i in 0..pc.len() {
+                        total += pc.value(i);
+                    }
+                }
+                assert!(any, "H3 level z{zoom} produced no cells");
+                assert_eq!(
+                    total,
+                    geoms.len() as i64,
+                    "H3 level z{zoom}: Σ point_count must equal the feature count"
+                );
+            } else {
+                // Geom levels keep real polygons and count 1 per feature.
+                let rows = read_level_rows(&reader, idx);
+                assert!(
+                    rows.iter().any(|(_, _, _, g)| matches!(
+                        g,
+                        Geometry::Polygon(_) | Geometry::MultiPolygon(_)
+                    )),
+                    "geom level z{zoom} must keep polygons"
+                );
+            }
+        }
+
+        // Canonical (finest) level is verbatim: the original polygons, in order.
+        let canonical = read_level_rows(&reader, report.levels.len() - 1);
+        assert_eq!(canonical.len(), geoms.len());
+        for (i, (_, _, _, g)) in canonical.iter().enumerate() {
+            assert_eq!(g, &geoms[i]);
+        }
+    }
+
+    /// #332: the streaming pipeline (default) writes the H3 cell prefix directly
+    /// and pipelines the geom suffix. Same invariants as the in-memory anchor:
+    /// coarse levels are hexagon cells whose counts partition the input, finer
+    /// levels keep polygons, canonical verbatim. Runs both pass-2 strategies.
+    #[test]
+    fn representation_h3_band_streaming_produces_cells() {
+        use super::super::stream::Pass2Strategy;
+        use arrow_array::cast::AsArray;
+        use arrow_array::types::Int64Type;
+
+        for strategy in [Pass2Strategy::Pipelined, Pass2Strategy::Serial] {
+            let geoms = polygon_fixture();
+            let tin = tempfile::NamedTempFile::new().unwrap();
+            let tout = tempfile::NamedTempFile::new().unwrap();
+            write_input(tin.path(), &geoms, false, None);
+
+            let opts = ConvertOptions {
+                mode: Mode::Duplicating,
+                levels: LevelPlan::ZoomRange {
+                    min_zoom: 0,
+                    max_zoom: 6,
+                },
+                representation: vec![
+                    band(0, 3, Representation::H3),
+                    band(4, 6, Representation::Geometry),
+                ],
+                streaming: true,
+                ..Default::default()
+            };
+            let report =
+                convert_to_overviews_strategy(tin.path(), tout.path(), &opts, strategy).unwrap();
+            assert!(validate_file(tout.path()).unwrap().is_valid());
+
+            let reader = OverviewReader::open(tout.path()).unwrap();
+            for (idx, lvl) in report.levels.iter().enumerate() {
+                let zoom = lvl.zoom.unwrap();
+                if zoom <= 3 {
+                    let mut total: i64 = 0;
+                    for batch in reader.read_level(idx, None).unwrap() {
+                        let batch = batch.unwrap();
+                        let pc = batch
+                            .column(batch.schema().index_of("point_count").unwrap())
+                            .as_primitive::<Int64Type>()
+                            .clone();
+                        for i in 0..pc.len() {
+                            total += pc.value(i);
+                        }
+                    }
+                    assert_eq!(
+                        total,
+                        geoms.len() as i64,
+                        "H3 level z{zoom}: \u{3a3} point_count must equal feature count"
+                    );
+                } else {
+                    let rows = read_level_rows(&reader, idx);
+                    assert!(
+                        rows.iter().any(|(_, _, _, g)| matches!(
+                            g,
+                            Geometry::Polygon(_) | Geometry::MultiPolygon(_)
+                        )),
+                        "geom level z{zoom} must keep polygons"
+                    );
+                }
+            }
+            let canonical = read_level_rows(&reader, report.levels.len() - 1);
+            assert_eq!(canonical.len(), geoms.len());
+        }
+    }
+
     /// Streaming and in-memory pipelines produce identical per-level rows
     /// for a point-band conversion (the #218-style engine equivalence).
     #[test]
@@ -4303,6 +4628,11 @@ mod tests {
         // Single-zoom entry and the "geometry" alias.
         let bands = parse_representation_spec("3:geometry").unwrap();
         assert_eq!(bands, vec![band(3, 3, Representation::Geometry)]);
+
+        // H3 aggregate band (#332), param-free like point/square.
+        let bands = parse_representation_spec("0-5:h3,6-14:geom").unwrap();
+        assert_eq!(bands[0], band(0, 5, Representation::H3));
+        assert_eq!(bands[1], band(6, 14, Representation::Geometry));
 
         assert!(parse_representation_spec("").is_err());
         assert!(parse_representation_spec("0-7").is_err());

--- a/crates/core/src/overview/export.rs
+++ b/crates/core/src/overview/export.rs
@@ -2886,7 +2886,7 @@ fn detect_crs(path: &Path) -> Result<Crs, ExportError> {
 
 /// Reproject one EPSG:3857 point (meters) to EPSG:4326 (lon/lat degrees).
 #[inline]
-fn webmerc_to_lnglat(x: f64, y: f64) -> (f64, f64) {
+pub(super) fn webmerc_to_lnglat(x: f64, y: f64) -> (f64, f64) {
     let lng = x / WEBMERC_HALF_M * 180.0;
     let lat = (2.0 * (y / WEBMERC_HALF_M * std::f64::consts::PI).exp().atan()
         - std::f64::consts::FRAC_PI_2)

--- a/crates/core/src/overview/h3agg.rs
+++ b/crates/core/src/overview/h3agg.rs
@@ -1,0 +1,203 @@
+//! H3 aggregate overview levels (#332).
+//!
+//! At coarse zooms an overview can render **H3 cell aggregates** instead of the
+//! real features: every feature is binned into the H3 cell covering its
+//! representative point, and each occupied cell becomes one output row carrying
+//! the cell's feature `count` and its boundary polygon. Zooming in, the geom
+//! band takes over and the real geometry returns — one PMTiles archive, no
+//! two-archive merge. This mirrors what `gpio process aggregate h3` does in
+//! geoparquet-io, and slots in as a row-collapsing sibling of the point/square
+//! representation bands (see [`super::simplify::Representation`]).
+//!
+//! # DIVERGENCE FROM geoparquet-io
+//!
+//! gpio bins on the true `ST_Centroid`. We bin on the **bbox center** that
+//! [`super::assign::AssignFeature`] already computes for level assignment (see
+//! `assign.rs` §"representative point"), so H3 keying costs nothing extra. For
+//! a count aggregation the difference is immaterial — both place a feature in
+//! one cell — and it keeps the hot path allocation-free.
+//!
+//! This module is deliberately **CRS-free and geometry-free on input**: the
+//! caller supplies representative points already in lon/lat degrees (the convert
+//! wiring reprojects EPSG:3857 rep points with
+//! [`super::export::webmerc_to_lnglat`] before calling in). That keeps the
+//! aggregator a pure, exhaustively testable function.
+
+use std::collections::HashMap;
+
+use geo::{Geometry, MultiPolygon};
+use h3o::{CellIndex, LatLng, Resolution};
+
+use super::assign::AssignFeature;
+use super::export::webmerc_to_lnglat;
+use super::level::Crs;
+
+/// The representative point (lon/lat degrees) each feature is binned by: the
+/// bbox center [`AssignFeature`] already carries. EPSG:3857 centers are
+/// reprojected to lon/lat; EPSG:4326 centers already are lon/lat.
+///
+/// See the module-level DIVERGENCE note on bbox-center vs true centroid.
+pub(super) fn rep_points_lonlat(features: &[AssignFeature], crs: Crs) -> Vec<(f64, f64)> {
+    features
+        .iter()
+        .map(|f| {
+            let (x, y) = f.center();
+            match crs {
+                Crs::Epsg4326 => (x, y),
+                Crs::Epsg3857 => webmerc_to_lnglat(x, y),
+            }
+        })
+        .collect()
+}
+
+/// One aggregated H3 cell: its id, the number of source features binned into
+/// it, and its boundary geometry in lon/lat degrees.
+#[derive(Debug, Clone, PartialEq)]
+pub struct H3CellRow {
+    /// The H3 cell index as a raw `u64` (written to the `h3_cell` column).
+    pub cell: u64,
+    /// Number of source features whose representative point fell in this cell.
+    pub count: i64,
+    /// The cell boundary as a `geo` geometry (a `Polygon`, or a `MultiPolygon`
+    /// for cells that h3o splits at the antimeridian).
+    pub geometry: Geometry<f64>,
+}
+
+/// Aggregate representative points into H3 cells at `resolution`.
+///
+/// Each `(lon, lat)` in degrees is binned into the covering H3 cell; the result
+/// is one [`H3CellRow`] per occupied cell, **ordered by cell id** so the output
+/// is deterministic regardless of input order. Points that are not valid
+/// lat/lng (non-finite, out of range) are skipped, so
+/// `Σ row.count <= points.len()` with equality when every point is valid.
+pub fn aggregate_h3_cells<I>(points_lonlat: I, resolution: Resolution) -> Vec<H3CellRow>
+where
+    I: IntoIterator<Item = (f64, f64)>,
+{
+    let mut counts: HashMap<CellIndex, i64> = HashMap::new();
+    for (lon, lat) in points_lonlat {
+        let Ok(ll) = LatLng::new(lat, lng_wrap(lon)) else {
+            continue;
+        };
+        *counts.entry(ll.to_cell(resolution)).or_insert(0) += 1;
+    }
+    let mut rows: Vec<H3CellRow> = counts
+        .into_iter()
+        .map(|(cell, count)| H3CellRow {
+            cell: u64::from(cell),
+            count,
+            geometry: cell_geometry(cell),
+        })
+        .collect();
+    rows.sort_unstable_by_key(|r| r.cell);
+    rows
+}
+
+/// Normalize a longitude into `[-180, 180]`. Reprojected 3857 rep points can
+/// land a hair outside the range at the antimeridian; h3o rejects those, so
+/// wrap first rather than silently drop the feature.
+#[inline]
+fn lng_wrap(lon: f64) -> f64 {
+    if !lon.is_finite() {
+        return lon; // let LatLng::new reject it
+    }
+    let mut l = (lon + 180.0) % 360.0;
+    if l < 0.0 {
+        l += 360.0;
+    }
+    l - 180.0
+}
+
+/// The cell boundary as a `geo::Geometry` in lon/lat degrees. h3o's `geo`
+/// feature yields a `MultiPolygon` already converted to degrees; a normal cell
+/// is a single ring, which we unwrap to a `Polygon` for a leaner MVT feature,
+/// keeping the `MultiPolygon` only for antimeridian-split cells.
+fn cell_geometry(cell: CellIndex) -> Geometry<f64> {
+    let mut mp = MultiPolygon::<f64>::from(cell);
+    if mp.0.len() == 1 {
+        Geometry::Polygon(mp.0.pop().unwrap())
+    } else {
+        Geometry::MultiPolygon(mp)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use geo::CoordsIter;
+
+    fn res(r: u8) -> Resolution {
+        Resolution::try_from(r).unwrap()
+    }
+
+    #[test]
+    fn counts_are_exact_and_order_independent() {
+        // Three points: two coincide (same cell), one elsewhere. Feeding them
+        // in two different orders must produce the identical row set, and the
+        // counts must sum to the input size.
+        let a = (2.349014, 48.864716); // Paris
+        let b = (2.349001, 48.864700); // ~2 m away -> same cell at res 6
+        let c = (-73.985, 40.748); // NYC
+        let forward = aggregate_h3_cells([a, b, c], res(6));
+        let reversed = aggregate_h3_cells([c, b, a], res(6));
+        assert_eq!(forward, reversed, "output must be order-independent");
+
+        let total: i64 = forward.iter().map(|r| r.count).sum();
+        assert_eq!(total, 3, "Σcount must equal the valid input point count");
+        assert_eq!(forward.len(), 2, "Paris pair collapses, NYC stands alone");
+        let paris = forward.iter().find(|r| r.count == 2).unwrap();
+        assert_eq!(paris.count, 2);
+    }
+
+    #[test]
+    fn finer_resolution_splits_nearby_points() {
+        // Two points ~2 m apart share a coarse cell but separate at a fine one.
+        let a = (2.349014, 48.864716);
+        let b = (2.349200, 48.864716);
+        assert_eq!(aggregate_h3_cells([a, b], res(6)).len(), 1);
+        assert_eq!(aggregate_h3_cells([a, b], res(13)).len(), 2);
+    }
+
+    #[test]
+    fn non_finite_points_are_skipped_not_panicked() {
+        // h3o normalizes finite-but-out-of-range coordinates internally, so the
+        // only inputs we drop are the non-finite ones (NaN / ±Inf in either
+        // component). Garbage in must never panic.
+        let good = (10.0, 50.0);
+        let rows = aggregate_h3_cells(
+            [
+                good,
+                (f64::NAN, 0.0),
+                (0.0, f64::NAN),
+                (f64::INFINITY, 0.0),
+                (0.0, f64::NEG_INFINITY),
+            ],
+            res(5),
+        );
+        let total: i64 = rows.iter().map(|r| r.count).sum();
+        assert_eq!(total, 1, "only the one finite point should be counted");
+    }
+
+    #[test]
+    fn cell_geometry_is_a_closed_nonempty_ring() {
+        let rows = aggregate_h3_cells([(0.0, 0.0)], res(4));
+        let geom = &rows[0].geometry;
+        let poly = match geom {
+            Geometry::Polygon(p) => p,
+            other => panic!("expected a Polygon near the equator, got {other:?}"),
+        };
+        let ext = poly.exterior();
+        // A hexagon ring is 7 coords (6 verts + closing point); pentagons 6.
+        assert!(ext.coords_count() >= 4, "ring too small");
+        let first = ext.coords().next().unwrap();
+        let last = ext.coords().last().unwrap();
+        assert_eq!(first, last, "exterior ring must be closed");
+    }
+
+    #[test]
+    fn longitudes_just_past_the_antimeridian_wrap_in() {
+        // 180.0000001 must not be dropped; it wraps to ~-179.9999999.
+        let rows = aggregate_h3_cells([(180.000_000_1, 0.0)], res(3));
+        assert_eq!(rows.iter().map(|r| r.count).sum::<i64>(), 1);
+    }
+}

--- a/crates/core/src/overview/level.rs
+++ b/crates/core/src/overview/level.rs
@@ -85,6 +85,64 @@ pub fn gsd(z: u8) -> f64 {
     gsd_with_base(z, GSD_TILE_BASE)
 }
 
+/// The 16 H3 resolutions, coarse (0) → fine (15), for edge-length scanning.
+const H3_RESOLUTIONS: [h3o::Resolution; 16] = [
+    h3o::Resolution::Zero,
+    h3o::Resolution::One,
+    h3o::Resolution::Two,
+    h3o::Resolution::Three,
+    h3o::Resolution::Four,
+    h3o::Resolution::Five,
+    h3o::Resolution::Six,
+    h3o::Resolution::Seven,
+    h3o::Resolution::Eight,
+    h3o::Resolution::Nine,
+    h3o::Resolution::Ten,
+    h3o::Resolution::Eleven,
+    h3o::Resolution::Twelve,
+    h3o::Resolution::Thirteen,
+    h3o::Resolution::Fourteen,
+    h3o::Resolution::Fifteen,
+];
+
+/// Pick the H3 resolution whose average hexagon edge length best matches a
+/// target ground sample distance (#332 auto per-zoom resolution).
+///
+/// H3 aggregate overview levels are param-free (like the `point`/`square`
+/// representation bands): each banded zoom auto-selects a resolution so coarse
+/// zooms get large hexagons and each finer zoom densifies, smoothly handing off
+/// to real geometry at the geom band. The match is nearest in **log-ratio** of
+/// [`h3o::Resolution::edge_length_m`] to `gsd_m`, which treats "hexagon twice
+/// the GSD" and "hexagon half the GSD" as equally far — the natural metric for
+/// a quantity that scales geometrically with zoom. A non-finite or non-positive
+/// `gsd_m` falls back to the coarsest resolution.
+///
+/// This is a deliberately simple geometric heuristic; a count- or
+/// tile-size-driven refinement (gpio's `--auto`) can layer on later without
+/// changing the band grammar.
+pub fn h3_res_for_gsd(gsd_m: f64) -> h3o::Resolution {
+    if !gsd_m.is_finite() || gsd_m <= 0.0 {
+        return h3o::Resolution::Zero;
+    }
+    let target = gsd_m.ln();
+    let mut best = h3o::Resolution::Zero;
+    let mut best_dist = f64::INFINITY;
+    for res in H3_RESOLUTIONS {
+        let dist = (res.edge_length_m().ln() - target).abs();
+        if dist < best_dist {
+            best_dist = dist;
+            best = res;
+        }
+    }
+    best
+}
+
+/// [`h3_res_for_gsd`] for a Web Mercator zoom under a given tile-band `base`
+/// (the same `base` that drives [`gsd_with_base`]).
+pub fn h3_res_for_zoom(z: u8, base: f64) -> h3o::Resolution {
+    h3_res_for_gsd(gsd_with_base(z, base))
+}
+
 /// Inverse of [`gsd`]: the (fractional) Web Mercator zoom for a target GSD.
 ///
 /// `z = log2(40_075_016.69 / 1024 / gsd)`. Returns a float; callers that need
@@ -706,6 +764,39 @@ mod tests {
                 },
             ],
             generalization: None,
+        }
+    }
+
+    #[test]
+    fn h3_res_for_gsd_monotonic_ladder() {
+        // Finer zoom (smaller GSD) must never select a coarser H3 resolution:
+        // the auto ladder densifies monotonically as you zoom in.
+        let mut prev = u8::from(h3_res_for_zoom(0, GSD_TILE_BASE));
+        for z in 1u8..=15 {
+            let res = u8::from(h3_res_for_zoom(z, GSD_TILE_BASE));
+            assert!(res >= prev, "z={z}: res {res} coarser than previous {prev}");
+            prev = res;
+        }
+    }
+
+    #[test]
+    fn h3_res_for_gsd_matches_nearest_edge_length() {
+        // An exact H3 edge length maps to that resolution (log-ratio distance
+        // is zero at the anchor, positive at every neighbour).
+        for res in H3_RESOLUTIONS {
+            assert_eq!(
+                u8::from(h3_res_for_gsd(res.edge_length_m())),
+                u8::from(res),
+                "edge length of res {} should map back to itself",
+                u8::from(res)
+            );
+        }
+    }
+
+    #[test]
+    fn h3_res_for_gsd_degenerate_input_is_coarsest() {
+        for bad in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            assert_eq!(h3_res_for_gsd(bad), h3o::Resolution::Zero, "gsd={bad}");
         }
     }
 

--- a/crates/core/src/overview/mod.rs
+++ b/crates/core/src/overview/mod.rs
@@ -18,6 +18,7 @@ pub mod coalesce;
 pub mod convert;
 pub mod export;
 pub mod filter;
+pub mod h3agg;
 #[cfg(test)]
 mod hostile;
 pub mod level;

--- a/crates/core/src/overview/pipeline.rs
+++ b/crates/core/src/overview/pipeline.rs
@@ -380,6 +380,10 @@ pub(super) fn run_pass2_buffered(
     in_flight: usize,
     backing: SinkBacking,
     out_schema: &Schema,
+    // Absolute writer level index of this buffered set's first level (#332):
+    // H3 aggregate levels are written directly by the driver as a coarse
+    // prefix, so the buffered geom levels start at `base_level`, not 0.
+    base_level: usize,
 ) -> Result<Vec<(LevelWriteOutcome, usize, usize)>, ConvertError> {
     let num_levels = ctxs.len();
     debug_assert_eq!(num_levels, hints.len());
@@ -510,7 +514,7 @@ pub(super) fn run_pass2_buffered(
     let mut outcomes = Vec::with_capacity(num_levels);
     for li in 0..num_levels {
         let sink = std::mem::replace(&mut sinks[li], LevelSink::Ram(Vec::new()));
-        outcomes.push(drain_sink(writer, li, hints[li], sink)?);
+        outcomes.push(drain_sink(writer, base_level + li, hints[li], sink)?);
     }
 
     timers.log_engine_summary(t_engine.elapsed().as_secs_f64(), rows.iter().sum());

--- a/crates/core/src/overview/simplify.rs
+++ b/crates/core/src/overview/simplify.rs
@@ -312,6 +312,15 @@ pub enum Representation {
     /// ([`CollapseMode::Square`], tippecanoe tiny-polygon reduction, #279).
     /// Type-preserving; above-tolerance polygons are unaffected.
     Square,
+    /// **Row-collapsing** H3 aggregate (#332): at this level every feature is
+    /// binned into the H3 cell covering its representative point and each
+    /// occupied cell becomes one row (cell boundary polygon + feature `count`).
+    /// Unlike the other variants this changes row cardinality, so H3 levels are
+    /// produced by [`super::h3agg`] rather than the per-feature simplify path —
+    /// [`simplify_step`] never runs on an H3 level. The band's H3 resolution is
+    /// auto-derived from the level GSD ([`super::level::h3_res_for_gsd`]); all
+    /// geometry kinds participate.
+    H3,
 }
 
 impl Representation {
@@ -321,6 +330,7 @@ impl Representation {
             Representation::Geometry => "geom",
             Representation::Point => "point",
             Representation::Square => "square",
+            Representation::H3 => "h3",
         }
     }
 }
@@ -446,6 +456,13 @@ pub fn simplify_step(
             };
             simplify_for_level(geom, gsd_meters, crs, &opts)
         }
+        // H3 (#332) levels are row-collapsing: the convert driver discards the
+        // per-feature geometry and replaces the whole level with H3 cell
+        // aggregates (`h3agg`). The per-level geometry pass still runs over
+        // every level's features generically before that replacement, so this
+        // arm is reached with output that is thrown away — simplify plainly and
+        // cheaply; the result is never written.
+        Representation::H3 => simplify_for_level(geom, gsd_meters, crs, opts),
     }
 }
 

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -232,7 +232,7 @@ fn partition_emitted_levels(
 }
 
 /// Build the three writer schemas (identical to the in-memory path):
-/// `source` (base), `cluster` (+ `point_count` when clustering, Q4), and `out`
+/// `source` (h3_count), `cluster` (+ `point_count` when clustering, Q4), and `out`
 /// (+ `coalesced_count` when coalescing, Q3). All three are needed downstream,
 /// so they are returned together.
 fn build_level_schemas(
@@ -602,17 +602,34 @@ pub(crate) fn convert_streaming_strategy(
     warn_plan_skipped_levels(&skipped, num_features, emitted[0].gsd, emitted[0].zoom);
 
     // --- Writer setup (identical to the in-memory path). ---------------------
-    // Writer schemas: base + point_count when clustering (Q4) + coalesced_count
+    // Writer schemas: h3_count + point_count when clustering (Q4) + coalesced_count
     // when coalescing (Q3).
     let geom_name = geom_field.name().clone();
     let (source_schema, cluster_schema, out_schema) =
         build_level_schemas(&input_schema, geom_idx, &geom_name, options);
 
-    let writer_levels: Vec<LevelSpec> = emitted
+    // H3 levels are counted from `level_specs` (the full zoom plan), not `emitted`
+    // (which omits levels with no assigned features — exactly the coarse H3 zooms
+    // where features are too small to pass the visibility gate).
+    let h3_count = level_specs
         .iter()
-        .map(|e| LevelSpec::new(e.gsd, e.zoom))
+        .take_while(|(_, zoom)| {
+            super::convert::representation_for_zoom(&options.representation, *zoom)
+                == super::simplify::Representation::H3
+        })
+        .count();
+
+    // H3 levels (0..h3_count) + geom levels from emitted.
+    let writer_levels: Vec<LevelSpec> = level_specs[..h3_count]
+        .iter()
+        .map(|(gsd, zoom)| LevelSpec::new(*gsd, *zoom))
+        .chain(emitted.iter().map(|e| LevelSpec::new(e.gsd, e.zoom)))
         .collect();
-    let emitted_gsds: Vec<f64> = emitted.iter().map(|e| e.gsd).collect();
+    let emitted_gsds: Vec<f64> = level_specs[..h3_count]
+        .iter()
+        .map(|(gsd, _)| *gsd)
+        .chain(emitted.iter().map(|e| e.gsd))
+        .collect();
     let mut writer_opts = OverviewWriterOptions::new(options.mode, writer_levels);
     writer_opts.max_row_group_size = options.max_row_group_size;
     writer_opts.row_group_size_policy = options.row_group_size_policy;
@@ -633,24 +650,18 @@ pub(crate) fn convert_streaming_strategy(
         .collect();
 
     // --- H3 aggregate levels (#332): write the coarse cell prefix directly. ---
-    // H3 bands are a validated contiguous coarse prefix (levels `0..base`).
-    // Their rows are cell aggregates, not per-feature output, so they are
-    // computed here from the pass-1 representative points (still resident) and
-    // written straight to the writer — the geom pipeline below then handles the
-    // suffix `base..`, skipping these already-written levels. `base == 0`
-    // (no H3 bands) leaves the geom path byte-identical to before.
-    let base = emitted
-        .iter()
-        .take_while(|e| {
-            super::convert::representation_for_zoom(&options.representation, e.zoom)
-                == super::simplify::Representation::H3
-        })
-        .count();
-    let mut h3_stats: Vec<(LevelWriteOutcome, usize, usize)> = Vec::with_capacity(base);
-    if base > 0 {
+    // H3 bands are a validated contiguous coarse prefix (levels `0..h3_count`).
+    // Their rows are cell aggregates binning ALL features, independent of the
+    // per-feature level assignment used by the geom levels. We iterate over
+    // `level_specs` (the full zoom plan), not `emitted` (which omits levels
+    // with no assigned features — exactly the coarse H3 zooms where features
+    // are too small to pass the visibility gate). `h3_count == 0` (no H3 bands)
+    // leaves the geom path byte-identical to before.
+    let mut h3_stats: Vec<(LevelWriteOutcome, usize, usize)> = Vec::with_capacity(h3_count);
+    if h3_count > 0 {
         let h3_points = super::h3agg::rep_points_lonlat(&features, crs);
-        for (level_idx, e) in emitted[..base].iter().enumerate() {
-            let res = super::level::h3_res_for_gsd(e.gsd);
+        for (level_idx, (gsd, _)) in level_specs[..h3_count].iter().enumerate() {
+            let res = super::level::h3_res_for_gsd(*gsd);
             let rows = super::h3agg::aggregate_h3_cells(h3_points.iter().copied(), res);
             let mut batch = super::convert::build_h3_level_batch(&cluster_schema, geom_idx, &rows)?;
             if options.coalesce_lines {
@@ -760,7 +771,7 @@ pub(crate) fn convert_streaming_strategy(
                 // H3 (#332) reuses the `point_count` column for geom levels too
                 // (filled 1, since `cluster_table` is None when clustering is
                 // off), so every level's schema matches the H3 cell batches.
-                cluster_enabled: options.cluster || base > 0,
+                cluster_enabled: options.cluster || h3_count > 0,
                 // Canonical level: singleton clusters, columns verbatim (§2.4).
                 cluster_table: cluster_tables
                     .as_ref()
@@ -789,19 +800,18 @@ pub(crate) fn convert_streaming_strategy(
     // the caller left it at IN_FLIGHT_BATCHES_AUTO) and surface it (#264).
     let in_flight_batches = resolve_and_log_in_flight_batches(options.in_flight_batches);
 
-    // The geom pipeline handles levels `base..n`; the H3 prefix `0..base` was
-    // already written above. `base == 0` for a non-H3 conversion, so both arms
-    // reduce to the original whole-plan behavior.
+    // The geom pipeline handles ALL of `emitted` (0..n), but writes to level indices
+    // `h3_count..h3_count+n` because the H3 prefix occupies 0..h3_count. When
+    // `h3_count == 0` (no H3 bands), this reduces to the original 0..n behavior.
     let geom_stats: Vec<(LevelWriteOutcome, usize, usize)> = match strategy {
         // Reference: one in-order re-read per level (pre-#213 behavior).
         Pass2Strategy::Serial => ctxs
             .iter()
             .enumerate()
-            .skip(base)
             .map(|(i, ctx)| {
                 write_level_streaming(
                     &mut writer,
-                    i,
+                    h3_count + i, // offset by H3 prefix
                     hints[i],
                     source,
                     options.read_batch_size,
@@ -814,7 +824,7 @@ pub(crate) fn convert_streaming_strategy(
         // Production: buffer the non-finest geom levels from a single read, then
         // stream the finest (verbatim, largest) level last into the writer.
         Pass2Strategy::Pipelined => {
-            let buffered_rows: usize = hints[base..n - 1].iter().sum();
+            let buffered_rows: usize = hints[..n - 1].iter().sum();
             // #305: pass 1's measured average encoded-geometry size per input
             // row sizes the RAM-vs-spill estimate (falls back to calibrated
             // constants on an empty scan). Same decision timing as before —
@@ -829,27 +839,27 @@ pub(crate) fn convert_streaming_strategy(
             log::info!(
                 "[convert] pass 2: building {} geom overview level(s) from a \
                  single read (finest level streamed last)",
-                n - base
+                n
             );
-            let mut stats = if n - base > 1 {
+            let mut stats = if n > 1 {
                 pipeline::run_pass2_buffered(
                     &mut writer,
-                    &ctxs[base..n - 1],
-                    &hints[base..n - 1],
+                    &ctxs[..n - 1],
+                    &hints[..n - 1],
                     source,
                     options.read_batch_size,
                     selected_row_groups.as_ref(),
                     in_flight_batches,
                     backing,
                     &out_schema,
-                    base,
+                    h3_count, // base_level offset for writer indices
                 )?
             } else {
                 Vec::new()
             };
             stats.push(write_level_streaming(
                 &mut writer,
-                n - 1,
+                h3_count + n - 1, // offset by H3 prefix
                 hints[n - 1],
                 source,
                 options.read_batch_size,
@@ -860,26 +870,35 @@ pub(crate) fn convert_streaming_strategy(
             stats
         }
     };
-    // H3 prefix stats precede the geom-suffix stats: combined, they are one
-    // entry per emitted level, in level order (what the report fold expects).
-    let level_stats: Vec<(LevelWriteOutcome, usize, usize)> = {
-        let mut s = h3_stats;
-        s.extend(geom_stats);
-        s
-    };
     log_validation_skips(validation_skips_before);
 
-    // Fold each emitted level's write outcome into the shared bookkeeping
-    // (#211): `record_level_outcome` appends a renumbered `LevelReport` for a
-    // written level, or — for a level the writer omitted because every
-    // candidate collapsed during simplification — warns and records the plan in
-    // `skipped`, exactly like a plan-time omission.
-    let mut level_reports = Vec::with_capacity(emitted.len());
-    for (e, (outcome, rows, vertices)) in emitted.iter().zip(level_stats) {
+    // Fold each level's write outcome into the shared bookkeeping (#211):
+    // `record_level_outcome` appends a renumbered `LevelReport` for a written
+    // level, or — for a level the writer omitted because every candidate
+    // collapsed during simplification — warns and records the plan in `skipped`.
+    // H3 levels come from `level_specs[..h3_count]`; geom levels from `emitted`.
+    let mut level_reports = Vec::with_capacity(h3_count + emitted.len());
+    for (i, (outcome, rows, vertices)) in h3_stats.into_iter().enumerate() {
+        let (gsd, zoom) = level_specs[i];
         record_level_outcome(
             outcome,
             SkippedLevelReport {
-                planned_level: e.orig as usize,
+                planned_level: i,
+                gsd,
+                zoom,
+            },
+            rows, // hint = rows for H3 (all features binned)
+            rows,
+            vertices,
+            &mut level_reports,
+            &mut skipped,
+        );
+    }
+    for (e, (outcome, rows, vertices)) in emitted.iter().zip(geom_stats) {
+        record_level_outcome(
+            outcome,
+            SkippedLevelReport {
+                planned_level: h3_count + e.orig as usize,
                 gsd: e.gsd,
                 zoom: e.zoom,
             },
@@ -1231,7 +1250,7 @@ fn run_pass1(
         // non-finite geometry produce no feature but still advance the row
         // index, so every row-keyed table stays aligned (H4 hardening; a
         // skipped row must never shift attributes onto a neighbor's geometry).
-        let base = num_rows;
+        let h3_count = num_rows;
         for (i, gopt) in geoms_buf.iter().enumerate() {
             // Attribute filter (#315): keep only rows where the predicate is
             // TRUE. The row index still advances (row-keyed tables stay
@@ -1266,12 +1285,12 @@ fn run_pass1(
                 point_count += 1;
             }
             if collect_lines && matches!(kind, FeatureKind::Line) {
-                line_rows.push(base + i);
+                line_rows.push(h3_count + i);
                 line_feat_pos.push(features.len());
                 line_geoms.push(g.clone());
             }
             features.push(AssignFeature {
-                index: base + i,
+                index: h3_count + i,
                 bbox: fbbox,
                 kind,
                 sort_key: None, // filled below once the ranking tier resolves
@@ -1334,7 +1353,7 @@ fn run_pass1(
 
     // Resolve the tier (same order + logging as the in-memory path). The
     // third element is the all-row class-group vector for coalescing, present
-    // only for the class-based tiers (matches `coalesce_group_column`).
+    // only for the class-h3_countd tiers (matches `coalesce_group_column`).
     type Resolved = (
         Option<Vec<Option<f64>>>,
         RankingProvenance,

--- a/crates/core/src/overview/stream.rs
+++ b/crates/core/src/overview/stream.rs
@@ -243,7 +243,20 @@ fn build_level_schemas(
 ) -> (Schema, Schema, Schema) {
     let geom_out_field = mixed_geometry_field(geom_name);
     let source_schema = build_source_schema(input_schema, geom_idx, geom_out_field);
-    let cluster_schema = if options.cluster {
+    // H3 aggregate bands (#332): cell rows carry NULL for every source
+    // attribute and reuse `point_count` as the cell feature count, so the
+    // schema must relax source-column nullability and include `point_count`
+    // exactly as clustering does.
+    let has_h3 = options
+        .representation
+        .iter()
+        .any(|b| b.repr == super::simplify::Representation::H3);
+    let source_schema = if has_h3 {
+        super::convert::relax_source_nullability(&source_schema, geom_idx)
+    } else {
+        source_schema
+    };
+    let cluster_schema = if options.cluster || has_h3 {
         append_point_count_field(&source_schema)
     } else {
         source_schema.clone()
@@ -280,6 +293,7 @@ fn select_row_groups_streaming(
     })
 }
 
+#[allow(clippy::cognitive_complexity)]
 pub(crate) fn convert_streaming_strategy(
     source: &ConvertSource,
     output_path: &Path,
@@ -618,6 +632,41 @@ pub(crate) fn convert_streaming_strategy(
         .filter(|&c| c != geom_idx)
         .collect();
 
+    // --- H3 aggregate levels (#332): write the coarse cell prefix directly. ---
+    // H3 bands are a validated contiguous coarse prefix (levels `0..base`).
+    // Their rows are cell aggregates, not per-feature output, so they are
+    // computed here from the pass-1 representative points (still resident) and
+    // written straight to the writer — the geom pipeline below then handles the
+    // suffix `base..`, skipping these already-written levels. `base == 0`
+    // (no H3 bands) leaves the geom path byte-identical to before.
+    let base = emitted
+        .iter()
+        .take_while(|e| {
+            super::convert::representation_for_zoom(&options.representation, e.zoom)
+                == super::simplify::Representation::H3
+        })
+        .count();
+    let mut h3_stats: Vec<(LevelWriteOutcome, usize, usize)> = Vec::with_capacity(base);
+    if base > 0 {
+        let h3_points = super::h3agg::rep_points_lonlat(&features, crs);
+        for (level_idx, e) in emitted[..base].iter().enumerate() {
+            let res = super::level::h3_res_for_gsd(e.gsd);
+            let rows = super::h3agg::aggregate_h3_cells(h3_points.iter().copied(), res);
+            let mut batch = super::convert::build_h3_level_batch(&cluster_schema, geom_idx, &rows)?;
+            if options.coalesce_lines {
+                // Cell rows never coalesce (table None ⇒ all 1); the index slice
+                // only carries the row count.
+                let idx = vec![0usize; rows.len()];
+                batch = super::convert::apply_coalesced_count(batch, &out_schema, &idx, None)?;
+            }
+            let n_cells = batch.num_rows();
+            // feature_count = Σ point_count = input features binned, not cell count.
+            let n_features: usize = rows.iter().map(|r| r.count as usize).sum();
+            let outcome = writer.write_level(level_idx, Some(n_cells), std::iter::once(batch))?;
+            h3_stats.push((outcome, n_features, 0));
+        }
+    }
+
     // --- Pass 2: single-read pipelined engine + canonical streamed last. -----
     // Pass-1 O(N) scratch has been freed by here; this marks the memory floor
     // the pass-2 output sink builds on (its ceiling is the #294 auto choice).
@@ -708,7 +757,10 @@ pub(crate) fn convert_streaming_strategy(
                 repr: repr_of(e.zoom),
                 crs,
                 simplify: &options.simplify,
-                cluster_enabled: options.cluster,
+                // H3 (#332) reuses the `point_count` column for geom levels too
+                // (filled 1, since `cluster_table` is None when clustering is
+                // off), so every level's schema matches the H3 cell batches.
+                cluster_enabled: options.cluster || base > 0,
                 // Canonical level: singleton clusters, columns verbatim (§2.4).
                 cluster_table: cluster_tables
                     .as_ref()
@@ -737,11 +789,15 @@ pub(crate) fn convert_streaming_strategy(
     // the caller left it at IN_FLIGHT_BATCHES_AUTO) and surface it (#264).
     let in_flight_batches = resolve_and_log_in_flight_batches(options.in_flight_batches);
 
-    let level_stats: Vec<(LevelWriteOutcome, usize, usize)> = match strategy {
+    // The geom pipeline handles levels `base..n`; the H3 prefix `0..base` was
+    // already written above. `base == 0` for a non-H3 conversion, so both arms
+    // reduce to the original whole-plan behavior.
+    let geom_stats: Vec<(LevelWriteOutcome, usize, usize)> = match strategy {
         // Reference: one in-order re-read per level (pre-#213 behavior).
         Pass2Strategy::Serial => ctxs
             .iter()
             .enumerate()
+            .skip(base)
             .map(|(i, ctx)| {
                 write_level_streaming(
                     &mut writer,
@@ -755,10 +811,10 @@ pub(crate) fn convert_streaming_strategy(
                 )
             })
             .collect::<Result<_, _>>()?,
-        // Production: buffer levels 0..n-1 from a single read, then stream the
-        // finest (verbatim, largest) level last straight into the writer.
+        // Production: buffer the non-finest geom levels from a single read, then
+        // stream the finest (verbatim, largest) level last into the writer.
         Pass2Strategy::Pipelined => {
-            let buffered_rows: usize = hints[..n - 1].iter().sum();
+            let buffered_rows: usize = hints[base..n - 1].iter().sum();
             // #305: pass 1's measured average encoded-geometry size per input
             // row sizes the RAM-vs-spill estimate (falls back to calibrated
             // constants on an empty scan). Same decision timing as before —
@@ -771,20 +827,22 @@ pub(crate) fn convert_streaming_strategy(
                 avg_geom_bytes,
             );
             log::info!(
-                "[convert] pass 2: building {n} overview level(s) from a \
-                 single read (finest level streamed last)"
+                "[convert] pass 2: building {} geom overview level(s) from a \
+                 single read (finest level streamed last)",
+                n - base
             );
-            let mut stats = if n > 1 {
+            let mut stats = if n - base > 1 {
                 pipeline::run_pass2_buffered(
                     &mut writer,
-                    &ctxs[..n - 1],
-                    &hints[..n - 1],
+                    &ctxs[base..n - 1],
+                    &hints[base..n - 1],
                     source,
                     options.read_batch_size,
                     selected_row_groups.as_ref(),
                     in_flight_batches,
                     backing,
                     &out_schema,
+                    base,
                 )?
             } else {
                 Vec::new()
@@ -801,6 +859,13 @@ pub(crate) fn convert_streaming_strategy(
             )?);
             stats
         }
+    };
+    // H3 prefix stats precede the geom-suffix stats: combined, they are one
+    // entry per emitted level, in level order (what the report fold expects).
+    let level_stats: Vec<(LevelWriteOutcome, usize, usize)> = {
+        let mut s = h3_stats;
+        s.extend(geom_stats);
+        s
     };
     log_validation_skips(validation_skips_before);
 

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -269,7 +269,7 @@ fn convert_report_to_dict(py: Python<'_>, report: &ConvertReport) -> PyResult<Py
 ///         type-preserving, so fill styles keep working). Mutually exclusive
 ///         with collapse. Defaults to False.
 ///     representation (str, optional): Zoom-band representation selector:
-///         comma-separated "LO-HI:KIND" bands (KIND: geom, point, square),
+///         comma-separated "LO-HI:KIND" bands (KIND: geom, point, square, h3),
 ///         e.g. "0-7:point,8-14:geom". Point bands render ALL polygonal
 ///         features as centroids; square bands emit dithered placeholder
 ///         squares for below-tolerance polygons. Requires a zoom-range plan


### PR DESCRIPTION
Closes #332.

## What

Adds `h3` as a zoom-band representation, alongside the existing `point` and `square` bands. At the banded coarse zooms, every feature is binned into the H3 cell covering its representative point, and each occupied cell becomes one row carrying the cell boundary polygon and a feature `count`. The finer geom band keeps the real geometry — so a single archive shows density hexagons when zoomed out and real polygons when zoomed in, with no two-archive merge.

```
tylertoo convert in.parquet out.pmtiles --representation 0-5:h3,6-14:geom
```

This mirrors `gpio process aggregate h3` (Chris Holmes' geoparquet-io work referenced in the issue), reframed as an overview band so the aggregate and the geometry live in one pyramid.

## Auto resolution (no knob)

The band is param-free like `point`. Each banded zoom auto-selects the H3 resolution whose average hexagon edge length is nearest — in log-ratio — to that zoom's ground-sample distance. Coarse zooms get large hexagons; each finer zoom densifies and hands off to polygons at the geom band. `h3o::Resolution::edge_length_m` drives the mapping, so there is no hardcoded table.

## Design notes

- **`overview::h3agg`** is a pure, CRS-free aggregator over lon/lat representative points. Binning reuses the bbox center `assign` already computes. DIVERGENCE FROM geoparquet-io: gpio bins on the true `ST_Centroid`; the bbox center is immaterial for a count and costs nothing extra.
- **Count reuses `point_count`.** Its meaning — "features this row represents" — is exactly the cell count, and it already rides the writer and MVT-property plumbing, so there is no new schema column. Source attribute columns are relaxed to nullable, since a cell carries no per-feature values.
- **H3 is a validated contiguous coarse prefix**, not composable with `point`/`square` in v1 (incompatible per-feature vs whole-cell semantics).
- **Both engines honor it.** The in-memory path branches per level. The streaming path writes the H3 prefix directly from pass-1 representative points (no second read), then pipelines the geom suffix with a base-level offset. For a non-H3 conversion `base == 0`, so the geom path is byte-identical to before.
- **`geo` 0.32 → 0.33** so the new `h3o` dependency shares one `geo-types` in the tree (h3o's `geo` feature needs 0.33). `i_overlay` follows to 4.5; the full suite still builds and the representation/cluster/coalesce tests pass.

## Tests

- resolution-ladder monotonicity + exact edge-length anchors
- aggregator: count exactness, order independence, non-finite skipping, cell-ring closure, antimeridian wrap
- `--representation` grammar accepts `h3`
- in-memory acceptance anchor: coarse levels are hexagon cells whose counts partition the input, finer levels keep polygons, canonical verbatim
- streaming acceptance across both pass-2 strategies (Serial + Pipelined)

## Follow-ups (out of scope)

- S2 via the `s2` crate (same band shape)
- metric/breakdown aggregation beyond count (sum/avg/min/max; the `AccumulateOp` enum is the extension point)
- count/tile-size-driven auto resolution (gpio's `--auto`)
- admin and a5 (no mature Rust a5 crate; admin is a spatial join, not a grid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)